### PR TITLE
fix: Keyframes persistence in project files

### DIFF
--- a/src/services/projectSync.ts
+++ b/src/services/projectSync.ts
@@ -118,7 +118,7 @@ function convertCompositions(compositions: Composition[]): ProjectComposition[] 
         vertices: m.vertices || [],
         position: m.position || { x: 0, y: 0 },
       })),
-      keyframes: [], // Keyframes stored separately in timeline
+      keyframes: c.keyframes || [], // Preserve keyframes from clip
       volume: c.volume ?? 1,
       audioEnabled: c.audioEnabled !== false,
       reversed: c.reversed || false,
@@ -285,6 +285,7 @@ function convertProjectCompositionToStore(projectComps: ProjectComposition[]): C
         transform: c.transform,
         effects: c.effects,
         masks: c.masks,
+        keyframes: c.keyframes || [], // Restore keyframes
         volume: c.volume,
         audioEnabled: c.audioEnabled,
         reversed: c.reversed,


### PR DESCRIPTION
## Summary
- Fix keyframes not being saved to project files (was always set to empty array)
- Fix keyframes not being restored when loading project

## Test plan
- [ ] Add keyframes to a clip
- [ ] Save project (Ctrl+S)
- [ ] Close and reopen project
- [ ] Verify keyframes are restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)