### PR TITLE
fix: Resolve TypeScript build errors

### DIFF
--- a/src/components/common/Toolbar.tsx
+++ b/src/components/common/Toolbar.tsx
@@ -683,7 +683,7 @@ export function Toolbar() {
 
       {/* Status */}
       <div className="toolbar-section toolbar-right">
-        <NativeHelperStatus toolbar />
+        <NativeHelperStatus />
         <span className={`status ${isEngineReady ? 'ready' : 'loading'}`}>
           {isEngineReady ? '● WebGPU Ready' : '○ Loading...'}
         </span>

--- a/src/components/export/ExportPanel.tsx
+++ b/src/components/export/ExportPanel.tsx
@@ -24,9 +24,8 @@ import type {
   FFmpegContainer,
   ProResProfile,
   DnxhrProfile,
-  HapFormat,
 } from '../../engine/ffmpeg';
-import type { Layer, TimelineClip, TimelineTrack } from '../../types';
+import type { Layer, LayerSource, TimelineClip, TimelineTrack } from '../../types';
 
 type EncoderType = 'webcodecs' | 'ffmpeg';
 
@@ -188,9 +187,11 @@ function buildLayerFromClip(
     // For export, we need to use HTMLVideoElement (not WebCodecsPlayer)
     // because we control seeking via video.currentTime
     // WebCodecsPlayer has its own playback and doesn't follow currentTime
-    const exportSource = {
-      ...clip.source,
-      webCodecsPlayer: undefined,  // Force HTMLVideoElement path during export
+    const exportSource: LayerSource = {
+      type: clip.source.videoElement ? 'video' : 'image',
+      videoElement: clip.source.videoElement,
+      imageElement: clip.source.imageElement,
+      // webCodecsPlayer explicitly omitted - force HTMLVideoElement path during export
     };
 
     return {
@@ -253,7 +254,7 @@ export function ExportPanel() {
   const [ffmpegPreset, setFfmpegPreset] = useState<string>('');
   const [proresProfile, setProresProfile] = useState<ProResProfile>('hq');
   const [dnxhrProfile, setDnxhrProfile] = useState<DnxhrProfile>('dnxhr_hq');
-  const [hapFormat, setHapFormat] = useState<HapFormat>('hap_q'); // Kept for type compat, HAP not available
+  // HAP not available in this FFmpeg build
   const [ffmpegQuality, setFfmpegQuality] = useState(18);
   const [ffmpegBitrate, setFfmpegBitrate] = useState(20_000_000);
   const [ffmpegRateControl, setFfmpegRateControl] = useState<'crf' | 'cbr' | 'vbr'>('crf');
@@ -397,9 +398,7 @@ export function ExportPanel() {
     if (presetConfig.dnxhrProfile) {
       setDnxhrProfile(presetConfig.dnxhrProfile);
     }
-    if (presetConfig.hapFormat) {
-      setHapFormat(presetConfig.hapFormat);
-    }
+    // HAP not available in this build
 
     setFfmpegPreset(presetId);
   }, []);

--- a/src/components/panels/YouTubePanel.tsx
+++ b/src/components/panels/YouTubePanel.tsx
@@ -243,7 +243,7 @@ export function YouTubePanel() {
 
     setDownloadingVideos(prev => new Set(prev).add(video.id));
 
-    const unsubscribe = subscribeToDownload(video.id, (progress: DownloadProgress) => {
+    const unsubscribe = subscribeToDownload(video.id, (_progress: DownloadProgress) => {
       // Progress tracked via downloadingVideos set
     });
 
@@ -313,12 +313,12 @@ export function YouTubePanel() {
     }
   };
 
-  // Auto-download when video is added to results
-  const handleVideoAdded = async (video: YouTubeVideo) => {
-    if (autoDownload && !downloadingVideos.has(video.id)) {
-      downloadVideoOnly(video);
-    }
-  };
+  // Auto-download when video is added to results (reserved for future use)
+  // const handleVideoAdded = async (video: YouTubeVideo) => {
+  //   if (autoDownload && !downloadingVideos.has(video.id)) {
+  //     downloadVideoOnly(video);
+  //   }
+  // };
 
   return (
     <div className="youtube-panel">
@@ -335,7 +335,7 @@ export function YouTubePanel() {
           />
           <button
             className="youtube-search-btn"
-            onClick={handleSearch}
+            onClick={() => handleSearch()}
             disabled={loading || !query.trim()}
           >
             {loading ? '...' : youtubeApiKey ? 'Search' : 'Add'}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -80,7 +80,7 @@ export function Timeline() {
     isRamPreviewing,
     isExporting,
     exportProgress,
-    exportCurrentTime,
+    // exportCurrentTime, - unused, kept in store for future display
     exportRange,
     startRamPreview,
     cancelRamPreview,

--- a/src/engine/core/types.ts
+++ b/src/engine/core/types.ts
@@ -94,7 +94,7 @@ export interface DetailedStats {
   dropsThisSecond: number;
   lastDropReason: 'none' | 'slow_raf' | 'slow_render' | 'slow_import';
   lastRafTime: number;
-  decoder: 'WebCodecs' | 'HTMLVideo' | 'HTMLVideo(cached)' | 'HTMLVideo(paused-cache)' | 'none';
+  decoder: 'WebCodecs' | 'HTMLVideo' | 'HTMLVideo(cached)' | 'HTMLVideo(paused-cache)' | 'NativeHelper' | 'none';
 }
 
 // Profile data for performance tracking

--- a/src/services/layerBuilder.ts
+++ b/src/services/layerBuilder.ts
@@ -145,11 +145,7 @@ class LayerBuilderService {
         const clipLocalTime = playheadPosition - clip.startTime;
         const keyframeLocalTime = clipLocalTime;
 
-        // Calculate source time using speed integration (handles keyframes)
-        const sourceTime = getSourceTimeForClip(clip.id, clipLocalTime);
-        const initialSpeed = getInterpolatedSpeed(clip.id, 0);
-        const startPoint = initialSpeed >= 0 ? clip.inPoint : clip.outPoint;
-        const clipTime = Math.max(clip.inPoint, Math.min(clip.outPoint, startPoint + sourceTime));
+        // Note: source time/clipTime calculation happens in syncVideoElements for native decoder
 
         const transform = getInterpolatedTransform(clip.id, keyframeLocalTime);
         const nativeInterpolatedEffects = getInterpolatedEffects(clip.id, keyframeLocalTime);

--- a/src/services/nativeHelper/NativeDecoder.ts
+++ b/src/services/nativeHelper/NativeDecoder.ts
@@ -7,7 +7,6 @@
  */
 
 import { NativeHelperClient } from './NativeHelperClient';
-import type { DecodedFrame } from './NativeHelperClient';
 import type { FileMetadata } from './protocol';
 
 export interface NativeDecoderOptions {
@@ -208,7 +207,9 @@ export class NativeDecoder {
       });
 
       // Create ImageBitmap from decoded data
-      const imageData = new ImageData(decoded.data, decoded.width, decoded.height);
+      // Ensure we have a proper Uint8ClampedArray with ArrayBuffer (not SharedArrayBuffer)
+      const pixelData = new Uint8ClampedArray(decoded.data);
+      const imageData = new ImageData(pixelData, decoded.width, decoded.height);
       const bitmap = await createImageBitmap(imageData);
 
       // Release old frame
@@ -251,7 +252,8 @@ export async function isNativeHelperAvailable(): Promise<boolean> {
  */
 export async function getNativeCodecs(): Promise<string[]> {
   try {
-    const info = await NativeHelperClient.getInfo();
+    // Check if helper is available by calling getInfo
+    await NativeHelperClient.getInfo();
     // The native helper supports these codecs via FFmpeg
     return ['prores', 'dnxhd', 'dnxhr', 'ffv1', 'utvideo', 'mjpeg', 'h264', 'h265', 'vp9'];
   } catch {

--- a/src/services/nativeHelper/NativeHelperClient.ts
+++ b/src/services/nativeHelper/NativeHelperClient.ts
@@ -11,7 +11,6 @@ import type {
   FileMetadata,
   SystemInfo,
   EncodeOutput,
-  FrameHeader,
 } from './protocol';
 
 import {
@@ -344,7 +343,7 @@ class NativeHelperClientImpl {
    */
   async downloadYouTube(
     url: string,
-    onProgress?: (percent: number) => void
+    _onProgress?: (percent: number) => void // Reserved for future progress reporting
   ): Promise<{ success: boolean; path?: string; error?: string }> {
     const id = this.nextId();
 

--- a/src/services/nativeHelper/protocol.ts
+++ b/src/services/nativeHelper/protocol.ts
@@ -167,6 +167,7 @@ export interface ErrorResponse {
 
 export interface ProgressResponse {
   id: string;
+  ok?: undefined;  // Distinguish from OkResponse/ErrorResponse
   progress: number;
   frames_done: number;
   frames_total: number;
@@ -174,6 +175,11 @@ export interface ProgressResponse {
 }
 
 export type Response = OkResponse | ErrorResponse | ProgressResponse;
+
+// Type guard for checking if response is a command result (has ok property)
+export function isCommandResponse(response: Response): response is OkResponse | ErrorResponse {
+  return 'ok' in response && response.ok !== undefined;
+}
 
 // File metadata
 export interface FileMetadata {

--- a/src/stores/timeline/clipSlice.ts
+++ b/src/stores/timeline/clipSlice.ts
@@ -9,7 +9,7 @@ import { generateWaveform, generateThumbnails, getDefaultEffectParams } from './
 import { textRenderer } from '../../services/textRenderer';
 import { googleFontsService } from '../../services/googleFontsService';
 import { WebCodecsPlayer } from '../../engine/WebCodecsPlayer';
-import { NativeDecoder, NativeHelperClient } from '../../services/nativeHelper';
+import { NativeDecoder } from '../../services/nativeHelper';
 
 // Check if file is a professional codec that needs Native Helper
 function isProfessionalCodecFile(file: File): boolean {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -208,7 +208,7 @@ export interface EngineStats {
   layerCount: number;
   targetFps: number;
   // Decoder info
-  decoder: 'WebCodecs' | 'HTMLVideo' | 'HTMLVideo(cached)' | 'HTMLVideo(paused-cache)' | 'none';
+  decoder: 'WebCodecs' | 'HTMLVideo' | 'HTMLVideo(cached)' | 'HTMLVideo(paused-cache)' | 'NativeHelper' | 'none';
   // Audio status
   audio: {
     playing: number;       // Number of audio elements currently playing
@@ -275,9 +275,11 @@ export interface TimelineClip {
     audioElement?: HTMLAudioElement;
     imageElement?: HTMLImageElement;
     webCodecsPlayer?: import('../engine/WebCodecsPlayer').WebCodecsPlayer;
+    nativeDecoder?: import('../services/nativeHelper/NativeDecoder').NativeDecoder;
     naturalDuration?: number;
     mediaFileId?: string;  // Reference to MediaFile for proxy lookup
     textCanvas?: HTMLCanvasElement;  // Pre-rendered text canvas for text clips
+    filePath?: string;  // Path to original file (for native helper to access directly)
   } | null;
   thumbnails?: string[];  // Array of data URLs for filmstrip preview
   linkedClipId?: string;  // ID of linked clip (e.g., audio linked to video)


### PR DESCRIPTION
## Summary
- Fix TypeScript compilation errors that caused Cloudflare build to fail
- No new features, just type fixes and unused variable cleanup

## Changes
- Remove unused props, imports, and variables
- Fix type mismatches in ExportPanel and FFmpegExportSection
- Update codec defaults to valid values (prores/mov instead of libx264/mp4)
- Add missing types (NativeHelper decoder, filePath property)

🤖 Generated with [Claude Code](https://claude.com/claude-code)