### PR TITLE
Fix TypeScript build errors for v1.1.0

### DIFF
--- a/src/components/export/ExportDialog.tsx
+++ b/src/components/export/ExportDialog.tsx
@@ -458,12 +458,6 @@ export function ExportDialog({ onClose }: ExportDialogProps) {
                 </div>
               )}
 
-              {/* Warning for slow clips */}
-              {progress?.slowClipsCount && progress.slowClipsCount > 0 && (
-                <div className="export-warning">
-                  {progress.slowClipsMessage}
-                </div>
-              )}
             </div>
 
             <div className="export-actions">

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -621,7 +621,7 @@ export function Timeline() {
 
     const updatePlayhead = (currentTime: number) => {
       const state = useTimelineStore.getState();
-      const { duration: dur, inPoint: ip, outPoint: op, loopPlayback: lp, pause: ps, clips, tracks } = state;
+      const { duration: dur, inPoint: ip, outPoint: op, loopPlayback: lp, pause: ps, clips } = state;
       const effectiveEnd = op !== null ? op : dur;
       const effectiveStart = ip !== null ? ip : 0;
 

--- a/src/engine/WebCodecsPlayer.ts
+++ b/src/engine/WebCodecsPlayer.ts
@@ -368,7 +368,7 @@ export class WebCodecsPlayer {
               configBox.write(stream);
               // The write() includes the box header (8 bytes: size + type), we need to skip it
               description = stream.buffer.slice(8);
-              console.log(`[WebCodecs] Extracted codec description: ${description.byteLength} bytes from ${entry.avcC ? 'avcC' : entry.hvcC ? 'hvcC' : entry.vpcC ? 'vpcC' : 'av1C'}`);
+              console.log(`[WebCodecs] Extracted codec description: ${description!.byteLength} bytes from ${entry.avcC ? 'avcC' : entry.hvcC ? 'hvcC' : entry.vpcC ? 'vpcC' : 'av1C'}`);
             } else {
               console.warn('[WebCodecs] No codec config box found in sample entry:', Object.keys(entry));
             }

--- a/src/services/layerBuilder.ts
+++ b/src/services/layerBuilder.ts
@@ -67,13 +67,6 @@ class LayerBuilderService {
   private cacheMisses = 0;
   private lastStatsLog = 0;
 
-  // === FILTER RESULT CACHING ===
-  // Cache filtered tracks/clips to avoid repeated array operations
-  private cachedVideoTracks: TimelineTrack[] = [];
-  private cachedClipsAtTime: TimelineClip[] = [];
-  private lastFilterFrame = -1;
-  private lastFilterClipsRef: TimelineClip[] | null = null;
-  private lastFilterTracksRef: TimelineTrack[] | null = null;
 
   /**
    * Invalidate the layer cache - call when external changes occur
@@ -123,10 +116,9 @@ class LayerBuilderService {
 
     // During playback with keyframes, we need per-frame updates for smooth animation
     // But for static content, we can skip if same frame
-    const hasKeyframedClips = clips.some(c =>
-      (c.keyframes && Object.keys(c.keyframes).length > 0) ||
-      (c.effects && c.effects.some(e => e.keyframes && Object.keys(e.keyframes).length > 0))
-    );
+    // Check clipKeyframes map in store (keyframes are not stored on clip object)
+    const { hasKeyframes } = timelineState;
+    const hasKeyframedClips = clips.some(c => hasKeyframes(c.id));
 
     const needsRebuild = !this.cacheValid ||
       clipsChanged ||

--- a/src/services/proxyFrameCache.ts
+++ b/src/services/proxyFrameCache.ts
@@ -423,14 +423,14 @@ class ProxyFrameCache {
         arrayBuffer = await audioFile.arrayBuffer();
       }
 
-      // Try 2: Original video file (extract audio from video)
-      if (!arrayBuffer && mediaFile?.blobUrl) {
-        console.log(`[AudioBuffer] Loading from video blob URL: ${mediaFileId}`);
+      // Try 2: Original video file URL (extract audio from video)
+      if (!arrayBuffer && mediaFile?.url) {
+        console.log(`[AudioBuffer] Loading from video URL: ${mediaFileId}`);
         try {
-          const response = await fetch(mediaFile.blobUrl);
+          const response = await fetch(mediaFile.url);
           arrayBuffer = await response.arrayBuffer();
         } catch (e) {
-          console.warn(`[AudioBuffer] Failed to fetch video blob:`, e);
+          console.warn(`[AudioBuffer] Failed to fetch video URL:`, e);
         }
       }
 
@@ -474,8 +474,6 @@ class ProxyFrameCache {
   // Track loading state to prevent duplicate loads
   private audioBufferLoading = new Set<string>();
 
-  // Legacy snippet sources (kept for cleanup)
-  private activeScrubSources: AudioBufferSourceNode[] = [];
 
   /**
    * VARISPEED SCRUBBING - Call this continuously while scrubbing


### PR DESCRIPTION
## Summary
- Fix all TypeScript compilation errors that would fail Cloudflare build
- Remove unused variables and fix type mismatches

## Changes
- ExportDialog: Remove non-existent slowClipsCount/slowClipsMessage
- Timeline: Remove unused tracks variable
- FrameExporter: Use fileSystemService for file handles
- WebCodecsPlayer: Fix description type assertion
- layerBuilder: Use store's hasKeyframes function
- proxyFrameCache: Use mediaFile.url instead of blobUrl

🤖 Generated with [Claude Code](https://claude.com/claude-code)