### PR TITLE
Fix: Add missing ClipDragState type fields

### DIFF
--- a/src/components/timeline/types.ts
+++ b/src/components/timeline/types.ts
@@ -15,6 +15,9 @@ export interface ClipDragState {
   altKeyPressed: boolean;      // If true, skip linked group movement (independent drag)
   forcingOverlap: boolean;     // If true, user has pushed through resistance and is forcing overlap
   dragStartTime: number;       // Timestamp when drag started (for track-change delay)
+  // Multi-select drag support
+  multiSelectTimeDelta?: number;  // Time delta to apply to all selected clips during preview
+  multiSelectClipIds?: string[];  // IDs of clips being moved together (excluding the main dragged clip)
 }
 
 // Clip trim state


### PR DESCRIPTION
## Summary
- Added missing multiSelectTimeDelta and multiSelectClipIds to ClipDragState interface
- These were accidentally not committed with the multi-select feature

## Test plan
- [ ] Build should pass on Cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)