### PR TITLE
Fix SAM2Overlay build error

### DIFF
--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -1187,6 +1187,8 @@ export function Preview({ panelId, compositionId }: PreviewProps) {
               <SAM2Overlay
                 canvasWidth={effectiveResolution.width}
                 canvasHeight={effectiveResolution.height}
+                displayWidth={canvasSize.width}
+                displayHeight={canvasSize.height}
               />
             )}
           </>


### PR DESCRIPTION
## Summary
- Fix missing `displayWidth`/`displayHeight` props on SAM2Overlay that caused Cloudflare build failure

## Test plan
- [ ] `tsc -b && vite build` passes without errors