### PR TITLE
Release 1.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ Decoding depends on what the **browser** supports — the container is just the 
 <tr><td><b>Gaussian Splats</b></td><td>PLY, SPLAT</td></tr>
 <tr><td><b>Download</b></td><td>YouTube, TikTok, Instagram, Twitter/X, Vimeo + <a href="https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md">all yt-dlp sites</a> via Native Helper</td></tr>
 <tr><th colspan="2">Export (Encode)</th></tr>
-<tr><td><b>Containers</b></td><td>MP4, WebM</td></tr>
+<tr><td><b>Video containers</b></td><td>MP4, WebM via WebCodecs / HTMLVideo; MOV, MKV, AVI, MXF via FFmpeg WASM</td></tr>
+<tr><td><b>FFmpeg codecs</b></td><td>ProRes, DNxHR, FFV1, UTVideo, MJPEG</td></tr>
 <tr><td><b>Video codecs</b></td><td>H.264, H.265¹, VP9, AV1 — GPU-accelerated via WebCodecs</td></tr>
-<tr><td><b>Audio codecs</b></td><td>AAC (MP4), Opus (WebM)</td></tr>
-<tr><td><b>Interchange</b></td><td>FCPXML (Final Cut Pro / DaVinci Resolve), PNG sequence</td></tr>
+<tr><td><b>Image export</b></td><td>PNG, JPG/JPEG, WebP, BMP (current playhead frame)</td></tr>
+<tr><td><b>Audio-only export</b></td><td>AAC or OGG/Opus depending on browser codec support</td></tr>
+<tr><td><b>Interchange</b></td><td>FCPXML (Final Cut Pro / DaVinci Resolve)</td></tr>
 </table>
 
 ¹ H.265 decode/encode depends on OS & hardware — full support on Windows, partial on macOS/Linux.
@@ -140,7 +142,7 @@ This requires the Native Helper to be running, a MasterSelects editor tab to be 
 | [**AI Integration**](docs/Features/AI-Integration.md) | Built-in OpenAI chat, 79 exported tool-callable edit actions, and local/native bridges for external agents |
 | [**FlashBoard**](docs/Features/FlashBoard.md) | Node-based AI canvas for text-to-video, image-to-video, and image generation |
 | [**Multicam AI**](docs/Features/Multicam-AI.md) | Sync cameras, transcribe footage, and generate Claude-powered multicam EDLs *(experimental)* |
-| [**Export Pipeline**](docs/Features/Export.md) | WebCodecs Fast/Precise, FFmpeg WASM *(experimental / WIP)*, FCPXML, and PNG sequence export |
+| [**Export Pipeline**](docs/Features/Export.md) | WebCodecs Fast/Precise, FFmpeg intermediates, image/audio-only export, FCPXML, and project-persistent presets |
 | [**Live EQ & Audio**](docs/Features/Audio.md) | 10-band parametric EQ with real-time Web Audio preview |
 | [**Download Panel**](docs/Features/Download-Panel.md) | YouTube, TikTok, Instagram, Twitter/X, Vimeo, and other yt-dlp-supported sites via Native Helper |
 | [**Vector Animation**](docs/Features/Vector-Animation.md) | `.lottie` and Lottie JSON clips with loop controls, fit, and deterministic preview/export |
@@ -232,7 +234,7 @@ If something breaks, refresh. If it's still broken, [open an issue](https://gith
 
 - **Frontend:** React 19, TypeScript, Zustand, Vite 7.2
 - **Rendering:** WebGPU + 2,500+ lines of WGSL shaders
-- **Video:** WebCodecs, mp4box, mp4-muxer, webm-muxer, HTMLVideo fallback, experimental FFmpeg WASM export path
+- **Video:** WebCodecs, MediaBunny, mp4box, HTMLVideo fallback, and experimental FFmpeg WASM export path
 - **Audio:** Web Audio API with 10-band live EQ, element-synced playback, drift correction, and waveform extraction
 - **AI:** Built-in OpenAI editor chat with 79 exported tools, Native Helper HTTP bridge for Claude Code / external agents, Claude/Anthropic for experimental multicam EDLs, SAM2 via ONNX Runtime, MatAnyone2 via Native Helper, local Whisper via Hugging Face Transformers, and Kie.ai / hosted cloud / PiAPI-backed generation flows
 - **Native:** Rust helper for Firefox storage backend, native decode/encode, and yt-dlp downloads

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p>
-  <a href="https://github.com/Sportinger/MasterSelects/releases"><img src="https://img.shields.io/badge/version-1.5.3-blue.svg" alt="Version"></a>
+  <a href="https://github.com/Sportinger/MasterSelects/releases"><img src="https://img.shields.io/badge/version-1.5.4-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"></a>
   <a href="https://app.fossa.com/projects/custom%2b61097%2fmasterselects"><img src="https://app.fossa.com/api/projects/custom%2b61097%2fmasterselects.svg?type=shield" alt="FOSSA Status"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # MasterSelects
 
-<h3>Browser-based Video Compositor & 3D Engine</h3>
+<h3>Browser-based Video Compositor, Vector Animation & 3D Engine</h3>
 
 <br>
 
@@ -15,11 +15,11 @@
 <p>
   GPU-first editing with <b>30 effects</b>, <b>37 blend modes</b>, <b>79 AI tools</b>, <b>real 3D via Three.js</b>, and only <b>14 dependencies</b>.<br>
   Built from scratch in <b>2,400+ lines of WGSL</b> and <b>138k lines of TypeScript</b>.<br>
-  Import <b>OBJ, glTF, GLB, FBX, PLY, SPLAT</b> assets directly into the timeline.
+  Import <b>.lottie, Lottie JSON, OBJ, glTF, GLB, FBX, PLY, SPLAT</b> assets directly into the timeline.
 </p>
 
 <p>
-  <a href="https://github.com/Sportinger/MasterSelects/releases"><img src="https://img.shields.io/badge/version-1.5.1-blue.svg" alt="Version"></a>
+  <a href="https://github.com/Sportinger/MasterSelects/releases"><img src="https://img.shields.io/badge/version-1.5.3-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"></a>
   <a href="https://app.fossa.com/projects/custom%2b61097%2fmasterselects"><img src="https://app.fossa.com/api/projects/custom%2b61097%2fmasterselects.svg?type=shield" alt="FOSSA Status"></a>
 </p>
@@ -56,6 +56,7 @@ Decoding depends on what the **browser** supports — the container is just the 
 <tr><td><b>Video codecs</b></td><td>H.264 (AVC), H.265 (HEVC)¹, VP8, VP9, AV1</td></tr>
 <tr><td><b>Audio files</b></td><td>WAV, MP3, OGG, FLAC, AAC, M4A, WMA, AIFF, OPUS</td></tr>
 <tr><td><b>Image</b></td><td>PNG, JPG/JPEG, WebP, GIF, BMP, SVG</td></tr>
+<tr><td><b>Vector animation</b></td><td><code>.lottie</code> packages and Lottie JSON files (content-sniffed)</td></tr>
 <tr><td><b>3D Models</b></td><td>OBJ, glTF, GLB, FBX — rendered via Three.js with lighting</td></tr>
 <tr><td><b>Gaussian Splats</b></td><td>PLY, SPLAT</td></tr>
 <tr><td><b>Download</b></td><td>YouTube, TikTok, Instagram, Twitter/X, Vimeo + <a href="https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md">all yt-dlp sites</a> via Native Helper</td></tr>
@@ -142,7 +143,8 @@ This requires the Native Helper to be running, a MasterSelects editor tab to be 
 | [**Export Pipeline**](docs/Features/Export.md) | WebCodecs Fast/Precise, FFmpeg WASM *(experimental / WIP)*, FCPXML, and PNG sequence export |
 | [**Live EQ & Audio**](docs/Features/Audio.md) | 10-band parametric EQ with real-time Web Audio preview |
 | [**Download Panel**](docs/Features/Download-Panel.md) | YouTube, TikTok, Instagram, Twitter/X, Vimeo, and other yt-dlp-supported sites via Native Helper |
-| [**Text & Solids**](docs/Features/Text-Clips.md) | 50 Google Fonts, stroke, shadow, solid color clips |
+| [**Vector Animation**](docs/Features/Vector-Animation.md) | `.lottie` and Lottie JSON clips with loop controls, fit, and deterministic preview/export |
+| [**Text & Solids**](docs/Features/Text-Clips.md) | 50 Google Fonts, stroke, shadow, and solid color clips |
 | [**Proxy System**](docs/Features/Proxy-System.md) | GPU-accelerated proxies with resume and cache indicator |
 | [**Output Manager**](docs/Features/Preview.md) | Multi-window outputs, source routing, corner pin warping, slice masks |
 | [**Slot Grid**](docs/Features/Slot-Grid.md) | Resolume-style 12x4 grid with multi-layer live playback and slot-clip trims |
@@ -318,6 +320,7 @@ src/
 │   ├── nativeHelper/    # Native decoder + WebSocket client
 │   ├── layerBuilder/    # Layer building + video sync
 │   ├── mediaRuntime/    # Media runtime bindings + playback
+│   ├── vectorAnimation/ # Lottie metadata sniffing + runtime canvas playback
 │   └── export/          # FCPXML export
 ├── shaders/             # WGSL (composite, effects, output, optical flow, slice)
 ├── hooks/               # React hooks (useEngine, useGlobalHistory, useMIDI, useTheme)

--- a/docs/Features/Export.md
+++ b/docs/Features/Export.md
@@ -2,7 +2,7 @@
 
 [Back to Index](./README.md)
 
-Video export, audio export, transparent stacked-alpha export, FFmpeg WASM export, and FCPXML interchange.
+Video export, image export, audio-only export, transparent stacked-alpha export, FFmpeg WASM intermediates, named export presets, and FCPXML interchange.
 
 ---
 
@@ -14,14 +14,28 @@ The export panel currently exposes three live encoder paths:
 - `htmlvideo` for the precise HTML-video-seeking pipeline
 - `ffmpeg` for the CPU FFmpeg WASM pipeline
 
-There is also a separate FCPXML export action for NLE interchange.
+FCPXML is exposed as a selectable export container for NLE interchange.
 
 ### Current Panel Layout
 
-- A sticky summary bar at the top shows only compact badges for mode, workflow, output, range, duration, and estimated size.
-- The main form is split into exactly two groups: `Video` and `Audio`.
-- The `Video` group now contains workflow selection, output naming, resolution, frame rate, delivery presets, codec controls, stacked-alpha, and range toggles.
-- The `Audio` group contains output naming for audio-only exports, sample rate, bitrate, normalization, and audio-only range controls.
+- A sticky summary bar at the top shows compact badges plus the primary export button.
+- Clicking a summary badge smooth-scrolls to the related control group and briefly highlights it.
+- A compact command row above `Basic` contains a project-persistent preset list plus `Load`, `Update`, and `Save`.
+- The workflow picker (`WebCodecs`, `HTMLVideo`, `FFmpeg`) is its own section above `Basic`.
+- `Basic` contains output naming and container selection. The container row is grouped by `Video`, `Image`, `Audio`, and `XML`, and switches output mode by selecting a deliverable directly.
+- The `Video` group contains codec selection, resolution, frame rate, bitrate/rate controls, stacked-alpha, and range toggles.
+- In `Image` mode the same middle group becomes an `Image` panel with format-aware resolution and quality controls, and it exports only the current playhead frame.
+- The `Audio` group contains sample rate, bitrate, normalization, and audio-only range controls.
+- Lower in the panel, legacy `Advanced Video`, `Advanced Audio`, and `Range & Summary` sections still exist for raw-value access.
+- Export settings and preset selection now live in a shared store, so changes inside the Export tab participate in global undo/redo and are restored with the project.
+
+### Export Presets
+
+- Presets are stored per project, not in browser-only local storage.
+- `Save` prompts for a name and creates a new preset or overwrites an existing preset with the same name.
+- `Update` overwrites the currently selected preset without asking for a new name.
+- `Load` restores the selected preset back into the live export settings.
+- Presets and the current export settings are written into the project UI state and restored with the project.
 
 ---
 
@@ -80,6 +94,9 @@ Supported codecs are checked at runtime:
 - WebM is limited to VP9 or AV1.
 - MP4 accepts the full codec list, but browser support is still checked with `VideoEncoder.isConfigSupported()`.
 - Unsupported combinations are not silently promised by the docs; they must pass the runtime checks or be remapped by the encoder logic.
+- The selected bitrate is passed into `VideoEncoder`, but in the WebCodecs path it is still a target, not a guaranteed final file bitrate.
+- `rateControl = cbr` maps to `VideoEncoderConfig.bitrateMode = "constant"` and falls back to variable bitrate if constant mode is rejected during encoder configuration.
+- Browser encoders can still undershoot the requested bitrate on simple material, so the panel treats file size as a target estimate rather than an exact promise.
 
 ---
 
@@ -122,6 +139,27 @@ Audio export is handled separately from the video encoder.
 
 ---
 
+## Image Export
+
+Image export renders a single composited frame at the current playhead position.
+
+### Supported Formats
+
+- PNG
+- JPG
+- WebP
+- BMP
+
+### Current Behavior
+
+- The export does not use the In/Out range. It always renders only the current playhead frame.
+- Custom resolution still applies before the image is written.
+- PNG and BMP are exported losslessly.
+- JPG and WebP expose a quality control in the panel.
+- Audio is ignored while image export is active.
+
+---
+
 ## FFmpeg Export
 
 The FFmpeg path is a separate CPU-based export pipeline.
@@ -144,9 +182,7 @@ The FFmpeg path is a separate CPU-based export pipeline.
 ### Supported Containers
 
 - MOV
-- MP4
 - MKV
-- WebM
 - AVI
 - MXF
 
@@ -161,7 +197,7 @@ The FFmpeg path is a separate CPU-based export pipeline.
 
 ## FCPXML Export
 
-FCPXML export is separate from video rendering.
+FCPXML export is available through the container chooser as `.fcpxml`.
 
 ### What It Exports
 

--- a/docs/Features/Export.md
+++ b/docs/Features/Export.md
@@ -16,6 +16,13 @@ The export panel currently exposes three live encoder paths:
 
 There is also a separate FCPXML export action for NLE interchange.
 
+### Current Panel Layout
+
+- A sticky summary bar at the top shows only compact badges for mode, workflow, output, range, duration, and estimated size.
+- The main form is split into exactly two groups: `Video` and `Audio`.
+- The `Video` group now contains workflow selection, output naming, resolution, frame rate, delivery presets, codec controls, stacked-alpha, and range toggles.
+- The `Audio` group contains output naming for audio-only exports, sample rate, bitrate, normalization, and audio-only range controls.
+
 ---
 
 ## WebCodecs And HTMLVideo Export

--- a/docs/Features/Export.md
+++ b/docs/Features/Export.md
@@ -29,6 +29,8 @@ There is also a separate FCPXML export action for NLE interchange.
 
 `FrameExporter` is used for both the WebCodecs and HTMLVideo export buttons.
 
+Canvas-backed sources such as text, solids, and Lottie are re-rendered for every export frame before capture, so the exported frame matches the current timeline time instead of reusing a stale first-frame texture.
+
 ### Fast Mode
 
 - Uses WebCodecs sequential decoding for a single clip.

--- a/docs/Features/Media-Panel.md
+++ b/docs/Features/Media-Panel.md
@@ -32,11 +32,14 @@ Import, organize, and manage media assets with folder structure, proxy generatio
 | **Video** | MP4, WebM, MOV, AVI, MKV, WMV, M4V, FLV |
 | **Audio** | WAV, MP3, OGG, FLAC, AAC, M4A, WMA, AIFF, OPUS |
 | **Image** | PNG, JPG/JPEG, GIF, WebP, BMP, SVG |
+| **Vector Animation** | `.lottie`, Lottie JSON (`.json`, content-sniffed) |
 
 The panel also accepts a few specialized asset types that flow into the timeline as 3D clips:
 
 - `model` files: OBJ, glTF/GLB, FBX
 - `gaussian-splat` files: PLY, SPLAT
+
+Lottie imports are treated as first-class media items. `.json` files are only accepted when their contents actually match Lottie structure, so arbitrary JSON data is not misclassified as animation.
 
 ### Import Methods
 
@@ -377,7 +380,7 @@ Clicking transcript or analysis badges selects the corresponding clip in the tim
 interface MediaFile {
   id: string;
   name: string;
-  type: 'video' | 'audio' | 'image';
+  type: 'video' | 'audio' | 'image' | 'lottie' | 'rive';
   file?: File;               // Undefined when needs reload
   url: string;
   parentId: string | null;
@@ -411,6 +414,7 @@ interface MediaFile {
   // Analysis
   analysisStatus?: AnalysisStatus;
   analysisCoverage?: number;
+  vectorAnimation?: VectorAnimationMetadata;
   // File System Access API
   hasFileHandle?: boolean;
   filePath?: string;
@@ -431,7 +435,7 @@ interface MediaFile {
 ### Drag Types
 | Item Type | Drag Payload Kind | Data Transfer Key |
 |-----------|-------------------|-------------------|
-| Media file (video/image) | `media-file` | `application/x-media-file-id` |
+| Media file (video/image/lottie) | `media-file` | `application/x-media-file-id` |
 | Media file (audio) | `media-file` (marked as audio) | `application/x-media-file-id` |
 | Composition | `composition` | `application/x-composition-id` |
 | Text item | `text` | `application/x-text-item-id` |
@@ -450,7 +454,7 @@ interface MediaFile {
 ### Track Type Enforcement
 | Media Type | Allowed Tracks |
 |------------|----------------|
-| Video/Image/Composition/Text/Solid/Mesh | Video tracks only |
+| Video/Image/Lottie/Composition/Text/Solid/Mesh | Video tracks only |
 | Audio | Audio tracks only |
 
 ---

--- a/docs/Features/Media-Panel.md
+++ b/docs/Features/Media-Panel.md
@@ -478,7 +478,8 @@ On project load:
 - Thumbnails restored from `Cache/thumbnails` by file hash
 - Existing proxies detected automatically, including legacy media-id based storage
 - Existing transcripts and analysis data loaded from the project folder
-- Blob URLs regenerated for available files
+- Dead blob/object URLs are regenerated for available files
+- If a retained `File` object is still present, image/video thumbnails are rebuilt when needed after refresh
 - Folder structure, expansion state, dock layout, and per-composition view state restored
 
 ### Media File IDs

--- a/docs/Features/Project-Persistence.md
+++ b/docs/Features/Project-Persistence.md
@@ -240,6 +240,7 @@ When opening a project, the app automatically:
 3. Checks read permission on restored handles
 4. Scans the `Raw/` folder for missing files (exact filename match, case-insensitive)
 5. Also checks stored IndexedDB handles for files not found in Raw
+6. Regenerates missing object URLs for files that were restored successfully and rebuilds previews when the underlying `File` object is still available
 
 ### Reload All Button
 In Media Panel toolbar:
@@ -301,6 +302,7 @@ interface ProjectFile {
 - Nested composition references
 - Text clip properties
 - Solid clip color
+- Vector animation settings (loop, end behavior, fit, animation selection, background)
 - Transcript and analysis data per clip
 - Scene description data
 
@@ -311,6 +313,7 @@ interface ProjectFile {
 - Bitrate and file size
 - hasAudio flag
 - Proxy status
+- Vector animation metadata (provider, animation names, default animation, frame count)
 - Folder organization (folderId)
 - `projectPath` when the file is copied into `Raw/`
 

--- a/docs/Features/Project-Persistence.md
+++ b/docs/Features/Project-Persistence.md
@@ -187,6 +187,7 @@ The `setupAutoSync()` function (in `projectLifecycle.ts`) subscribes to store ch
 - Clips or tracks change (timelineStore)
 - YouTube panel state changes
 - Dock layout changes
+- Export settings or export presets change
 
 ### Manual Save
 - `Ctrl+S` shortcut
@@ -324,6 +325,7 @@ interface ProjectFile {
 - Transcript language preference
 - View toggles: thumbnails, waveforms, proxy, transcript markers
 - Changelog preferences (`showChangelogOnStartup`, `lastSeenChangelogVersion`)
+- Export panel state: live export settings, named export presets, and the selected preset
 
 ### Other Persisted Panels
 - YouTube panel state is saved in `project.json`

--- a/docs/Features/README.md
+++ b/docs/Features/README.md
@@ -4,7 +4,7 @@
 
 Current feature documentation for the `staging` branch.
 
-Version 1.5.1 | April 2026
+Version 1.5.3 | April 2026
 
 ---
 
@@ -23,6 +23,7 @@ The docs in this folder were re-audited against the current codebase and now tra
 | **AI Control** | OpenAI chat with 79 exported tools plus local/native bridge access for external agents |
 | **AI Video Workspace** | Classic AI Video plus FlashBoard board-mode generation and media import |
 | **3D Layers** | Three.js layers, camera clips, Gaussian splats, and splat effectors |
+| **Vector Animation** | Lottie clips with deterministic canvas playback, looping, and export |
 | **Audio** | Element-synced playback, drift correction, waveform extraction, EQ, and audio export |
 | **Project Storage** | `project.json` source of truth, RAW-copy-first media flow, autosave, relink, backups |
 | **Native Helper** | Firefox storage backend, yt-dlp download flow, local AI bridge, native jobs |
@@ -53,6 +54,7 @@ The docs in this folder were re-audited against the current codebase and now tra
 | [Masks](./Masks.md) | Overlay mask editing, feathering, stored modes, and current limitations |
 | [Text Clips](./Text-Clips.md) | Canvas-backed text rendering, typography controls, and timeline text items |
 | [3D Layers](./3D-Layers.md) | Three.js scene path, native Gaussian splats, cameras, and splat effectors |
+| [Vector Animation](./Vector-Animation.md) | Lottie import, runtime playback, looping, and export behavior |
 | [Audio](./Audio.md) | Playback sync, EQ, waveform extraction, audio clip behavior, and export |
 | [Export](./Export.md) | WebCodecs fast/precise export, FFmpeg WASM path, and interchange output |
 | [Proxy System](./Proxy-System.md) | Proxy generation, on-disk frame layout, audio proxies, and warmup behavior |
@@ -109,7 +111,7 @@ Native Helper     Rust service with HTTP/WebSocket bridge, yt-dlp, helper-backed
 
 ## Audit Notes
 
-- The authoritative app version is [`src/version.ts`](../../src/version.ts), currently `1.5.1`.
+- The authoritative app version is [`src/version.ts`](../../src/version.ts), currently `1.5.3`.
 - Preview quality is wired into engine-backed preview resolution through `useEngine()`; it does not affect export resolution or the HTML-only source monitor.
 - `openComposition` and `searchVideos` are still the two known AI dispatch gaps.
 - Gaussian AI tool definitions exist in code but are not exported through `AI_TOOLS` yet.
@@ -120,4 +122,4 @@ Native Helper     Rust service with HTTP/WebSocket bridge, yt-dlp, helper-backed
 ## Version History
 
 See [`src/version.ts`](../../src/version.ts) and [`src/changelog-data.json`](../../src/changelog-data.json) for the authoritative changelog.
-Current version: 1.5.1.
+Current version: 1.5.3.

--- a/docs/Features/README.md
+++ b/docs/Features/README.md
@@ -4,7 +4,7 @@
 
 Current feature documentation for the `staging` branch.
 
-Version 1.5.3 | April 2026
+Version 1.5.4 | April 2026
 
 ---
 
@@ -111,7 +111,7 @@ Native Helper     Rust service with HTTP/WebSocket bridge, yt-dlp, helper-backed
 
 ## Audit Notes
 
-- The authoritative app version is [`src/version.ts`](../../src/version.ts), currently `1.5.3`.
+- The authoritative app version is [`src/version.ts`](../../src/version.ts), currently `1.5.4`.
 - Preview quality is wired into engine-backed preview resolution through `useEngine()`; it does not affect export resolution or the HTML-only source monitor.
 - `openComposition` and `searchVideos` are still the two known AI dispatch gaps.
 - Gaussian AI tool definitions exist in code but are not exported through `AI_TOOLS` yet.
@@ -122,4 +122,4 @@ Native Helper     Rust service with HTTP/WebSocket bridge, yt-dlp, helper-backed
 ## Version History
 
 See [`src/version.ts`](../../src/version.ts) and [`src/changelog-data.json`](../../src/changelog-data.json) for the authoritative changelog.
-Current version: 1.5.3.
+Current version: 1.5.4.

--- a/docs/Features/README.md
+++ b/docs/Features/README.md
@@ -56,7 +56,7 @@ The docs in this folder were re-audited against the current codebase and now tra
 | [3D Layers](./3D-Layers.md) | Three.js scene path, native Gaussian splats, cameras, and splat effectors |
 | [Vector Animation](./Vector-Animation.md) | Lottie import, runtime playback, looping, and export behavior |
 | [Audio](./Audio.md) | Playback sync, EQ, waveform extraction, audio clip behavior, and export |
-| [Export](./Export.md) | WebCodecs fast/precise export, FFmpeg WASM path, and interchange output |
+| [Export](./Export.md) | WebCodecs fast/precise export, FFmpeg intermediates, image/audio-only export, FCPXML, and project-persistent presets |
 | [Proxy System](./Proxy-System.md) | Proxy generation, on-disk frame layout, audio proxies, and warmup behavior |
 | [Media Panel](./Media-Panel.md) | Import flow, RAW-copy promotion, folders, compositions, and relinking |
 | [Project Persistence](./Project-Persistence.md) | Save/load model, IndexedDB handle cache, continuous save, interval save mode, relink, and project roots |

--- a/docs/Features/Timeline.md
+++ b/docs/Features/Timeline.md
@@ -56,6 +56,7 @@ getTrackChildren()  // Query child tracks
 - Imported from `.lottie` packages or Lottie JSON files from the Media Panel.
 - Uses the same canvas-backed render path as text and solids, so preview, nested comps, and export stay deterministic.
 - Exposes per-clip loop, end behavior, fit, animation selection, and background controls in the Properties panel.
+- When loop is enabled, the clip can be extended beyond its source duration on the right trim edge without freezing on the first pass.
 
 ### Solid
 - Flat color clips used for mattes and backgrounds.

--- a/docs/Features/Timeline.md
+++ b/docs/Features/Timeline.md
@@ -2,14 +2,14 @@
 
 [<- Back to Index](./README.md)
 
-The Timeline is the core editing interface for multi-track editing. It now covers video, audio, text, solid, mesh, composition, camera, and splat-effector clips, with keyframe lanes, transitions, multicam grouping, pick-whip parenting, and slot-grid playback.
+The Timeline is the core editing interface for multi-track editing. It now covers video, audio, image, Lottie, text, solid, mesh, composition, camera, and splat-effector clips, with keyframe lanes, transitions, multicam grouping, pick-whip parenting, and slot-grid playback.
 
 ---
 
 ## Track Types
 
 ### Video Tracks
-- Hold video, image, text, solid, mesh, composition, camera, and splat-effector clips.
+- Hold video, image, Lottie, text, solid, mesh, composition, camera, and splat-effector clips.
 - Higher tracks render on top of lower tracks.
 - Expanded tracks can show keyframe property rows and curve editors.
 - Default layout starts with `Video 2` above `Video 1`.
@@ -52,6 +52,11 @@ getTrackChildren()  // Query child tracks
 - Created through the timeline text slice.
 - Supports typography, stroke, shadow, and path text.
 
+### Lottie
+- Imported from `.lottie` packages or Lottie JSON files from the Media Panel.
+- Uses the same canvas-backed render path as text and solids, so preview, nested comps, and export stay deterministic.
+- Exposes per-clip loop, end behavior, fit, animation selection, and background controls in the Properties panel.
+
 ### Solid
 - Flat color clips used for mattes and backgrounds.
 
@@ -88,6 +93,7 @@ getTrackChildren()  // Query child tracks
 
 ### Copy and Paste
 - Copying clips includes linked audio automatically when the video clip is selected.
+- Copy/paste preserves Lottie clip type and vector animation settings.
 - Copying keyframes stores them relative to the earliest copied keyframe.
 - Pasting keyframes targets the selected clip when exactly one clip is selected; otherwise it falls back to the original clip from the clipboard data.
 
@@ -138,6 +144,7 @@ getTrackChildren()  // Query child tracks
 - Composition clips can be nested to a depth of 8.
 - Composition changes propagate into nested render data.
 - Composition switches trigger clip entrance/exit animations in the timeline UI.
+- Lottie clips inside nested comps render through the same canvas path used in the primary timeline and export flow.
 
 ### Transitions
 - Transitions operate between adjacent clips on the same track.

--- a/docs/Features/UI-Panels.md
+++ b/docs/Features/UI-Panels.md
@@ -327,6 +327,7 @@ The unified Properties panel adapts its tabs to the selected clip type and to sl
 
 | Clip Type | Tabs |
 |-----------|------|
+| **Lottie** | Lottie, Transform, Effects, Masks |
 | **Gaussian avatar** | Blendshapes, Transform, Effects, Masks |
 | **Gaussian splat** | Transform, Gaussian Splat, Effects, Masks |
 | **Camera** | Transform, Camera |

--- a/docs/Features/Vector-Animation.md
+++ b/docs/Features/Vector-Animation.md
@@ -1,0 +1,90 @@
+[Back to Index](./README.md)
+
+# Vector Animation
+
+Vector animation clips currently ship through the Lottie path. `.lottie` packages and Lottie JSON files import as first-class media items, render through the same timeline/export pipeline as other clips, and expose clip-specific controls in the Properties panel.
+
+`rive` is still only a reserved type in the data model. It is not wired into import, runtime playback, or export yet.
+
+---
+
+## Supported Sources
+
+- `.lottie` packages
+- Lottie JSON files when the JSON structure is positively identified as a Lottie animation
+
+The import path does not treat arbitrary `.json` files as animation. Files are sniffed first, then promoted to `type: 'lottie'` only when the payload matches expected Lottie structure.
+
+---
+
+## Timeline Behavior
+
+- Lottie clips live on video tracks.
+- The clip bar shows an `L` badge in the timeline.
+- `naturalDuration`, frame rate, dimensions, animation names, and other vector metadata are extracted during import.
+- Loop-enabled clips can be extended beyond their source duration on the right trim edge.
+- Copy/paste, nested compositions, slot decks, and background-layer playback preserve the clip type and vector animation settings.
+
+---
+
+## Properties Panel
+
+Lottie clips add a dedicated `Lottie` tab in the unified Properties panel.
+
+Current controls:
+
+- Loop toggle
+- End behavior: `hold`, `clear`, or `loop`
+- Fit: `contain`, `cover`, or `fill`
+- Animation picker when a `.lottie` package exposes multiple animations
+- Background color override
+
+The tab also shows the clip name plus imported width, height, and frame rate metadata when available.
+
+---
+
+## Rendering
+
+Lottie playback is driven by `src/services/vectorAnimation/LottieRuntimeManager.ts`.
+
+- Each clip gets a dedicated runtime canvas.
+- Timeline time is converted into a deterministic target frame rather than relying on autoplay.
+- The runtime canvas is marked as dynamic, so `TextureManager` re-uploads it every frame instead of caching only the first frame.
+- The same canvas-backed source flows through preview, nested comps, slot/background playback, thumbnails, and export.
+
+That shared path is the reason reloading at a different playhead position now shows the correct frame immediately, and why preview and export stay aligned.
+
+---
+
+## Persistence And Reload
+
+Saved data includes:
+
+- media-level vector metadata
+- clip-level `vectorAnimationSettings`
+- serialized timeline clip type `lottie`
+- clipboard payloads and nested-composition clip data
+
+On project load, the app restores the Lottie clip metadata from project data and recreates the runtime from the file, the copied `Raw/` media, or a recovered file handle.
+
+If a retained `File` object still exists after refresh but the browser object URL is dead, the Media panel regenerates the missing URL and image/video thumbnail automatically.
+
+---
+
+## Export
+
+Lottie export does not use a separate renderer.
+
+- The export layer builder asks the runtime for the correct frame at the current export time.
+- That frame is composited through the normal GPU path with effects, transforms, masks, nested comps, and other layers.
+- Output is rasterized into the final render like any other canvas-backed source.
+
+This keeps Lottie clips deterministic in fast preview, precise export, and image export.
+
+---
+
+## Current Limits
+
+- Only Lottie is implemented today. Rive is not.
+- Export output is rasterized; there is no vector-native export target.
+- If no `Raw/` copy or file handle is available after reload, the clip still needs the normal relink flow.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "masterselects",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "masterselects",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "dependencies": {
         "@ffmpeg/core": "^0.12.6",
         "@ffmpeg/ffmpeg": "^0.12.6",
         "@ffmpeg/util": "^0.12.2",
         "@huggingface/transformers": "^3.8.1",
+        "@lottiefiles/dotlottie-web": "^0.71.0",
         "@types/three": "^0.183.1",
         "@webgpu/types": "^0.1.66",
         "mediabunny": "^1.39.2",
@@ -1975,6 +1976,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lottiefiles/dotlottie-web": {
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-web/-/dotlottie-web-0.71.0.tgz",
+      "integrity": "sha512-CliQttL0Rk0or/aDQkqUJXnC9Cm5TxzNdOqy/YlzKlU6mu+XgTMwyt5/HpPiltlMeaqBmM9mOzfevpyP4QmudQ==",
+      "license": "MIT"
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "masterselects",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@ffmpeg/ffmpeg": "^0.12.6",
     "@ffmpeg/util": "^0.12.2",
     "@huggingface/transformers": "^3.8.1",
+    "@lottiefiles/dotlottie-web": "^0.71.0",
     "@types/three": "^0.183.1",
     "@webgpu/types": "^0.1.66",
     "mediabunny": "^1.39.2",

--- a/src/App.css
+++ b/src/App.css
@@ -2553,6 +2553,684 @@ input, textarea {
   background: var(--bg-hover);
 }
 
+/* Export Panel refresh */
+.export-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-3) 0;
+}
+
+.export-mode-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 4px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+}
+
+.export-mode-tab {
+  padding: 8px 12px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--font-md);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: background var(--transition-fast) ease, color var(--transition-fast) ease;
+}
+
+.export-mode-tab:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-primary);
+}
+
+.export-mode-tab.is-active {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 72%, transparent) 0%, color-mix(in srgb, var(--accent-hover) 88%, transparent) 100%);
+  color: var(--bg-primary);
+}
+
+.export-mode-tab:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.export-toolbar-cta {
+  width: auto;
+  min-width: 152px;
+}
+
+.export-form {
+  padding: var(--sp-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  overflow-y: auto;
+}
+
+.export-summary-sticky {
+  position: sticky;
+  top: 0;
+  z-index: 8;
+  backdrop-filter: blur(14px);
+}
+
+.export-summary-badges {
+  padding: 10px 12px;
+}
+
+.export-summary-badges .export-pill-row {
+  gap: 6px;
+}
+
+.export-hero-card,
+.export-section {
+  padding: 14px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.025) 0%, rgba(255, 255, 255, 0.01) 100%),
+    var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.16);
+}
+
+.export-hero-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 10px;
+}
+
+.export-hero-main {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.export-hero-kicker {
+  font-size: 11px;
+  font-weight: var(--font-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.export-hero-title-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.export-hero-title-row h3 {
+  margin: 0;
+  font-size: 20px;
+  line-height: 1.1;
+  color: var(--text-primary);
+}
+
+.export-hero-main p {
+  margin: 0;
+  max-width: 54ch;
+  font-size: var(--font-md);
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.export-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: var(--font-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.export-hero-metrics {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: flex-start;
+  gap: 4px;
+  min-width: 120px;
+}
+
+.export-hero-metric-label,
+.export-hero-metric-subtle {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.export-hero-metrics strong {
+  font-size: 24px;
+  line-height: 1;
+  color: var(--text-primary);
+}
+
+.export-pill-row {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.export-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.045);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.export-pill-warning {
+  color: var(--warning-light);
+  border-color: color-mix(in srgb, var(--warning) 35%, transparent);
+  background: var(--warning-subtle);
+}
+
+.export-hero-footnote {
+  grid-column: 1 / -1;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.export-workflow-section,
+.export-workflow-section .export-legacy-control {
+  display: none;
+}
+
+.export-channel-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.export-channel-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+}
+
+.export-channel-card.is-disabled {
+  opacity: 0.82;
+}
+
+.export-channel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.export-channel-title {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.export-channel-title span {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.export-channel-title strong {
+  font-size: 18px;
+  line-height: 1.1;
+  color: var(--text-primary);
+}
+
+.export-method-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.export-method-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  min-height: 110px;
+  padding: 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  color: var(--text-secondary);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast) ease,
+    transform var(--transition-fast) ease,
+    box-shadow var(--transition-fast) ease,
+    color var(--transition-fast) ease;
+}
+
+.export-method-card strong {
+  color: var(--text-primary);
+  font-size: 14px;
+}
+
+.export-method-card span:last-child {
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.export-method-card:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border-color));
+  color: var(--text-primary);
+}
+
+.export-method-card.is-active {
+  border-color: color-mix(in srgb, var(--accent) 70%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 11%, transparent) 0%, rgba(255, 255, 255, 0.02) 100%), var(--bg-primary);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 45%, transparent);
+}
+
+.export-method-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: var(--font-semibold);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.export-status-row {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+}
+
+.export-status-button {
+  padding: 6px 12px;
+  font-size: 11px;
+}
+
+.export-status-ok {
+  color: var(--success);
+  font-size: 12px;
+  font-weight: var(--font-semibold);
+}
+
+.export-error-inline {
+  margin-top: 4px;
+  font-size: 11px;
+}
+
+.export-basics-section {
+  padding: 0;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  gap: 14px;
+}
+
+.export-basics-section > .export-section-header {
+  display: none;
+}
+
+.export-quick-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.export-field-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+}
+
+.export-subcard {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.export-field-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.export-field-head span {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.export-field-head strong {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.export-chip-row,
+.export-toggle-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.export-chip,
+.export-toggle {
+  padding: 8px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast) ease,
+    background var(--transition-fast) ease,
+    color var(--transition-fast) ease,
+    transform var(--transition-fast) ease;
+}
+
+.export-chip:hover,
+.export-toggle:hover {
+  transform: translateY(-1px);
+  color: var(--text-primary);
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border-color));
+}
+
+.export-chip.is-active,
+.export-toggle.is-active {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.export-toggle:disabled,
+.export-chip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.export-chip-static {
+  cursor: default;
+}
+
+.export-chip-static:hover {
+  transform: none;
+  color: var(--text-secondary);
+}
+
+.export-inline-inputs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.export-inline-inputs-single {
+  max-width: 140px;
+}
+
+.export-inline-inputs span {
+  color: var(--text-muted);
+}
+
+.export-preset-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.export-preset-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 12px;
+  background: var(--bg-primary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  color: var(--text-secondary);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast) ease,
+    background var(--transition-fast) ease,
+    transform var(--transition-fast) ease;
+}
+
+.export-preset-card strong {
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.export-preset-card span {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.export-preset-card:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border-color));
+}
+
+.export-preset-card.is-active {
+  border-color: color-mix(in srgb, var(--accent) 34%, transparent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.export-audio-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.export-inline-note {
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.export-inline-note-warning {
+  background: var(--warning-subtle);
+  border-color: color-mix(in srgb, var(--warning) 35%, transparent);
+  color: var(--warning-light);
+}
+
+.export-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.export-stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+}
+
+.export-stat-card span {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.export-stat-card strong {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.export-stats-grid-compact {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.export-advanced-section {
+  display: none;
+  gap: 10px;
+}
+
+.export-advanced-section .export-section-header {
+  color: var(--text-primary);
+  border-bottom-style: dashed;
+}
+
+.export-panel .control-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.export-panel .control-row label {
+  display: flex;
+  align-items: center;
+  min-width: 96px;
+  font-size: var(--font-md);
+  color: var(--text-secondary);
+}
+
+.export-panel select,
+.export-panel input[type="text"],
+.export-panel input[type="number"] {
+  flex: 1;
+  min-width: 0;
+  padding: 10px 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  color: var(--text-primary);
+  font-size: var(--font-md);
+}
+
+.export-input-group {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.export-range-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+}
+
+.export-range-row input[type="range"] {
+  flex: 1;
+}
+
+.export-range-row span {
+  min-width: 78px;
+  text-align: right;
+}
+
+.export-summary {
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+}
+
+.export-progress-container {
+  padding: var(--sp-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+.export-progress-bar {
+  height: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.export-progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-hover));
+  transition: width var(--transition-fast) ease-out;
+}
+
+.export-progress-info {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: var(--font-md);
+  color: var(--text-secondary);
+}
+
+.export-eta {
+  text-align: left;
+  font-size: var(--font-md);
+  color: var(--text-primary);
+}
+
+.export-cancel-btn {
+  width: 100%;
+  padding: var(--sp-2);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  cursor: pointer;
+}
+
+@media (max-width: 900px) {
+  .export-toolbar,
+  .export-hero-card {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .export-toolbar-cta {
+    width: 100%;
+  }
+
+  .export-method-grid,
+  .export-channel-grid,
+  .export-preset-grid,
+  .export-quick-grid,
+  .export-stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .export-hero-metrics {
+    align-items: flex-start;
+  }
+}
+
 /* Clip Properties Panel */
 .clip-properties-panel {
   display: flex;

--- a/src/App.css
+++ b/src/App.css
@@ -2605,7 +2605,7 @@ input, textarea {
 }
 
 .export-form {
-  padding: var(--sp-3);
+  padding: 0 var(--sp-3) var(--sp-3);
   display: flex;
   flex-direction: column;
   gap: var(--sp-3);
@@ -2620,11 +2620,61 @@ input, textarea {
 }
 
 .export-summary-badges {
-  padding: 10px 12px;
+  margin: 0 calc(var(--sp-3) * -1) 0;
+  padding: 10px 12px 12px;
+  border-top: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
 }
 
 .export-summary-badges .export-pill-row {
   gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.export-summary-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: stretch;
+  gap: 12px;
+}
+
+.export-summary-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
+  min-width: 108px;
+  white-space: nowrap;
+  padding: 10px 18px;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--success) 42%, transparent);
+  background: color-mix(in srgb, var(--success) 14%, rgba(255, 255, 255, 0.02));
+  color: var(--success-light);
+  font-weight: var(--font-semibold);
+  letter-spacing: 0.01em;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  transition:
+    transform var(--transition-fast) ease,
+    border-color var(--transition-fast) ease,
+    color var(--transition-fast) ease,
+    background var(--transition-fast) ease;
+}
+
+.export-summary-cta:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--success) 18%, rgba(255, 255, 255, 0.03));
+  border-color: color-mix(in srgb, var(--success) 56%, transparent);
+  color: color-mix(in srgb, var(--success-light) 88%, #ffffff 12%);
+  transform: translateY(-1px);
+}
+
+.export-summary-cta:disabled {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: var(--text-muted);
+  box-shadow: none;
 }
 
 .export-hero-card,
@@ -2731,6 +2781,27 @@ input, textarea {
   border: 1px solid rgba(255, 255, 255, 0.08);
   color: var(--text-secondary);
   font-size: 12px;
+  font: inherit;
+  line-height: 1.2;
+  white-space: nowrap;
+  cursor: pointer;
+  appearance: none;
+  transition:
+    transform var(--transition-fast) ease,
+    border-color var(--transition-fast) ease,
+    color var(--transition-fast) ease,
+    background var(--transition-fast) ease;
+}
+
+.export-pill:hover {
+  transform: translateY(-1px);
+  color: var(--text-primary);
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border-color));
+}
+
+.export-pill:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 28%, transparent);
 }
 
 .export-pill-warning {
@@ -2750,9 +2821,51 @@ input, textarea {
   display: none;
 }
 
+.export-command-row {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.export-command-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.export-command-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.export-preset-picker {
+  display: inline-flex;
+  align-items: center;
+  flex: 1 1 220px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.export-preset-picker select {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  padding: 8px 34px 8px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font: inherit;
+}
+
 .export-channel-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
   gap: 12px;
   align-items: start;
 }
@@ -2765,6 +2878,7 @@ input, textarea {
   background: rgba(255, 255, 255, 0.025);
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 14px;
+  scroll-margin-top: 104px;
 }
 
 .export-channel-card.is-disabled {
@@ -2807,9 +2921,9 @@ input, textarea {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 8px;
-  min-height: 110px;
-  padding: 12px;
+  gap: 6px;
+  min-height: 0;
+  padding: 10px 12px;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 12px;
@@ -2895,8 +3009,12 @@ input, textarea {
 
 .export-quick-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 10px;
+}
+
+.export-quick-grid-stack {
+  grid-template-columns: 1fr;
 }
 
 .export-field-card {
@@ -2907,6 +3025,27 @@ input, textarea {
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 12px;
+  scroll-margin-top: 104px;
+}
+
+.export-scroll-highlight {
+  animation: export-scroll-highlight 1.1s ease;
+}
+
+@keyframes export-scroll-highlight {
+  0%,
+  100% {
+    border-color: rgba(255, 255, 255, 0.06);
+    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+  }
+
+  30%,
+  70% {
+    border-color: color-mix(in srgb, var(--accent) 58%, rgba(255, 255, 255, 0.06));
+    box-shadow:
+      0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent),
+      0 0 22px color-mix(in srgb, var(--accent) 16%, transparent);
+  }
 }
 
 .export-subcard {
@@ -2935,6 +3074,33 @@ input, textarea {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+}
+
+.export-container-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px 18px;
+}
+
+.export-container-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.export-container-group-label {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.export-container-group .export-chip-row {
+  display: grid;
+  grid-template-columns: repeat(2, max-content);
+  justify-content: start;
+  align-content: start;
 }
 
 .export-chip,
@@ -2996,6 +3162,37 @@ input, textarea {
 
 .export-inline-inputs span {
   color: var(--text-muted);
+}
+
+.export-slider-control {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.export-slider-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.export-slider-head label {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.export-slider-value {
+  min-width: 0;
+  font-size: 12px;
+  color: var(--text-primary);
+  text-align: right;
+}
+
+.export-slider-input {
+  width: 100%;
+  min-width: 0;
 }
 
 .export-preset-grid {
@@ -3216,6 +3413,20 @@ input, textarea {
 
   .export-toolbar-cta {
     width: 100%;
+  }
+
+  .export-summary-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .export-command-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .export-summary-cta {
+    width: 100%;
+    min-height: 44px;
   }
 
   .export-method-grid,

--- a/src/changelog-data.json
+++ b/src/changelog-data.json
@@ -1,6 +1,37 @@
 [
   {
     "date": "2026-04-16",
+    "type": "improve",
+    "title": "Export Panel Was Rebuilt Around Deliverables and Presets",
+    "description": "The export tab now uses grouped Video/Image/Audio/XML containers, a sticky badge summary, clickable section jumps, named project-persistent presets with Load/Update/Save, and shared export state that participates in undo/redo and project restore.",
+    "section": "Export / Persistence",
+    "commits": [
+      "337031ff",
+      "e5a74cc6"
+    ]
+  },
+  {
+    "date": "2026-04-16",
+    "type": "fix",
+    "title": "WebCodecs Export Bitrate Controls Now Reach the Encoder",
+    "description": "The selected bitrate and VBR/CBR mode are now passed into the WebCodecs encoder configuration, with a constant-bitrate fallback path and clearer UI messaging that browser bitrate values are still targets rather than exact final file sizes.",
+    "section": "Export / Encoding",
+    "commits": [
+      "e5a74cc6"
+    ]
+  },
+  {
+    "date": "2026-04-16",
+    "type": "improve",
+    "title": "Export Documentation and README Now Match the Current Runtime",
+    "description": "The export docs, project persistence docs, and README were updated to reflect the current preset system, container modes, FFmpeg intermediate formats, audio-only/image export behavior, and the actual MediaBunny-based export stack.",
+    "section": "Documentation",
+    "commits": [
+      "e5a74cc6"
+    ]
+  },
+  {
+    "date": "2026-04-16",
     "type": "new",
     "title": "Lottie Clips Import, Loop, Properties, and Export",
     "description": "`.lottie` packages and Lottie JSON now import as first-class timeline clips with deterministic preview/export rendering, save-load and clipboard persistence, a dedicated properties tab, and loop-aware timeline extension.",

--- a/src/changelog-data.json
+++ b/src/changelog-data.json
@@ -1,5 +1,25 @@
 [
   {
+    "date": "2026-04-16",
+    "type": "new",
+    "title": "Lottie Clips Import, Loop, Properties, and Export",
+    "description": "`.lottie` packages and Lottie JSON now import as first-class timeline clips with deterministic preview/export rendering, save-load and clipboard persistence, a dedicated properties tab, and loop-aware timeline extension.",
+    "section": "Vector Animation / Timeline",
+    "commits": [
+      "0901f0ab"
+    ]
+  },
+  {
+    "date": "2026-04-16",
+    "type": "fix",
+    "title": "Media Previews Recover Broken Blob URLs After Reload",
+    "description": "The media panels now rebuild missing object URLs and thumbnails from retained File objects so image and video previews stop breaking after refresh or project restore.",
+    "section": "Media Panel / Persistence",
+    "commits": [
+      "0901f0ab"
+    ]
+  },
+  {
     "date": "2026-04-15",
     "type": "fix",
     "title": "README Startup Size and Three.js Bundle Notes Were Corrected",

--- a/src/components/export/ExportPanel.tsx
+++ b/src/components/export/ExportPanel.tsx
@@ -1,6 +1,6 @@
 // Export Panel - embedded panel for frame-by-frame video export
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Logger } from '../../services/logger';
 import { downloadFCPXML } from '../../services/export/fcpxmlExport';
 
@@ -33,6 +33,7 @@ import { useExportState, type EncoderType } from './useExportState';
 export function ExportPanel() {
   const ffmpegFrameRendererRef = useRef<FFmpegFrameRenderer | null>(null);
   const ffmpegAudioPipelineRef = useRef<AudioExportPipeline | null>(null);
+  const [videoEnabled, setVideoEnabled] = useState(true);
   const { duration, inPoint, outPoint, playheadPosition, startExport, setExportProgress, endExport } = useTimelineStore(useShallow(s => ({
     duration: s.duration,
     inPoint: s.inPoint,
@@ -588,23 +589,20 @@ export function ExportPanel() {
 
     let estimatedBitrate: number;
 
-    if (encoder === 'webcodecs' || encoder === 'htmlvideo') {
+    if (!videoEnabled) {
+      estimatedBitrate = audioBitrate;
+    } else if (encoder === 'webcodecs' || encoder === 'htmlvideo') {
       estimatedBitrate = bitrate;
+    } else if (ffmpegRateControl === 'crf') {
+      const pixels = (useCustomResolution ? customWidth * customHeight : width * height);
+      const qualityFactor = Math.pow(2, (51 - ffmpegQuality) / 6);
+      estimatedBitrate = (pixels * actualFps * qualityFactor) / 10000;
+      estimatedBitrate = Math.min(estimatedBitrate, 100_000_000);
     } else {
-      // FFmpeg estimation
-      if (ffmpegRateControl === 'crf') {
-        // CRF: estimate based on quality and resolution
-        const pixels = (useCustomResolution ? customWidth * customHeight : width * height);
-        const qualityFactor = Math.pow(2, (51 - ffmpegQuality) / 6); // CRF scale
-        estimatedBitrate = (pixels * actualFps * qualityFactor) / 10000;
-        estimatedBitrate = Math.min(estimatedBitrate, 100_000_000); // Cap at 100 Mbps
-      } else {
-        estimatedBitrate = ffmpegBitrate;
-      }
+      estimatedBitrate = ffmpegBitrate;
     }
 
-    // Add ~10% for audio if included
-    if (includeAudio && (encoder === 'webcodecs' || encoder === 'htmlvideo')) {
+    if (videoEnabled && includeAudio && (encoder === 'webcodecs' || encoder === 'htmlvideo')) {
       estimatedBitrate += audioBitrate;
     }
 
@@ -623,6 +621,121 @@ export function ExportPanel() {
   const ffmpegCodecInfo = getCodecInfo(ffmpegCodec);
   // Only MJPEG has quality slider (q:v), professional codecs use profiles
   const showFFmpegQualityControl = ffmpegCodec === 'mjpeg';
+  const isWebCodecsEncoder = encoder === 'webcodecs' || encoder === 'htmlvideo';
+  const currentContainerId = isWebCodecsEncoder ? containerFormat : ffmpegContainer;
+  const currentContainerLabel = isWebCodecsEncoder
+    ? FrameExporter.getContainerFormats().find(({ id }) => id === containerFormat)?.label ?? containerFormat.toUpperCase()
+    : CONTAINER_FORMATS.find(({ id }) => id === ffmpegContainer)?.name ?? ffmpegContainer.toUpperCase();
+  const currentCodecLabel = isWebCodecsEncoder
+    ? FrameExporter.getVideoCodecs(containerFormat).find(({ id }) => id === videoCodec)?.label ?? videoCodec.toUpperCase()
+    : ffmpegCodecInfo?.name ?? ffmpegCodec.toUpperCase();
+  const methodMeta = encoder === 'webcodecs'
+    ? {
+        title: 'WebCodecs Fast',
+        badge: 'Fast',
+        description: 'Best for quick delivery renders directly in the browser.',
+      }
+    : encoder === 'htmlvideo'
+      ? {
+          title: 'HTMLVideo Precise',
+          badge: 'Precise',
+          description: 'Safer for difficult seeking cases and frame-accurate timing.',
+        }
+      : {
+          title: 'FFmpeg CPU',
+          badge: isFFmpegMultiThreaded ? 'Intermediate' : 'CPU',
+          description: 'Professional intermediates and edit-friendly interchange formats.',
+        };
+  const audioExtension = audioCodec === 'opus' ? 'ogg' : 'aac';
+  const audioCodecLabel = audioCodec?.toUpperCase() ?? 'AAC';
+  const outputHeight = stackedAlpha ? actualHeight * 2 : actualHeight;
+  const frameCount = Math.ceil((endTime - startTime) * actualFps);
+  const estimatedSizeLabel = (!videoEnabled && !includeAudio) ? '-' : estimatedSize();
+  const exportModeLabel = videoEnabled
+    ? (includeAudio ? 'Video + Audio' : 'Video Only')
+    : (includeAudio ? 'Audio Only' : 'Nothing Selected');
+  const exportDisabled =
+    isExporting ||
+    endTime <= startTime ||
+    !videoEnabled && !includeAudio ||
+    (videoEnabled && encoder === 'ffmpeg' && isFFmpegLoading);
+  const primaryExportLabel = videoEnabled ? 'Export Video' : includeAudio ? 'Export Audio' : 'Select Video or Audio';
+  const videoSummaryBadges = [
+    currentContainerLabel,
+    currentCodecLabel,
+    `${actualWidth}x${outputHeight}`,
+    `${actualFps} fps`,
+    encoder === 'ffmpeg'
+      ? (ffmpegPreset ? `Preset: ${ffmpegPreset}` : currentCodecLabel)
+      : `${(bitrate / 1_000_000).toFixed(1)} Mbps`,
+  ];
+  const audioSummaryBadges = includeAudio
+    ? [
+        audioCodecLabel,
+        `${audioSampleRate / 1000} kHz`,
+        `${Math.round(audioBitrate / 1000)} kbps`,
+        normalizeAudio ? 'Normalized' : 'Unprocessed',
+      ]
+    : [];
+  const summaryBadges = [
+    exportModeLabel,
+    videoEnabled ? methodMeta.title : `Audio ${audioCodecLabel}`,
+    ...(videoEnabled ? videoSummaryBadges : []),
+    ...audioSummaryBadges,
+    `Range ${formatTime(startTime)} - ${formatTime(endTime)}`,
+    `Duration ${formatTime(endTime - startTime)}`,
+    stackedAlpha && videoEnabled ? 'Stacked alpha' : null,
+    `Size ${estimatedSizeLabel}`,
+  ].filter(Boolean) as string[];
+  const showSharedFileInVideo = videoEnabled;
+  const showSharedFileInAudio = !videoEnabled && includeAudio;
+  const showRangeInVideo = videoEnabled;
+  const showRangeInAudio = !videoEnabled && includeAudio;
+  const quickResolutionPresets = FrameExporter.getPresetResolutions();
+  const quickFrameRatePresets = [24, 30, 60];
+  const webQualityPresets = [
+    { id: 'review', label: 'Review', detail: '8 Mbps', value: 8_000_000 },
+    { id: 'standard', label: 'Standard', detail: '15 Mbps', value: 15_000_000 },
+    { id: 'high', label: 'High', detail: '25 Mbps', value: 25_000_000 },
+    { id: 'master', label: 'Master', detail: '50 Mbps', value: 50_000_000 },
+  ] as const;
+  const ffmpegWorkflowPresets = [
+    { id: 'premiere', label: 'Premiere', detail: 'ProRes HQ MOV' },
+    { id: 'davinci', label: 'Resolve', detail: 'DNxHR HQ MXF' },
+    { id: 'finalcut', label: 'Final Cut', detail: 'ProRes HQ MOV' },
+    { id: 'archive', label: 'Archive', detail: 'FFV1 MKV' },
+  ] as const;
+
+  const handleQuickResolutionPreset = useCallback((value: string) => {
+    setUseCustomResolution(false);
+    handleResolutionChange(value);
+  }, [handleResolutionChange, setUseCustomResolution]);
+
+  const handleQuickFpsPreset = useCallback((value: number) => {
+    setUseCustomFps(false);
+    setFps(value);
+  }, [setFps, setUseCustomFps]);
+
+  const handleQuickBitratePreset = useCallback((value: number) => {
+    setRateControl('vbr');
+    setBitrate(value);
+  }, [setBitrate, setRateControl]);
+
+  const handlePrimaryExport = useCallback(() => {
+    if (!videoEnabled) {
+      if (includeAudio) {
+        void handleExportAudioOnly();
+      }
+      return;
+    }
+
+    if (isWebCodecsEncoder) {
+      void handleExport();
+      return;
+    }
+
+    void handleFFmpegExport();
+  }, [handleExport, handleExportAudioOnly, handleFFmpegExport, includeAudio, isWebCodecsEncoder, videoEnabled]);
 
   // If neither encoder is supported, show error
   if (!webCodecsAvailable && !ffmpegAvailable) {
@@ -641,50 +754,101 @@ export function ExportPanel() {
 
   return (
     <div className="export-panel">
-      {/* Action Buttons - Always visible at top */}
-      <div style={{ display: 'flex', gap: '8px', marginBottom: '12px', padding: '12px 12px 0' }}>
+      <div className="export-toolbar">
+        <div className="export-mode-tabs" role="tablist" aria-label="Export type">
+          <button type="button" className="export-mode-tab is-active" aria-selected="true">
+            Video
+          </button>
+          <button
+            type="button"
+            className="export-mode-tab"
+            onClick={handleRenderFrame}
+            disabled={isExporting || !videoEnabled}
+          >
+            Frame
+          </button>
+          <button
+            type="button"
+            className="export-mode-tab"
+            onClick={handleExportAudioOnly}
+            disabled={isExporting || endTime <= startTime || !isAudioSupported || !includeAudio}
+            title={!isAudioSupported ? 'Audio encoding not supported in this browser' : `Export as ${audioCodec?.toUpperCase() || 'audio'}`}
+          >
+            Audio
+          </button>
+          <button
+            type="button"
+            className="export-mode-tab"
+            onClick={handleExportFCPXML}
+            disabled={isExporting}
+            title="Export timeline as Final Cut Pro XML (compatible with Resolve, Premiere)"
+          >
+            XML
+          </button>
+        </div>
         <button
-          className="btn"
-          onClick={handleRenderFrame}
-          style={{ flex: 1 }}
-          disabled={isExporting}
+          className="btn export-start-btn export-toolbar-cta"
+          onClick={handlePrimaryExport}
+          disabled={exportDisabled}
         >
-          Frame
-        </button>
-        <button
-          className="btn export-start-btn"
-          onClick={(encoder === 'webcodecs' || encoder === 'htmlvideo') ? handleExport : handleFFmpegExport}
-          disabled={isExporting || endTime <= startTime || (encoder === 'ffmpeg' && isFFmpegLoading)}
-          style={{ flex: 1 }}
-        >
-          Export Video
-        </button>
-        <button
-          className="btn"
-          onClick={handleExportAudioOnly}
-          disabled={isExporting || endTime <= startTime || !isAudioSupported}
-          style={{ flex: 1 }}
-          title={!isAudioSupported ? 'Audio encoding not supported in this browser' : `Export as ${audioCodec?.toUpperCase() || 'audio'}`}
-        >
-          Export Audio
-        </button>
-        <button
-          className="btn"
-          onClick={handleExportFCPXML}
-          disabled={isExporting}
-          style={{ flex: 1 }}
-          title="Export timeline as Final Cut Pro XML (compatible with Resolve, Premiere)"
-        >
-          XML
+          {primaryExportLabel}
         </button>
       </div>
 
       {!isExporting ? (
         <div className="export-form">
+          <section className="export-hero-card export-summary-sticky export-summary-badges">
+            <div className="export-pill-row">
+              {summaryBadges.map((badge) => (
+                <span
+                  key={badge}
+                  className={`export-pill${badge.includes('Stacked alpha') || badge.startsWith('Size ') ? ' export-pill-warning' : ''}`}
+                >
+                  {badge}
+                </span>
+              ))}
+            </div>
+          </section>
+
           {/* Encoder Selection */}
-          <div className="export-section">
-            <div className="export-section-header">Encoder</div>
-            <div className="control-row">
+          <div className="export-section export-workflow-section">
+            <div className="export-section-header">Workflow</div>
+            <div className="export-method-grid">
+              {webCodecsAvailable && (
+                <button
+                  type="button"
+                  className={`export-method-card${encoder === 'webcodecs' ? ' is-active' : ''}`}
+                  onClick={() => setEncoder('webcodecs')}
+                >
+                  <span className="export-method-chip">Fast</span>
+                  <strong>WebCodecs</strong>
+                  <span>Hardware-assisted browser export for quick delivery files.</span>
+                </button>
+              )}
+              {webCodecsAvailable && (
+                <button
+                  type="button"
+                  className={`export-method-card${encoder === 'htmlvideo' ? ' is-active' : ''}`}
+                  onClick={() => setEncoder('htmlvideo')}
+                >
+                  <span className="export-method-chip">Precise</span>
+                  <strong>HTMLVideo</strong>
+                  <span>Safer fallback when seek accuracy matters more than speed.</span>
+                </button>
+              )}
+              {ffmpegAvailable && (
+                <button
+                  type="button"
+                  className={`export-method-card${encoder === 'ffmpeg' ? ' is-active' : ''}`}
+                  onClick={() => setEncoder('ffmpeg')}
+                >
+                  <span className="export-method-chip">CPU</span>
+                  <strong>FFmpeg</strong>
+                  <span>Intermediates, archival codecs, and NLE-friendly containers.</span>
+                </button>
+              )}
+            </div>
+            <div className="control-row export-legacy-control">
               <label>Method</label>
               <select
                 value={encoder}
@@ -706,18 +870,18 @@ export function ExportPanel() {
 
             {/* FFmpeg Load Button / Status */}
             {encoder === 'ffmpeg' && (
-              <div className="control-row" style={{ justifyContent: 'flex-end' }}>
+              <div className="export-status-row">
                 {!isFFmpegReady ? (
                   <button
+                    type="button"
                     onClick={loadFFmpeg}
                     disabled={isFFmpegLoading}
-                    className="btn-small"
-                    style={{ fontSize: '11px', padding: '4px 12px' }}
+                    className="btn-small export-status-button"
                   >
-                    {isFFmpegLoading ? 'Loading...' : 'Load FFmpeg'}
+                    {isFFmpegLoading ? 'Loading FFmpeg...' : 'Load FFmpeg Runtime'}
                   </button>
                 ) : (
-                  <span style={{ fontSize: '11px', color: 'var(--success, #4caf50)' }}>
+                  <span className="export-status-ok">
                     FFmpeg Ready
                   </span>
                 )}
@@ -725,15 +889,635 @@ export function ExportPanel() {
             )}
 
             {ffmpegLoadError && encoder === 'ffmpeg' && (
-              <div className="export-error" style={{ margin: '4px 0', fontSize: '11px' }}>
+              <div className="export-error export-error-inline">
                 {ffmpegLoadError}
               </div>
             )}
           </div>
 
+          <div className="export-section export-basics-section">
+            <div className="export-section-header">Basics</div>
+
+            <div className="export-channel-grid">
+              <div className={`export-channel-card${videoEnabled ? '' : ' is-disabled'}`}>
+                <div className="export-channel-head">
+                  <div className="export-channel-title">
+                    <span>Video</span>
+                    <strong>{videoEnabled ? `${actualWidth}x${outputHeight}` : 'Disabled'}</strong>
+                  </div>
+                  <button
+                    type="button"
+                    className={`export-toggle${videoEnabled ? ' is-active' : ''}`}
+                    onClick={() => setVideoEnabled((current) => !current)}
+                  >
+                    {videoEnabled ? 'On' : 'Off'}
+                  </button>
+                </div>
+
+                {videoEnabled ? (
+                  <>
+                    {showSharedFileInVideo && (
+                      <div className="export-field-card export-subcard">
+                        <div className="export-field-head">
+                          <span>Output</span>
+                          <strong>.{currentContainerId}</strong>
+                        </div>
+                        <div className="control-row">
+                          <label>Name</label>
+                          <div className="export-input-group">
+                            <input
+                              type="text"
+                              value={filename}
+                              onChange={(e) => setFilename(e.target.value)}
+                              placeholder="export"
+                            />
+                            <select
+                              className="export-extension-select"
+                              value={currentContainerId}
+                              onChange={(e) => {
+                                if (isWebCodecsEncoder) {
+                                  setContainerFormat(e.target.value as ContainerFormat);
+                                } else {
+                                  handleFFmpegContainerChange(e.target.value as FFmpegContainer);
+                                }
+                              }}
+                            >
+                              {isWebCodecsEncoder ? (
+                                FrameExporter.getContainerFormats().map(({ id }) => (
+                                  <option key={id} value={id}>.{id}</option>
+                                ))
+                              ) : (
+                                CONTAINER_FORMATS.map(({ id }) => (
+                                  <option key={id} value={id}>.{id}</option>
+                                ))
+                              )}
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    <div className="export-field-card export-subcard export-video-workflow-card">
+                      <div className="export-field-head">
+                        <span>Workflow</span>
+                        <strong>{methodMeta.title}</strong>
+                      </div>
+
+                      <div className="export-method-grid">
+                        {webCodecsAvailable && (
+                          <button
+                            type="button"
+                            className={`export-method-card${encoder === 'webcodecs' ? ' is-active' : ''}`}
+                            onClick={() => setEncoder('webcodecs')}
+                          >
+                            <span className="export-method-chip">Fast</span>
+                            <strong>WebCodecs</strong>
+                            <span>Hardware-assisted browser export for quick delivery files.</span>
+                          </button>
+                        )}
+                        {webCodecsAvailable && (
+                          <button
+                            type="button"
+                            className={`export-method-card${encoder === 'htmlvideo' ? ' is-active' : ''}`}
+                            onClick={() => setEncoder('htmlvideo')}
+                          >
+                            <span className="export-method-chip">Precise</span>
+                            <strong>HTMLVideo</strong>
+                            <span>Safer fallback when seek accuracy matters more than speed.</span>
+                          </button>
+                        )}
+                        {ffmpegAvailable && (
+                          <button
+                            type="button"
+                            className={`export-method-card${encoder === 'ffmpeg' ? ' is-active' : ''}`}
+                            onClick={() => setEncoder('ffmpeg')}
+                          >
+                            <span className="export-method-chip">CPU</span>
+                            <strong>FFmpeg</strong>
+                            <span>Intermediates, archival codecs, and NLE-friendly containers.</span>
+                          </button>
+                        )}
+                      </div>
+
+                      {encoder === 'ffmpeg' && (
+                        <div className="export-status-row">
+                          {!isFFmpegReady ? (
+                            <button
+                              type="button"
+                              onClick={loadFFmpeg}
+                              disabled={isFFmpegLoading}
+                              className="btn-small export-status-button"
+                            >
+                              {isFFmpegLoading ? 'Loading FFmpeg...' : 'Load FFmpeg Runtime'}
+                            </button>
+                          ) : (
+                            <span className="export-status-ok">
+                              FFmpeg Ready
+                            </span>
+                          )}
+                        </div>
+                      )}
+
+                      {ffmpegLoadError && encoder === 'ffmpeg' && (
+                        <div className="export-error export-error-inline">
+                          {ffmpegLoadError}
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="export-chip-row">
+                      {videoSummaryBadges.map((badge) => (
+                        <span key={badge} className="export-chip export-chip-static">{badge}</span>
+                      ))}
+                    </div>
+
+                    <div className="export-quick-grid">
+                      <div className="export-field-card">
+                        <div className="export-field-head">
+                          <span>Resolution</span>
+                          <strong>{actualWidth}x{actualHeight}</strong>
+                        </div>
+                        <div className="export-chip-row">
+                          {quickResolutionPresets.map(({ label, width: presetWidth, height: presetHeight }) => (
+                            <button
+                              key={`${presetWidth}x${presetHeight}`}
+                              type="button"
+                              className={`export-chip${!useCustomResolution && width === presetWidth && height === presetHeight ? ' is-active' : ''}`}
+                              onClick={() => handleQuickResolutionPreset(`${presetWidth}x${presetHeight}`)}
+                            >
+                              {label.split(' ')[0]}
+                            </button>
+                          ))}
+                          <button
+                            type="button"
+                            className={`export-chip${useCustomResolution ? ' is-active' : ''}`}
+                            onClick={() => setUseCustomResolution(true)}
+                          >
+                            Custom
+                          </button>
+                        </div>
+                        {useCustomResolution && (
+                          <div className="export-inline-inputs">
+                            <input
+                              type="number"
+                              value={customWidth}
+                              onChange={(e) => setCustomWidth(Math.max(1, parseInt(e.target.value) || 1920))}
+                              placeholder="Width"
+                              min="1"
+                              max="7680"
+                            />
+                            <span>x</span>
+                            <input
+                              type="number"
+                              value={customHeight}
+                              onChange={(e) => setCustomHeight(Math.max(1, parseInt(e.target.value) || 1080))}
+                              placeholder="Height"
+                              min="1"
+                              max="4320"
+                            />
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="export-field-card">
+                        <div className="export-field-head">
+                          <span>Frame Rate</span>
+                          <strong>{actualFps} fps</strong>
+                        </div>
+                        <div className="export-chip-row">
+                          {quickFrameRatePresets.map((presetFps) => (
+                            <button
+                              key={presetFps}
+                              type="button"
+                              className={`export-chip${!useCustomFps && fps === presetFps ? ' is-active' : ''}`}
+                              onClick={() => handleQuickFpsPreset(presetFps)}
+                            >
+                              {presetFps} fps
+                            </button>
+                          ))}
+                          <button
+                            type="button"
+                            className={`export-chip${useCustomFps ? ' is-active' : ''}`}
+                            onClick={() => setUseCustomFps(true)}
+                          >
+                            Custom
+                          </button>
+                        </div>
+                        {useCustomFps && (
+                          <div className="export-inline-inputs export-inline-inputs-single">
+                            <input
+                              type="number"
+                              value={customFps}
+                              onChange={(e) => setCustomFps(Math.max(1, Math.min(240, parseFloat(e.target.value) || 30)))}
+                              min={1}
+                              max={240}
+                              step={0.001}
+                            />
+                          </div>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="export-field-card">
+                      <div className="export-field-head">
+                        <span>{isWebCodecsEncoder ? 'Delivery Preset' : 'FFmpeg Workflow'}</span>
+                        <strong>{isWebCodecsEncoder ? `${(bitrate / 1_000_000).toFixed(1)} Mbps` : (ffmpegPreset || 'Custom')}</strong>
+                      </div>
+                      <div className="export-preset-grid">
+                        {isWebCodecsEncoder ? (
+                          webQualityPresets.map((preset) => (
+                            <button
+                              key={preset.id}
+                              type="button"
+                              className={`export-preset-card${rateControl === 'vbr' && bitrate === preset.value ? ' is-active' : ''}`}
+                              onClick={() => handleQuickBitratePreset(preset.value)}
+                            >
+                              <strong>{preset.label}</strong>
+                              <span>{preset.detail}</span>
+                            </button>
+                          ))
+                        ) : (
+                          ffmpegWorkflowPresets.map((preset) => (
+                            <button
+                              key={preset.id}
+                              type="button"
+                              className={`export-preset-card${ffmpegPreset === preset.id ? ' is-active' : ''}`}
+                              onClick={() => applyFFmpegPreset(preset.id)}
+                            >
+                              <strong>{preset.label}</strong>
+                              <span>{preset.detail}</span>
+                            </button>
+                          ))
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="export-field-card export-subcard">
+                      <div className="export-field-head">
+                        <span>Codec & Quality</span>
+                        <strong>{currentCodecLabel}</strong>
+                      </div>
+
+                      {encoder === 'ffmpeg' && (
+                        <div className="control-row">
+                          <label>Preset</label>
+                          <select value={ffmpegPreset} onChange={(e) => applyFFmpegPreset(e.target.value)}>
+                            <option value="">Custom</option>
+                            <optgroup label="Professional NLEs">
+                              <option value="premiere">Adobe Premiere</option>
+                              <option value="finalcut">Final Cut Pro</option>
+                              <option value="davinci">DaVinci Resolve</option>
+                              <option value="avid">Avid Media Composer</option>
+                            </optgroup>
+                            <optgroup label="ProRes Quality">
+                              <option value="prores_proxy">ProRes Proxy</option>
+                              <option value="prores_lt">ProRes LT</option>
+                              <option value="prores_hq">ProRes HQ</option>
+                              <option value="prores_4444">ProRes 4444 (Alpha)</option>
+                            </optgroup>
+                            <optgroup label="Lossless / Archive">
+                              <option value="archive">Archive (FFV1)</option>
+                              <option value="utvideo_alpha">UTVideo (Alpha)</option>
+                            </optgroup>
+                            <optgroup label="Quick Export">
+                              <option value="mjpeg_preview">MJPEG Preview</option>
+                            </optgroup>
+                          </select>
+                        </div>
+                      )}
+
+                      <div className="control-row">
+                        <label>Codec</label>
+                        {isWebCodecsEncoder ? (
+                          <select
+                            value={videoCodec}
+                            onChange={(e) => setVideoCodec(e.target.value as VideoCodec)}
+                          >
+                            {FrameExporter.getVideoCodecs(containerFormat).map(({ id, label }) => (
+                              <option key={id} value={id} disabled={!codecSupport[id]}>
+                                {label} {!codecSupport[id] ? '(not supported)' : ''}
+                              </option>
+                            ))}
+                          </select>
+                        ) : (
+                          <CodecSelector
+                            container={ffmpegContainer}
+                            value={ffmpegCodec}
+                            onChange={handleFFmpegCodecChange}
+                          />
+                        )}
+                      </div>
+
+                      {encoder === 'ffmpeg' && ffmpegCodecInfo && (
+                        <div className="export-inline-note">
+                          {ffmpegCodecInfo.description}
+                          {ffmpegCodecInfo.supportsAlpha && ' | Alpha'}
+                          {ffmpegCodecInfo.supports10bit && ' | 10-bit'}
+                        </div>
+                      )}
+
+                      {encoder === 'ffmpeg' && ffmpegCodec === 'prores' && (
+                        <div className="control-row">
+                          <label>Profile</label>
+                          <select
+                            value={proresProfile}
+                            onChange={(e) => setProresProfile(e.target.value as ProResProfile)}
+                          >
+                            {PRORES_PROFILES.map((p) => (
+                              <option key={p.id} value={p.id}>
+                                {p.name} - {p.description}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      )}
+
+                      {encoder === 'ffmpeg' && ffmpegCodec === 'dnxhd' && (
+                        <div className="control-row">
+                          <label>Profile</label>
+                          <select
+                            value={dnxhrProfile}
+                            onChange={(e) => setDnxhrProfile(e.target.value as DnxhrProfile)}
+                          >
+                            {DNXHR_PROFILES.map((p) => (
+                              <option key={p.id} value={p.id}>
+                                {p.name} - {p.description}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      )}
+
+                      {isWebCodecsEncoder ? (
+                        <>
+                          <div className="control-row">
+                            <label>Rate Control</label>
+                            <select
+                              value={rateControl}
+                              onChange={(e) => setRateControl(e.target.value as 'vbr' | 'cbr')}
+                            >
+                              <option value="vbr">VBR (Variable Bitrate)</option>
+                              <option value="cbr">CBR (Constant Bitrate)</option>
+                            </select>
+                          </div>
+
+                          <div className="control-row">
+                            <label>{rateControl === 'cbr' ? 'Bitrate' : 'Target Bitrate'}</label>
+                            <select
+                              value={bitrate}
+                              onChange={(e) => setBitrate(Number(e.target.value))}
+                            >
+                              <option value={5_000_000}>5 Mbps (Low)</option>
+                              <option value={10_000_000}>10 Mbps (Medium)</option>
+                              <option value={15_000_000}>15 Mbps (High)</option>
+                              <option value={20_000_000}>20 Mbps</option>
+                              <option value={25_000_000}>25 Mbps (Very High)</option>
+                              <option value={35_000_000}>35 Mbps</option>
+                              <option value={50_000_000}>50 Mbps (Max)</option>
+                            </select>
+                          </div>
+
+                          <div className="control-row">
+                            <label>Fine Tune</label>
+                            <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flex: 1 }}>
+                              <input
+                                type="range"
+                                min={1_000_000}
+                                max={100_000_000}
+                                step={500_000}
+                                value={bitrate}
+                                onChange={(e) => setBitrate(Number(e.target.value))}
+                                style={{ flex: 1 }}
+                              />
+                              <span style={{ minWidth: '70px', fontSize: '12px', textAlign: 'right' }}>
+                                {(bitrate / 1_000_000).toFixed(1)} Mbps
+                              </span>
+                            </div>
+                          </div>
+                        </>
+                      ) : showFFmpegQualityControl && (
+                        <div className="control-row">
+                          <label>Quality</label>
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flex: 1 }}>
+                            <input
+                              type="range"
+                              min={1}
+                              max={31}
+                              value={ffmpegQuality}
+                              onChange={(e) => setFfmpegQuality(parseInt(e.target.value))}
+                              style={{ flex: 1 }}
+                            />
+                            <span style={{ minWidth: '60px', textAlign: 'right', fontSize: '12px' }}>
+                              {ffmpegQuality} {ffmpegQuality <= 5 ? '(High)' : ffmpegQuality <= 10 ? '(Good)' : ffmpegQuality <= 20 ? '(Med)' : '(Low)'}
+                            </span>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="export-field-card export-subcard">
+                      <div className="export-field-head">
+                        <span>Alpha</span>
+                        <strong>{stackedAlpha ? 'Stacked' : 'Off'}</strong>
+                      </div>
+                      <div className="export-chip-row">
+                        <button
+                          type="button"
+                          className={`export-toggle${stackedAlpha ? ' is-active' : ''}`}
+                          onClick={() => setStackedAlpha(!stackedAlpha)}
+                          disabled={!isWebCodecsEncoder}
+                        >
+                          Stacked Alpha
+                        </button>
+                        {showRangeInVideo && (
+                          <button
+                            type="button"
+                            className={`export-toggle${useInOut ? ' is-active' : ''}`}
+                            onClick={() => setUseInOut(!useInOut)}
+                          >
+                            Use In/Out
+                          </button>
+                        )}
+                      </div>
+                      {stackedAlpha && (
+                        <div className="export-inline-note export-inline-note-warning">
+                          Output becomes {actualWidth}x{actualHeight * 2}. Top half is RGB, bottom half is alpha as grayscale.
+                        </div>
+                      )}
+                      {showRangeInVideo && (
+                        <div className="export-stats-grid export-stats-grid-compact">
+                          <div className="export-stat-card">
+                            <span>Output</span>
+                            <strong>{actualWidth}x{outputHeight}</strong>
+                          </div>
+                          <div className="export-stat-card">
+                            <span>Frames</span>
+                            <strong>{frameCount}</strong>
+                          </div>
+                          <div className="export-stat-card">
+                            <span>Est. Size</span>
+                            <strong>{estimatedSizeLabel}</strong>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </>
+                ) : (
+                  <div className="export-inline-note">
+                    Video export is disabled. The primary action switches to audio export when audio is enabled.
+                  </div>
+                )}
+              </div>
+
+              <div className={`export-channel-card${includeAudio ? '' : ' is-disabled'}`}>
+                <div className="export-channel-head">
+                  <div className="export-channel-title">
+                    <span>Audio</span>
+                    <strong>{includeAudio ? `${audioSampleRate / 1000} kHz` : 'Disabled'}</strong>
+                  </div>
+                  <button
+                    type="button"
+                    className={`export-toggle${includeAudio ? ' is-active' : ''}`}
+                    onClick={() => setIncludeAudio(!includeAudio)}
+                    disabled={isWebCodecsEncoder && !isAudioSupported}
+                  >
+                    {includeAudio ? 'On' : 'Off'}
+                  </button>
+                </div>
+
+                {includeAudio ? (
+                  <>
+                    {showSharedFileInAudio && (
+                      <div className="export-field-card export-subcard">
+                        <div className="export-field-head">
+                          <span>Output</span>
+                          <strong>.{audioExtension}</strong>
+                        </div>
+                        <div className="control-row">
+                          <label>Name</label>
+                          <div className="export-input-group">
+                            <input
+                              type="text"
+                              value={filename}
+                              onChange={(e) => setFilename(e.target.value)}
+                              placeholder="export"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    <div className="export-chip-row">
+                      {audioSummaryBadges.map((badge) => (
+                        <span key={badge} className="export-chip export-chip-static">{badge}</span>
+                      ))}
+                    </div>
+
+                    <div className="export-field-card export-subcard">
+                      <div className="export-field-head">
+                        <span>Format</span>
+                        <strong>{audioCodecLabel}</strong>
+                      </div>
+                      <div className="export-audio-grid">
+                        <div className="control-row">
+                          <label>Sample Rate</label>
+                          <select
+                            value={audioSampleRate}
+                            onChange={(e) => setAudioSampleRate(Number(e.target.value) as 44100 | 48000)}
+                          >
+                            <option value={48000}>48 kHz (Video)</option>
+                            <option value={44100}>44.1 kHz (CD)</option>
+                          </select>
+                        </div>
+
+                        <div className="control-row">
+                          <label>Quality</label>
+                          <select
+                            value={audioBitrate}
+                            onChange={(e) => setAudioBitrate(Number(e.target.value))}
+                          >
+                            <option value={128000}>128 kbps</option>
+                            <option value={192000}>192 kbps</option>
+                            <option value={256000}>256 kbps (High)</option>
+                            <option value={320000}>320 kbps (Max)</option>
+                          </select>
+                        </div>
+
+                        {encoder === 'ffmpeg' && (
+                          <div className="control-row">
+                            <label>Audio Codec</label>
+                            <span style={{ fontSize: '11px', color: 'var(--text-secondary)' }}>
+                              {ffmpegContainer === 'mov' ? 'AAC' :
+                               ffmpegContainer === 'mkv' ? 'FLAC' :
+                               ffmpegContainer === 'avi' ? 'PCM' :
+                               ffmpegContainer === 'mxf' ? 'PCM' : 'AAC'} (auto)
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="export-field-card export-subcard">
+                      <div className="export-field-head">
+                        <span>Processing</span>
+                        <strong>{normalizeAudio ? 'Normalized' : 'Direct'}</strong>
+                      </div>
+                      <div className="export-chip-row">
+                        <button
+                          type="button"
+                          className={`export-toggle${normalizeAudio ? ' is-active' : ''}`}
+                          onClick={() => setNormalizeAudio(!normalizeAudio)}
+                        >
+                          Normalize
+                        </button>
+                        {showRangeInAudio && (
+                          <button
+                            type="button"
+                            className={`export-toggle${useInOut ? ' is-active' : ''}`}
+                            onClick={() => setUseInOut(!useInOut)}
+                          >
+                            Use In/Out
+                          </button>
+                        )}
+                      </div>
+
+                      {isWebCodecsEncoder && !isAudioSupported && (
+                        <div className="export-inline-note export-inline-note-warning">
+                          Browser audio encoding is not available here. Video export still works.
+                        </div>
+                      )}
+
+                      {showRangeInAudio && (
+                        <div className="export-stats-grid export-stats-grid-compact">
+                          <div className="export-stat-card">
+                            <span>Output</span>
+                            <strong>{audioCodecLabel} only</strong>
+                          </div>
+                          <div className="export-stat-card">
+                            <span>Duration</span>
+                            <strong>{formatTime(endTime - startTime)}</strong>
+                          </div>
+                          <div className="export-stat-card">
+                            <span>Est. Size</span>
+                            <strong>{estimatedSizeLabel}</strong>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </>
+                ) : (
+                  <div className="export-inline-note">
+                    Audio export is disabled. The video export stays silent unless you turn audio back on.
+                  </div>
+                )}
+              </div>
+            </div>
+
+          </div>
+
           {/* Video Settings */}
-          <div className="export-section">
-            <div className="export-section-header">Video</div>
+          <div className="export-section export-advanced-section">
+            <div className="export-section-header">Advanced Video</div>
 
             {/* Filename */}
             <div className="control-row">
@@ -747,9 +1531,9 @@ export function ExportPanel() {
                 />
                 <select
                   className="export-extension-select"
-                  value={(encoder === 'webcodecs' || encoder === 'htmlvideo') ? containerFormat : ffmpegContainer}
+                  value={currentContainerId}
                   onChange={(e) => {
-                    if (encoder === 'webcodecs' || encoder === 'htmlvideo') {
+                    if (isWebCodecsEncoder) {
                       setContainerFormat(e.target.value as ContainerFormat);
                     } else {
                       handleFFmpegContainerChange(e.target.value as FFmpegContainer);
@@ -826,8 +1610,8 @@ export function ExportPanel() {
             {encoder === 'ffmpeg' && ffmpegCodecInfo && (
               <div style={{ fontSize: '11px', color: 'var(--text-secondary)', marginTop: '-4px', marginBottom: '8px', paddingLeft: '4px' }}>
                 {ffmpegCodecInfo.description}
-                {ffmpegCodecInfo.supportsAlpha && ' • Alpha'}
-                {ffmpegCodecInfo.supports10bit && ' • 10-bit'}
+                {ffmpegCodecInfo.supportsAlpha && ' | Alpha'}
+                {ffmpegCodecInfo.supports10bit && ' | 10-bit'}
               </div>
             )}
 
@@ -1046,8 +1830,8 @@ export function ExportPanel() {
           </div>
 
           {/* Audio Settings */}
-          <div className="export-section">
-            <div className="export-section-header">Audio</div>
+          <div className="export-section export-advanced-section">
+            <div className="export-section-header">Advanced Audio</div>
 
             <div className="control-row">
               <label>
@@ -1120,8 +1904,8 @@ export function ExportPanel() {
 
           {/* Alpha Settings */}
           {(encoder === 'webcodecs' || encoder === 'htmlvideo') && (
-            <div className="export-section">
-              <div className="export-section-header">Alpha</div>
+            <div className="export-section export-advanced-section">
+              <div className="export-section-header">Advanced Alpha</div>
 
               <div className="control-row">
                 <label>
@@ -1152,8 +1936,8 @@ export function ExportPanel() {
           )}
 
           {/* Range Settings */}
-          <div className="export-section">
-            <div className="export-section-header">Range</div>
+          <div className="export-section export-advanced-section">
+            <div className="export-section-header">Range & Summary</div>
 
             <div className="control-row">
               <label>

--- a/src/components/export/ExportPanel.tsx
+++ b/src/components/export/ExportPanel.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useState } from 'react';
 import { Logger } from '../../services/logger';
 import { downloadFCPXML } from '../../services/export/fcpxmlExport';
+import { projectFileService } from '../../services/projectFileService';
 
 const log = Logger.create('ExportPanel');
 import { FrameExporter, downloadBlob } from '../../engine/export';
@@ -18,22 +19,123 @@ import {
   DNXHR_PROFILES,
   CONTAINER_FORMATS,
   getCodecInfo,
+  getCodecsForContainer,
 } from '../../engine/ffmpeg';
 import { CodecSelector } from './CodecSelector';
 import type {
   FFmpegExportSettings,
   FFmpegProgress,
   FFmpegContainer,
+  FFmpegVideoCodec,
   ProResProfile,
   DnxhrProfile,
 } from '../../engine/ffmpeg';
 import { FFmpegFrameRenderer } from './exportHelpers';
 import { useExportState, type EncoderType } from './useExportState';
+import {
+  useExportStore,
+  type ExportImageFormat as ImageFormat,
+} from '../../stores/exportStore';
+
+type ExportSummaryTarget =
+  | 'command-bar'
+  | 'basic-output'
+  | 'basic-container'
+  | 'basic-workflow'
+  | 'video-section'
+  | 'video-resolution'
+  | 'video-fps'
+  | 'video-rate'
+  | 'video-codec'
+  | 'video-alpha'
+  | 'image-section'
+  | 'image-resolution'
+  | 'image-quality'
+  | 'audio-section'
+  | 'audio-format'
+  | 'audio-quality'
+  | 'audio-processing';
+
+type ExportSummaryBadge = {
+  label: string;
+  target: ExportSummaryTarget;
+  warning?: boolean;
+};
+
+const IMAGE_FORMATS: Array<{
+  id: ImageFormat;
+  label: string;
+  mimeType: string;
+  supportsAlpha: boolean;
+  lossless: boolean;
+}> = [
+  { id: 'png', label: 'PNG', mimeType: 'image/png', supportsAlpha: true, lossless: true },
+  { id: 'jpg', label: 'JPG', mimeType: 'image/jpeg', supportsAlpha: false, lossless: false },
+  { id: 'webp', label: 'WebP', mimeType: 'image/webp', supportsAlpha: true, lossless: false },
+  { id: 'bmp', label: 'BMP', mimeType: 'image/bmp', supportsAlpha: false, lossless: true },
+];
+
+const IMAGE_QUALITY_PRESETS = [
+  { id: 'draft', label: 'Draft', value: 0.72 },
+  { id: 'standard', label: 'Standard', value: 0.85 },
+  { id: 'high', label: 'High', value: 0.92 },
+  { id: 'max', label: 'Max', value: 1 },
+] as const;
+
+function canvasToBlob(canvas: HTMLCanvasElement, type: string, quality?: number): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob);
+        return;
+      }
+      reject(new Error(`Failed to export ${type}`));
+    }, type, quality);
+  });
+}
+
+function encodeBmp(imageData: ImageData): Blob {
+  const { width, height, data } = imageData;
+  const rowStride = width * 3;
+  const rowPadding = (4 - (rowStride % 4)) % 4;
+  const paddedRowStride = rowStride + rowPadding;
+  const pixelArraySize = paddedRowStride * height;
+  const fileSize = 54 + pixelArraySize;
+  const buffer = new ArrayBuffer(fileSize);
+  const view = new DataView(buffer);
+
+  view.setUint8(0, 0x42);
+  view.setUint8(1, 0x4d);
+  view.setUint32(2, fileSize, true);
+  view.setUint32(10, 54, true);
+  view.setUint32(14, 40, true);
+  view.setInt32(18, width, true);
+  view.setInt32(22, height, true);
+  view.setUint16(26, 1, true);
+  view.setUint16(28, 24, true);
+  view.setUint32(34, pixelArraySize, true);
+  view.setInt32(38, 2835, true);
+  view.setInt32(42, 2835, true);
+
+  let offset = 54;
+  for (let y = height - 1; y >= 0; y--) {
+    for (let x = 0; x < width; x++) {
+      const pixelOffset = (y * width + x) * 4;
+      view.setUint8(offset++, data[pixelOffset + 2]);
+      view.setUint8(offset++, data[pixelOffset + 1]);
+      view.setUint8(offset++, data[pixelOffset]);
+    }
+    offset += rowPadding;
+  }
+
+  return new Blob([buffer], { type: 'image/bmp' });
+}
 
 export function ExportPanel() {
   const ffmpegFrameRendererRef = useRef<FFmpegFrameRenderer | null>(null);
   const ffmpegAudioPipelineRef = useRef<AudioExportPipeline | null>(null);
-  const [videoEnabled, setVideoEnabled] = useState(true);
+  const summaryHighlightTimeoutsRef = useRef<Map<HTMLElement, number>>(new Map());
+  const [setupStatus, setSetupStatus] = useState<string | null>(null);
   const { duration, inPoint, outPoint, playheadPosition, startExport, setExportProgress, endExport } = useTimelineStore(useShallow(s => ({
     duration: s.duration,
     inPoint: s.inPoint,
@@ -47,6 +149,21 @@ export function ExportPanel() {
     getActiveComposition: s.getActiveComposition,
   })));
   const composition = getActiveComposition();
+  const {
+    presets,
+    selectedPresetId,
+    setSelectedPresetId,
+    savePreset,
+    updatePreset,
+    loadPreset,
+  } = useExportStore(useShallow((state) => ({
+    presets: state.presets,
+    selectedPresetId: state.selectedPresetId,
+    setSelectedPresetId: state.setSelectedPresetId,
+    savePreset: state.savePreset,
+    updatePreset: state.updatePreset,
+    loadPreset: state.loadPreset,
+  })));
 
   // All export state, effects, and simple handlers extracted to hook
   const {
@@ -58,19 +175,24 @@ export function ExportPanel() {
     useInOut, setUseInOut, filename, setFilename,
     bitrate, setBitrate, containerFormat, setContainerFormat,
     videoCodec, setVideoCodec, codecSupport, rateControl, setRateControl,
-    ffmpegCodec, ffmpegContainer, ffmpegPreset,
+    ffmpegCodec, ffmpegContainer,
     proresProfile, setProresProfile, dnxhrProfile, setDnxhrProfile,
     ffmpegQuality, setFfmpegQuality, ffmpegBitrate, ffmpegRateControl,
     isFFmpegLoading, isFFmpegReady, ffmpegLoadError,
     stackedAlpha, setStackedAlpha,
     includeAudio, setIncludeAudio, audioSampleRate, setAudioSampleRate,
     audioBitrate, setAudioBitrate, normalizeAudio, setNormalizeAudio,
+    videoEnabled, setVideoEnabled,
+    visualMode, setVisualMode,
+    imageFormat, setImageFormat,
+    imageQuality, setImageQuality,
+    specialContainer, setSpecialContainer,
     isExporting, setIsExporting, progress, setProgress,
     ffmpegProgress, setFfmpegProgress, exportPhase, setExportPhase,
     error, setError, exporter, setExporter,
     isSupported, isAudioSupported, audioCodec,
     isFFmpegSupported, isFFmpegMultiThreaded,
-    handleResolutionChange, loadFFmpeg, applyFFmpegPreset,
+    handleResolutionChange, loadFFmpeg,
     handleFFmpegContainerChange, handleFFmpegCodecChange,
   } = useExportState(composition);
 
@@ -101,6 +223,7 @@ export function ExportPanel() {
       codec: videoCodec,
       container: containerFormat,
       bitrate,
+      rateControl,
       startTime,
       endTime,
       // Alpha
@@ -137,7 +260,37 @@ export function ExportPanel() {
       // End export progress in timeline
       endExport();
     }
-  }, [width, height, customWidth, customHeight, useCustomResolution, fps, customFps, useCustomFps, bitrate, startTime, endTime, filename, isExporting, includeAudio, audioSampleRate, audioBitrate, normalizeAudio, containerFormat, videoCodec]);
+  }, [
+    audioBitrate,
+    audioSampleRate,
+    bitrate,
+    containerFormat,
+    customFps,
+    customHeight,
+    customWidth,
+    encoder,
+    endExport,
+    filename,
+    fps,
+    includeAudio,
+    isExporting,
+    normalizeAudio,
+    rateControl,
+    setError,
+    setExportProgress,
+    setExporter,
+    setIsExporting,
+    setProgress,
+    stackedAlpha,
+    startExport,
+    startTime,
+    endTime,
+    useCustomFps,
+    useCustomResolution,
+    videoCodec,
+    width,
+    height,
+  ]);
 
   // Handle cancel
   const handleCancel = useCallback(() => {
@@ -509,66 +662,74 @@ export function ExportPanel() {
 
   // Handle render current frame
   const handleRenderFrame = useCallback(async () => {
+    if (isExporting) {
+      return;
+    }
+
+    const actualWidth = useCustomResolution ? customWidth : width;
+    const actualHeight = useCustomResolution ? customHeight : height;
+    const exportTime = playheadPosition;
+    const exportFps = useCustomFps ? customFps : fps;
+    const selectedImageFormat = IMAGE_FORMATS.find(({ id }) => id === imageFormat) ?? IMAGE_FORMATS[0];
+    const originalDimensions = engine.getOutputDimensions();
+    const frameRenderer = new FFmpegFrameRenderer({
+      width: actualWidth,
+      height: actualHeight,
+      fps: exportFps,
+      startTime: exportTime,
+      endTime: exportTime + (1 / Math.max(exportFps, 1)),
+    });
+
     try {
-      // Read pixels from the engine's composited frame
+      await frameRenderer.initialize();
+      engine.setExporting(true);
+      engine.setResolution(actualWidth, actualHeight);
+      engine.setRenderTimeOverride(exportTime);
+
+      const layers = await frameRenderer.buildLayersAtTime(exportTime);
+      await engine.ensureExportLayersReady(layers);
+      engine.render(layers);
+
       const pixels = await engine.readPixels();
       if (!pixels) {
         setError('Failed to read frame from GPU');
         return;
       }
 
-      // Get the engine's output dimensions (this is what was actually rendered)
-      const { width: engineWidth, height: engineHeight } = engine.getOutputDimensions();
-
-      // Create ImageData from the pixels
-      const imageData = new ImageData(new Uint8ClampedArray(pixels), engineWidth, engineHeight);
-
-      // Create a canvas to draw the image
+      const imageData = new ImageData(new Uint8ClampedArray(pixels), actualWidth, actualHeight);
       const canvas = document.createElement('canvas');
-      canvas.width = engineWidth;
-      canvas.height = engineHeight;
+      canvas.width = actualWidth;
+      canvas.height = actualHeight;
       const ctx = canvas.getContext('2d');
       if (!ctx) {
         setError('Failed to create canvas context');
         return;
       }
 
-      // Draw the image data
       ctx.putImageData(imageData, 0, 0);
-
-      // If custom resolution is different, scale to target size
-      const actualWidth = useCustomResolution ? customWidth : width;
-      const actualHeight = useCustomResolution ? customHeight : height;
-
-      if (actualWidth !== engineWidth || actualHeight !== engineHeight) {
-        // Create a scaled canvas
-        const scaledCanvas = document.createElement('canvas');
-        scaledCanvas.width = actualWidth;
-        scaledCanvas.height = actualHeight;
-        const scaledCtx = scaledCanvas.getContext('2d');
-        if (scaledCtx) {
-          scaledCtx.drawImage(canvas, 0, 0, actualWidth, actualHeight);
-          scaledCanvas.toBlob((blob) => {
-            if (blob) {
-              const frameName = `${filename}_frame_${Math.floor(playheadPosition * 1000)}.png`;
-              downloadBlob(blob, frameName);
-            }
-          }, 'image/png');
-        }
-      } else {
-        // Export at native resolution
-        canvas.toBlob((blob) => {
-          if (blob) {
-            const frameName = `${filename}_frame_${Math.floor(playheadPosition * 1000)}.png`;
-            downloadBlob(blob, frameName);
-          }
-        }, 'image/png');
-      }
+      const blob = imageFormat === 'bmp'
+        ? encodeBmp(imageData)
+        : await canvasToBlob(
+            canvas,
+            selectedImageFormat.mimeType,
+            selectedImageFormat.lossless ? undefined : imageQuality,
+          );
+      const frameName = `${filename}_frame_${Math.floor(playheadPosition * 1000)}.${imageFormat}`;
+      downloadBlob(blob, frameName);
     } catch (e) {
       log.error('Frame render failed', e);
       setError(e instanceof Error ? e.message : 'Frame render failed');
+    } finally {
+      frameRenderer.cleanup();
+      engine.setRenderTimeOverride(null);
+      engine.setExporting(false);
+      engine.setResolution(originalDimensions.width, originalDimensions.height);
     }
-  }, [width, height, customWidth, customHeight, useCustomResolution, filename, playheadPosition]);
+  }, [
+    width, height, customWidth, customHeight, useCustomResolution,
+    fps, customFps, useCustomFps,
+    filename, playheadPosition, imageFormat, imageQuality, isExporting,
+  ]);
 
   // Format time as MM:SS.ff
   const formatTime = (seconds: number) => {
@@ -622,10 +783,13 @@ export function ExportPanel() {
   // Only MJPEG has quality slider (q:v), professional codecs use profiles
   const showFFmpegQualityControl = ffmpegCodec === 'mjpeg';
   const isWebCodecsEncoder = encoder === 'webcodecs' || encoder === 'htmlvideo';
-  const currentContainerId = isWebCodecsEncoder ? containerFormat : ffmpegContainer;
-  const currentContainerLabel = isWebCodecsEncoder
-    ? FrameExporter.getContainerFormats().find(({ id }) => id === containerFormat)?.label ?? containerFormat.toUpperCase()
-    : CONTAINER_FORMATS.find(({ id }) => id === ffmpegContainer)?.name ?? ffmpegContainer.toUpperCase();
+  const isXmlMode = specialContainer === 'xml';
+  const currentContainerId = isXmlMode ? 'fcpxml' : (isWebCodecsEncoder ? containerFormat : ffmpegContainer);
+  const currentContainerLabel = isXmlMode
+    ? 'FCPXML'
+    : isWebCodecsEncoder
+      ? FrameExporter.getContainerFormats().find(({ id }) => id === containerFormat)?.label ?? containerFormat.toUpperCase()
+      : CONTAINER_FORMATS.find(({ id }) => id === ffmpegContainer)?.name ?? ffmpegContainer.toUpperCase();
   const currentCodecLabel = isWebCodecsEncoder
     ? FrameExporter.getVideoCodecs(containerFormat).find(({ id }) => id === videoCodec)?.label ?? videoCodec.toUpperCase()
     : ffmpegCodecInfo?.name ?? ffmpegCodec.toUpperCase();
@@ -646,51 +810,124 @@ export function ExportPanel() {
           badge: isFFmpegMultiThreaded ? 'Intermediate' : 'CPU',
           description: 'Professional intermediates and edit-friendly interchange formats.',
         };
+  const ffmpegAudioCodecLabel = ffmpegContainer === 'mov'
+    ? 'AAC'
+    : ffmpegContainer === 'mkv'
+      ? 'FLAC'
+      : ffmpegContainer === 'avi'
+        ? 'PCM'
+        : ffmpegContainer === 'mxf'
+          ? 'PCM'
+          : 'AAC';
+  const isImageMode = !isXmlMode && videoEnabled && visualMode === 'image';
+  const isVideoMode = !isXmlMode && videoEnabled && visualMode === 'video';
+  const isAudioOnlyMode = !isXmlMode && !videoEnabled;
+  const effectiveIncludeAudio = (isVideoMode || isXmlMode) && includeAudio;
+  const selectedImageFormat = IMAGE_FORMATS.find(({ id }) => id === imageFormat) ?? IMAGE_FORMATS[0];
   const audioExtension = audioCodec === 'opus' ? 'ogg' : 'aac';
   const audioCodecLabel = audioCodec?.toUpperCase() ?? 'AAC';
-  const outputHeight = stackedAlpha ? actualHeight * 2 : actualHeight;
-  const frameCount = Math.ceil((endTime - startTime) * actualFps);
-  const estimatedSizeLabel = (!videoEnabled && !includeAudio) ? '-' : estimatedSize();
-  const exportModeLabel = videoEnabled
-    ? (includeAudio ? 'Video + Audio' : 'Video Only')
-    : (includeAudio ? 'Audio Only' : 'Nothing Selected');
+  const currentAudioCodecLabel = isVideoMode && encoder === 'ffmpeg'
+    ? ffmpegAudioCodecLabel
+    : audioCodecLabel;
+  const outputHeight = stackedAlpha && isVideoMode ? actualHeight * 2 : actualHeight;
+  const frameCount = isVideoMode ? Math.ceil((endTime - startTime) * actualFps) : 1;
+  const displayExtension = isXmlMode ? 'fcpxml' : isAudioOnlyMode ? audioExtension : isImageMode ? imageFormat : currentContainerId;
+  const estimatedSizeLabel = isXmlMode ? 'Metadata only' : isImageMode ? 'Current frame' : (!videoEnabled && !includeAudio) ? '-' : estimatedSize();
+  const sizeLabelPrefix = isVideoMode && isWebCodecsEncoder ? 'Target' : 'Size';
+  const sizeStatLabel = isVideoMode && isWebCodecsEncoder ? 'Target Size' : 'Est. Size';
+  const webCodecsRateNote = rateControl === 'vbr'
+    ? 'VBR is only a bitrate target. Simple shots can encode much smaller than the selected Mbps.'
+    : 'CBR tries to stay closer, but browser encoders can still drift from the requested bitrate.';
+  const exportModeLabel = isXmlMode
+    ? 'Timeline XML'
+    : isImageMode
+    ? 'Image'
+    : isVideoMode
+      ? (effectiveIncludeAudio ? 'Video + Audio' : 'Video Only')
+      : (includeAudio ? 'Audio Only' : 'Nothing Selected');
   const exportDisabled =
     isExporting ||
-    endTime <= startTime ||
-    !videoEnabled && !includeAudio ||
-    (videoEnabled && encoder === 'ffmpeg' && isFFmpegLoading);
-  const primaryExportLabel = videoEnabled ? 'Export Video' : includeAudio ? 'Export Audio' : 'Select Video or Audio';
-  const videoSummaryBadges = [
-    currentContainerLabel,
-    currentCodecLabel,
-    `${actualWidth}x${outputHeight}`,
-    `${actualFps} fps`,
-    encoder === 'ffmpeg'
-      ? (ffmpegPreset ? `Preset: ${ffmpegPreset}` : currentCodecLabel)
-      : `${(bitrate / 1_000_000).toFixed(1)} Mbps`,
-  ];
-  const audioSummaryBadges = includeAudio
+    (!isImageMode && !isXmlMode && endTime <= startTime) ||
+    isAudioOnlyMode && (!includeAudio || !isAudioSupported) ||
+    (isVideoMode && encoder === 'ffmpeg' && isFFmpegLoading);
+  const primaryExportLabel = 'Export';
+  const audioSummaryBadges = (effectiveIncludeAudio || isAudioOnlyMode && includeAudio)
     ? [
-        audioCodecLabel,
-        `${audioSampleRate / 1000} kHz`,
-        `${Math.round(audioBitrate / 1000)} kbps`,
-        normalizeAudio ? 'Normalized' : 'Unprocessed',
+        { label: currentAudioCodecLabel, target: 'audio-format' as const },
+        { label: `${audioSampleRate / 1000} kHz`, target: 'audio-format' as const },
+        { label: `${Math.round(audioBitrate / 1000)} kbps`, target: 'audio-quality' as const },
+        { label: normalizeAudio ? 'Normalized' : 'Unprocessed', target: 'audio-processing' as const },
       ]
     : [];
-  const summaryBadges = [
-    exportModeLabel,
-    videoEnabled ? methodMeta.title : `Audio ${audioCodecLabel}`,
-    ...(videoEnabled ? videoSummaryBadges : []),
-    ...audioSummaryBadges,
-    `Range ${formatTime(startTime)} - ${formatTime(endTime)}`,
-    `Duration ${formatTime(endTime - startTime)}`,
-    stackedAlpha && videoEnabled ? 'Stacked alpha' : null,
-    `Size ${estimatedSizeLabel}`,
-  ].filter(Boolean) as string[];
-  const showSharedFileInVideo = videoEnabled;
-  const showSharedFileInAudio = !videoEnabled && includeAudio;
-  const showRangeInVideo = videoEnabled;
-  const showRangeInAudio = !videoEnabled && includeAudio;
+  const summaryBadges: ExportSummaryBadge[] = isXmlMode
+    ? [
+        { label: exportModeLabel, target: 'basic-container' },
+        { label: currentContainerLabel, target: 'basic-container' },
+        { label: `${composition?.width ?? actualWidth}x${composition?.height ?? actualHeight}`, target: 'basic-output' },
+        { label: `${composition?.frameRate ?? actualFps} fps`, target: 'basic-output' },
+        { label: includeAudio ? 'With audio refs' : 'No audio refs', target: 'audio-section' },
+      ]
+    : isImageMode
+    ? [
+        { label: exportModeLabel, target: 'image-section' },
+        { label: selectedImageFormat.label, target: 'basic-container' },
+        { label: `${actualWidth}x${actualHeight}`, target: 'image-resolution' },
+        { label: `Frame ${formatTime(playheadPosition)}`, target: 'image-section' },
+        {
+          label: selectedImageFormat.lossless ? 'Lossless' : `${Math.round(imageQuality * 100)}% quality`,
+          target: 'image-quality',
+        },
+        {
+          label: selectedImageFormat.supportsAlpha ? 'Alpha kept' : 'Opaque export',
+          target: 'image-quality',
+          warning: !selectedImageFormat.supportsAlpha,
+        },
+      ]
+    : [
+        {
+          label: exportModeLabel,
+          target: isVideoMode ? 'video-section' : 'audio-section',
+        },
+        {
+          label: isVideoMode ? methodMeta.title : `Audio ${currentAudioCodecLabel}`,
+          target: isVideoMode ? 'video-section' : 'audio-format',
+        },
+        ...(isVideoMode ? [
+          { label: currentContainerLabel, target: 'basic-container' as const },
+          { label: currentCodecLabel, target: 'video-codec' as const },
+          { label: `${actualWidth}x${outputHeight}`, target: 'video-resolution' as const },
+          { label: `${actualFps} fps`, target: 'video-fps' as const },
+          {
+            label: encoder === 'ffmpeg'
+              ? (showFFmpegQualityControl ? `MJPEG Q${ffmpegQuality}` : currentCodecLabel)
+              : `${(bitrate / 1_000_000).toFixed(1)} Mbps`,
+            target: encoder === 'ffmpeg' && !showFFmpegQualityControl ? 'video-codec' as const : 'video-rate' as const,
+          },
+        ] : []),
+        ...audioSummaryBadges,
+        {
+          label: `Range ${formatTime(startTime)} - ${formatTime(endTime)}`,
+          target: isVideoMode ? 'video-alpha' : 'audio-processing',
+        },
+        {
+          label: `Duration ${formatTime(endTime - startTime)}`,
+          target: isVideoMode ? 'video-alpha' : 'audio-processing',
+        },
+        ...(stackedAlpha && isVideoMode ? [{
+          label: 'Stacked alpha',
+          target: 'video-alpha' as const,
+          warning: true,
+        }] : []),
+        {
+          label: `${sizeLabelPrefix} ${estimatedSizeLabel}`,
+          target: isVideoMode
+            ? (isWebCodecsEncoder || showFFmpegQualityControl ? 'video-rate' : 'video-codec')
+            : 'audio-quality',
+          warning: true,
+        },
+      ];
+  const showRangeInVideo = isVideoMode;
+  const showRangeInAudio = isAudioOnlyMode && includeAudio;
   const quickResolutionPresets = FrameExporter.getPresetResolutions();
   const quickFrameRatePresets = [24, 30, 60];
   const webQualityPresets = [
@@ -699,12 +936,18 @@ export function ExportPanel() {
     { id: 'high', label: 'High', detail: '25 Mbps', value: 25_000_000 },
     { id: 'master', label: 'Master', detail: '50 Mbps', value: 50_000_000 },
   ] as const;
-  const ffmpegWorkflowPresets = [
-    { id: 'premiere', label: 'Premiere', detail: 'ProRes HQ MOV' },
-    { id: 'davinci', label: 'Resolve', detail: 'DNxHR HQ MXF' },
-    { id: 'finalcut', label: 'Final Cut', detail: 'ProRes HQ MOV' },
-    { id: 'archive', label: 'Archive', detail: 'FFV1 MKV' },
+  const audioSampleRatePresets = [
+    { value: 48000 as const, label: '48 kHz' },
+    { value: 44100 as const, label: '44.1 kHz' },
   ] as const;
+  const audioBitratePresets = [
+    { value: 128000, label: '128 kbps' },
+    { value: 192000, label: '192 kbps' },
+    { value: 256000, label: '256 kbps' },
+    { value: 320000, label: '320 kbps' },
+  ] as const;
+  const selectedPreset = presets.find((preset) => preset.id === selectedPresetId) ?? null;
+  const selectedPresetName = selectedPreset?.name ?? '';
 
   const handleQuickResolutionPreset = useCallback((value: string) => {
     setUseCustomResolution(false);
@@ -721,7 +964,107 @@ export function ExportPanel() {
     setBitrate(value);
   }, [setBitrate, setRateControl]);
 
+  const saveCurrentSetup = useCallback(() => {
+    try {
+      const suggestedName = selectedPresetName || filename || 'Export Preset';
+      const nextName = window.prompt('Preset name', suggestedName);
+      if (nextName === null) {
+        return;
+      }
+
+      const result = savePreset(nextName);
+      if (!result) {
+        setSetupStatus('Preset name required');
+        return;
+      }
+
+      const suffix = projectFileService.isProjectOpen() ? '' : ' (session only)';
+      setSetupStatus(result.overwritten ? `Preset updated${suffix}` : `Preset saved${suffix}`);
+    } catch (error) {
+      log.error('Failed to save export setup', error);
+      setSetupStatus('Preset save failed');
+    }
+  }, [filename, savePreset, selectedPresetName]);
+
+  const updateCurrentSetup = useCallback(() => {
+    try {
+      if (!selectedPresetId) {
+        setSetupStatus(presets.length > 0 ? 'Select a preset' : 'No presets saved');
+        return;
+      }
+
+      const updatedPreset = updatePreset(selectedPresetId);
+      if (!updatedPreset) {
+        setSetupStatus('Preset not found');
+        return;
+      }
+
+      const suffix = projectFileService.isProjectOpen() ? '' : ' (session only)';
+      setSetupStatus(`Preset updated${suffix}`);
+    } catch (error) {
+      log.error('Failed to update export setup', error);
+      setSetupStatus('Preset update failed');
+    }
+  }, [presets.length, selectedPresetId, updatePreset]);
+
+  const loadSavedSetup = useCallback(() => {
+    try {
+      if (!selectedPresetId) {
+        setSetupStatus(presets.length > 0 ? 'Select a preset' : 'No presets saved');
+        return;
+      }
+
+      const loaded = loadPreset(selectedPresetId);
+      setSetupStatus(loaded ? 'Preset loaded' : 'Preset not found');
+    } catch (error) {
+      log.error('Failed to load export setup', error);
+      setSetupStatus('Preset load failed');
+    }
+  }, [loadPreset, presets.length, selectedPresetId]);
+
+  const scrollToSummaryTarget = useCallback((target: ExportSummaryTarget) => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const node = document.querySelector<HTMLElement>(`[data-export-target="${target}"]`);
+    if (!node) {
+      return;
+    }
+
+    node.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center',
+    });
+
+    const existingTimeout = summaryHighlightTimeoutsRef.current.get(node);
+    if (existingTimeout) {
+      window.clearTimeout(existingTimeout);
+    }
+
+    node.classList.remove('export-scroll-highlight');
+    void node.offsetHeight;
+    node.classList.add('export-scroll-highlight');
+
+    const timeout = window.setTimeout(() => {
+      node.classList.remove('export-scroll-highlight');
+      summaryHighlightTimeoutsRef.current.delete(node);
+    }, 1200);
+
+    summaryHighlightTimeoutsRef.current.set(node, timeout);
+  }, []);
+
   const handlePrimaryExport = useCallback(() => {
+    if (isXmlMode) {
+      handleExportFCPXML();
+      return;
+    }
+
+    if (isImageMode) {
+      void handleRenderFrame();
+      return;
+    }
+
     if (!videoEnabled) {
       if (includeAudio) {
         void handleExportAudioOnly();
@@ -735,7 +1078,7 @@ export function ExportPanel() {
     }
 
     void handleFFmpegExport();
-  }, [handleExport, handleExportAudioOnly, handleFFmpegExport, includeAudio, isWebCodecsEncoder, videoEnabled]);
+  }, [handleExport, handleExportAudioOnly, handleExportFCPXML, handleFFmpegExport, handleRenderFrame, includeAudio, isImageMode, isWebCodecsEncoder, isXmlMode, videoEnabled]);
 
   // If neither encoder is supported, show error
   if (!webCodecsAvailable && !ffmpegAvailable) {
@@ -754,61 +1097,68 @@ export function ExportPanel() {
 
   return (
     <div className="export-panel">
-      <div className="export-toolbar">
-        <div className="export-mode-tabs" role="tablist" aria-label="Export type">
-          <button type="button" className="export-mode-tab is-active" aria-selected="true">
-            Video
-          </button>
-          <button
-            type="button"
-            className="export-mode-tab"
-            onClick={handleRenderFrame}
-            disabled={isExporting || !videoEnabled}
-          >
-            Frame
-          </button>
-          <button
-            type="button"
-            className="export-mode-tab"
-            onClick={handleExportAudioOnly}
-            disabled={isExporting || endTime <= startTime || !isAudioSupported || !includeAudio}
-            title={!isAudioSupported ? 'Audio encoding not supported in this browser' : `Export as ${audioCodec?.toUpperCase() || 'audio'}`}
-          >
-            Audio
-          </button>
-          <button
-            type="button"
-            className="export-mode-tab"
-            onClick={handleExportFCPXML}
-            disabled={isExporting}
-            title="Export timeline as Final Cut Pro XML (compatible with Resolve, Premiere)"
-          >
-            XML
-          </button>
-        </div>
-        <button
-          className="btn export-start-btn export-toolbar-cta"
-          onClick={handlePrimaryExport}
-          disabled={exportDisabled}
-        >
-          {primaryExportLabel}
-        </button>
-      </div>
-
       {!isExporting ? (
         <div className="export-form">
           <section className="export-hero-card export-summary-sticky export-summary-badges">
-            <div className="export-pill-row">
-              {summaryBadges.map((badge) => (
-                <span
-                  key={badge}
-                  className={`export-pill${badge.includes('Stacked alpha') || badge.startsWith('Size ') ? ' export-pill-warning' : ''}`}
-                >
-                  {badge}
-                </span>
-              ))}
+            <div className="export-summary-actions">
+              <div className="export-pill-row">
+                {summaryBadges.map((badge) => (
+                  <button
+                    key={`${badge.target}-${badge.label}`}
+                    type="button"
+                    className={`export-pill${badge.warning ? ' export-pill-warning' : ''}`}
+                    onClick={() => scrollToSummaryTarget(badge.target)}
+                  >
+                    {badge.label}
+                  </button>
+                ))}
+              </div>
+              <button
+                className="btn export-start-btn export-summary-cta"
+                onClick={handlePrimaryExport}
+                disabled={exportDisabled}
+              >
+                {primaryExportLabel}
+              </button>
             </div>
           </section>
+
+          <div className="export-section export-command-row" data-export-target="command-bar">
+            <div className="export-command-bar">
+              <div className="export-command-actions">
+                <div className="export-preset-picker">
+                  <select
+                    id="export-preset-select"
+                    aria-label="Export preset"
+                    value={selectedPresetId ?? ''}
+                    onChange={(e) => setSelectedPresetId(e.target.value || null)}
+                  >
+                    <option value="">Project presets</option>
+                    {presets.map((preset) => (
+                      <option key={preset.id} value={preset.id}>
+                        {preset.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <button type="button" className="export-chip" onClick={loadSavedSetup} disabled={!selectedPresetId}>
+                  Load
+                </button>
+                <button type="button" className="export-chip" onClick={updateCurrentSetup} disabled={!selectedPresetId}>
+                  Update
+                </button>
+                <button type="button" className="export-chip" onClick={saveCurrentSetup}>
+                  Save
+                </button>
+              </div>
+            </div>
+
+            {setupStatus && (
+              <div className="export-inline-note">
+                {setupStatus}
+              </div>
+            )}
+          </div>
 
           {/* Encoder Selection */}
           <div className="export-section export-workflow-section">
@@ -899,140 +1249,231 @@ export function ExportPanel() {
             <div className="export-section-header">Basics</div>
 
             <div className="export-channel-grid">
-              <div className={`export-channel-card${videoEnabled ? '' : ' is-disabled'}`}>
+              <div className="export-channel-card export-basic-card">
                 <div className="export-channel-head">
                   <div className="export-channel-title">
-                    <span>Video</span>
-                    <strong>{videoEnabled ? `${actualWidth}x${outputHeight}` : 'Disabled'}</strong>
+                    <span>Basic</span>
+                    <strong>.{displayExtension}</strong>
                   </div>
-                  <button
-                    type="button"
-                    className={`export-toggle${videoEnabled ? ' is-active' : ''}`}
-                    onClick={() => setVideoEnabled((current) => !current)}
-                  >
-                    {videoEnabled ? 'On' : 'Off'}
-                  </button>
                 </div>
 
-                {videoEnabled ? (
-                  <>
-                    {showSharedFileInVideo && (
-                      <div className="export-field-card export-subcard">
-                        <div className="export-field-head">
-                          <span>Output</span>
-                          <strong>.{currentContainerId}</strong>
-                        </div>
-                        <div className="control-row">
-                          <label>Name</label>
-                          <div className="export-input-group">
-                            <input
-                              type="text"
-                              value={filename}
-                              onChange={(e) => setFilename(e.target.value)}
-                              placeholder="export"
-                            />
-                            <select
-                              className="export-extension-select"
-                              value={currentContainerId}
-                              onChange={(e) => {
-                                if (isWebCodecsEncoder) {
-                                  setContainerFormat(e.target.value as ContainerFormat);
-                                } else {
-                                  handleFFmpegContainerChange(e.target.value as FFmpegContainer);
-                                }
-                              }}
-                            >
-                              {isWebCodecsEncoder ? (
-                                FrameExporter.getContainerFormats().map(({ id }) => (
-                                  <option key={id} value={id}>.{id}</option>
-                                ))
-                              ) : (
-                                CONTAINER_FORMATS.map(({ id }) => (
-                                  <option key={id} value={id}>.{id}</option>
-                                ))
-                              )}
-                            </select>
-                          </div>
-                        </div>
+                <div className="export-field-card export-subcard" data-export-target="basic-output">
+                  <div className="export-field-head">
+                    <span>Output</span>
+                    <strong>{`${filename || 'export'}.${displayExtension}`}</strong>
+                  </div>
+                  <div className="control-row">
+                    <label>Name</label>
+                    <div className="export-input-group">
+                      <input
+                        type="text"
+                        value={filename}
+                        onChange={(e) => setFilename(e.target.value)}
+                        placeholder="export"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="export-field-card export-subcard" data-export-target="basic-container">
+                  <div className="export-field-head">
+                    <span>Container</span>
+                    <strong>.{displayExtension}</strong>
+                  </div>
+                  <div className="export-container-groups">
+                    <div className="export-container-group">
+                      <span className="export-container-group-label">Video</span>
+                      <div className="export-chip-row">
+                        {(isWebCodecsEncoder ? FrameExporter.getContainerFormats() : CONTAINER_FORMATS).map((format) => (
+                          <button
+                            key={`video-${format.id}`}
+                            type="button"
+                            className={`export-chip${!isXmlMode && isVideoMode && currentContainerId === format.id ? ' is-active' : ''}`}
+                            onClick={() => {
+                              setSpecialContainer('none');
+                              setVideoEnabled(true);
+                              setVisualMode('video');
+                              if (isWebCodecsEncoder) {
+                                setContainerFormat(format.id as ContainerFormat);
+                              } else {
+                                handleFFmpegContainerChange(format.id as FFmpegContainer);
+                              }
+                            }}
+                          >
+                            .{format.id}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="export-container-group">
+                      <span className="export-container-group-label">Image</span>
+                      <div className="export-chip-row">
+                        {IMAGE_FORMATS.map((format) => (
+                          <button
+                            key={`image-${format.id}`}
+                            type="button"
+                            className={`export-chip${!isXmlMode && isImageMode && imageFormat === format.id ? ' is-active' : ''}`}
+                            onClick={() => {
+                              setSpecialContainer('none');
+                              setVideoEnabled(true);
+                              setVisualMode('image');
+                              setImageFormat(format.id);
+                            }}
+                          >
+                            .{format.id}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="export-container-group">
+                      <span className="export-container-group-label">Audio</span>
+                      <div className="export-chip-row">
+                        <button
+                          type="button"
+                          className={`export-chip${!isXmlMode && isAudioOnlyMode ? ' is-active' : ''}`}
+                          onClick={() => {
+                            setSpecialContainer('none');
+                            setVideoEnabled(false);
+                            setIncludeAudio(true);
+                          }}
+                          disabled={!isAudioSupported}
+                        >
+                          .{audioExtension}
+                        </button>
+                      </div>
+                    </div>
+
+                    <div className="export-container-group">
+                      <span className="export-container-group-label">XML</span>
+                      <div className="export-chip-row">
+                        <button
+                          type="button"
+                          className={`export-chip${isXmlMode ? ' is-active' : ''}`}
+                          onClick={() => {
+                            setSpecialContainer('xml');
+                            setVideoEnabled(true);
+                          }}
+                        >
+                          .fcpxml
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {isVideoMode ? (
+                  <div className="export-field-card export-subcard" data-export-target="basic-workflow">
+                    <div className="export-field-head">
+                      <span>Workflow</span>
+                      <strong>{methodMeta.title}</strong>
+                    </div>
+                    <div className="export-chip-row">
+                      {webCodecsAvailable && (
+                        <button
+                          type="button"
+                          className={`export-chip${encoder === 'webcodecs' ? ' is-active' : ''}`}
+                          onClick={() => setEncoder('webcodecs')}
+                        >
+                          WebCodecs
+                        </button>
+                      )}
+                      {webCodecsAvailable && (
+                        <button
+                          type="button"
+                          className={`export-chip${encoder === 'htmlvideo' ? ' is-active' : ''}`}
+                          onClick={() => setEncoder('htmlvideo')}
+                        >
+                          HTMLVideo
+                        </button>
+                      )}
+                      {ffmpegAvailable && (
+                        <button
+                          type="button"
+                          className={`export-chip${encoder === 'ffmpeg' ? ' is-active' : ''}`}
+                          onClick={() => setEncoder('ffmpeg')}
+                        >
+                          FFmpeg
+                        </button>
+                      )}
+                    </div>
+
+                    {encoder === 'ffmpeg' && (
+                      <div className="export-status-row">
+                        {!isFFmpegReady ? (
+                          <button
+                            type="button"
+                            onClick={loadFFmpeg}
+                            disabled={isFFmpegLoading}
+                            className="btn-small export-status-button"
+                          >
+                            {isFFmpegLoading ? 'Loading FFmpeg...' : 'Load FFmpeg Runtime'}
+                          </button>
+                        ) : (
+                          <span className="export-status-ok">
+                            FFmpeg Ready
+                          </span>
+                        )}
                       </div>
                     )}
 
-                    <div className="export-field-card export-subcard export-video-workflow-card">
-                      <div className="export-field-head">
-                        <span>Workflow</span>
-                        <strong>{methodMeta.title}</strong>
+                    {ffmpegLoadError && encoder === 'ffmpeg' && (
+                      <div className="export-error export-error-inline">
+                        {ffmpegLoadError}
                       </div>
+                    )}
+                  </div>
+                ) : isXmlMode ? (
+                  <div className="export-inline-note">
+                    XML export writes a Final Cut Pro interchange file from the current timeline instead of rendering media.
+                  </div>
+                ) : isImageMode ? (
+                  <div className="export-inline-note">
+                    Image export renders exactly one frame at the current playhead position.
+                  </div>
+                ) : isAudioOnlyMode ? (
+                  <div className="export-inline-note">
+                    Audio-only export uses the detected browser codec.
+                  </div>
+                ) : null}
+              </div>
 
-                      <div className="export-method-grid">
-                        {webCodecsAvailable && (
-                          <button
-                            type="button"
-                            className={`export-method-card${encoder === 'webcodecs' ? ' is-active' : ''}`}
-                            onClick={() => setEncoder('webcodecs')}
-                          >
-                            <span className="export-method-chip">Fast</span>
-                            <strong>WebCodecs</strong>
-                            <span>Hardware-assisted browser export for quick delivery files.</span>
-                          </button>
-                        )}
-                        {webCodecsAvailable && (
-                          <button
-                            type="button"
-                            className={`export-method-card${encoder === 'htmlvideo' ? ' is-active' : ''}`}
-                            onClick={() => setEncoder('htmlvideo')}
-                          >
-                            <span className="export-method-chip">Precise</span>
-                            <strong>HTMLVideo</strong>
-                            <span>Safer fallback when seek accuracy matters more than speed.</span>
-                          </button>
-                        )}
-                        {ffmpegAvailable && (
-                          <button
-                            type="button"
-                            className={`export-method-card${encoder === 'ffmpeg' ? ' is-active' : ''}`}
-                            onClick={() => setEncoder('ffmpeg')}
-                          >
-                            <span className="export-method-chip">CPU</span>
-                            <strong>FFmpeg</strong>
-                            <span>Intermediates, archival codecs, and NLE-friendly containers.</span>
-                          </button>
-                        )}
-                      </div>
+              <div className={`export-channel-card${!isXmlMode && videoEnabled ? '' : ' is-disabled'}`} data-export-target={isImageMode ? 'image-section' : 'video-section'}>
+                <div className="export-channel-head">
+                  <div className="export-channel-title">
+                    <span>{isXmlMode ? 'XML' : isImageMode ? 'Image' : 'Video'}</span>
+                    <strong>{isXmlMode ? 'Timeline interchange' : videoEnabled ? `${actualWidth}x${outputHeight}` : 'Disabled'}</strong>
+                  </div>
+                  {isXmlMode ? (
+                    <span className="export-chip export-chip-static">FCPXML</span>
+                  ) : (
+                    <button
+                      type="button"
+                      className={`export-toggle${videoEnabled ? ' is-active' : ''}`}
+                      onClick={() => {
+                        if (videoEnabled) {
+                          setVideoEnabled(false);
+                          return;
+                        }
+                        setSpecialContainer('none');
+                        setVideoEnabled(true);
+                        setVisualMode('video');
+                      }}
+                    >
+                      {videoEnabled ? 'On' : 'Off'}
+                    </button>
+                  )}
+                </div>
 
-                      {encoder === 'ffmpeg' && (
-                        <div className="export-status-row">
-                          {!isFFmpegReady ? (
-                            <button
-                              type="button"
-                              onClick={loadFFmpeg}
-                              disabled={isFFmpegLoading}
-                              className="btn-small export-status-button"
-                            >
-                              {isFFmpegLoading ? 'Loading FFmpeg...' : 'Load FFmpeg Runtime'}
-                            </button>
-                          ) : (
-                            <span className="export-status-ok">
-                              FFmpeg Ready
-                            </span>
-                          )}
-                        </div>
-                      )}
-
-                      {ffmpegLoadError && encoder === 'ffmpeg' && (
-                        <div className="export-error export-error-inline">
-                          {ffmpegLoadError}
-                        </div>
-                      )}
-                    </div>
-
-                    <div className="export-chip-row">
-                      {videoSummaryBadges.map((badge) => (
-                        <span key={badge} className="export-chip export-chip-static">{badge}</span>
-                      ))}
-                    </div>
-
-                    <div className="export-quick-grid">
-                      <div className="export-field-card">
+                {isXmlMode ? (
+                  <div className="export-inline-note">
+                    XML export uses the current timeline structure and clip references. Render-specific video settings do not apply here.
+                  </div>
+                ) : isImageMode ? (
+                  <>
+                    <div className="export-quick-grid export-quick-grid-stack">
+                      <div className="export-field-card export-subcard" data-export-target="image-resolution">
                         <div className="export-field-head">
                           <span>Resolution</span>
                           <strong>{actualWidth}x{actualHeight}</strong>
@@ -1079,7 +1520,107 @@ export function ExportPanel() {
                         )}
                       </div>
 
-                      <div className="export-field-card">
+                      <div className="export-field-card export-subcard" data-export-target="image-quality">
+                        <div className="export-field-head">
+                          <span>Quality</span>
+                          <strong>{selectedImageFormat.lossless ? 'Lossless' : `${Math.round(imageQuality * 100)}%`}</strong>
+                        </div>
+                        <div className="export-chip-row">
+                          <span className="export-chip export-chip-static">
+                            {selectedImageFormat.supportsAlpha ? 'Alpha kept' : 'Opaque'}
+                          </span>
+                          {!selectedImageFormat.lossless && IMAGE_QUALITY_PRESETS.map((preset) => (
+                            <button
+                              key={preset.id}
+                              type="button"
+                              className={`export-chip${Math.abs(imageQuality - preset.value) < 0.001 ? ' is-active' : ''}`}
+                              onClick={() => setImageQuality(preset.value)}
+                            >
+                              {preset.label}
+                            </button>
+                          ))}
+                        </div>
+                        {!selectedImageFormat.lossless && (
+                          <div className="export-slider-control">
+                            <div className="export-slider-head">
+                              <label>Fine Tune</label>
+                              <span className="export-slider-value">{Math.round(imageQuality * 100)}%</span>
+                            </div>
+                            <input
+                              className="export-slider-input"
+                              type="range"
+                              min={0.4}
+                              max={1}
+                              step={0.01}
+                              value={imageQuality}
+                              onChange={(e) => setImageQuality(Number(e.target.value))}
+                            />
+                          </div>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="export-field-card export-subcard">
+                      <div className="export-field-head">
+                        <span>Frame</span>
+                        <strong>{formatTime(playheadPosition)}</strong>
+                      </div>
+                      <div className="export-inline-note">
+                        Exports the exact composited frame currently under the playhead.
+                      </div>
+                    </div>
+                  </>
+                ) : videoEnabled ? (
+                  <>
+                    <div className="export-quick-grid">
+                      <div className="export-field-card export-subcard" data-export-target="video-resolution">
+                        <div className="export-field-head">
+                          <span>Resolution</span>
+                          <strong>{actualWidth}x{actualHeight}</strong>
+                        </div>
+                        <div className="export-chip-row">
+                          {quickResolutionPresets.map(({ label, width: presetWidth, height: presetHeight }) => (
+                            <button
+                              key={`${presetWidth}x${presetHeight}`}
+                              type="button"
+                              className={`export-chip${!useCustomResolution && width === presetWidth && height === presetHeight ? ' is-active' : ''}`}
+                              onClick={() => handleQuickResolutionPreset(`${presetWidth}x${presetHeight}`)}
+                            >
+                              {label.split(' ')[0]}
+                            </button>
+                          ))}
+                          <button
+                            type="button"
+                            className={`export-chip${useCustomResolution ? ' is-active' : ''}`}
+                            onClick={() => setUseCustomResolution(true)}
+                          >
+                            Custom
+                          </button>
+                        </div>
+                        {useCustomResolution && (
+                          <div className="export-inline-inputs">
+                            <input
+                              type="number"
+                              value={customWidth}
+                              onChange={(e) => setCustomWidth(Math.max(1, parseInt(e.target.value) || 1920))}
+                              placeholder="Width"
+                              min="1"
+                              max="7680"
+                            />
+                            <span>x</span>
+                            <input
+                              type="number"
+                              value={customHeight}
+                              onChange={(e) => setCustomHeight(Math.max(1, parseInt(e.target.value) || 1080))}
+                              placeholder="Height"
+                              min="1"
+                              max="4320"
+                            />
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="export-field-card export-subcard" data-export-target="video-fps">
                         <div className="export-field-head">
                           <span>Frame Rate</span>
                           <strong>{actualFps} fps</strong>
@@ -1118,94 +1659,114 @@ export function ExportPanel() {
                       </div>
                     </div>
 
-                    <div className="export-field-card">
+                    {(isWebCodecsEncoder || showFFmpegQualityControl) && (
+                    <div className="export-field-card export-subcard" data-export-target="video-rate">
                       <div className="export-field-head">
-                        <span>{isWebCodecsEncoder ? 'Delivery Preset' : 'FFmpeg Workflow'}</span>
-                        <strong>{isWebCodecsEncoder ? `${(bitrate / 1_000_000).toFixed(1)} Mbps` : (ffmpegPreset || 'Custom')}</strong>
+                        <span>{isWebCodecsEncoder ? 'Rate' : 'Quality'}</span>
+                        <strong>
+                          {isWebCodecsEncoder
+                            ? `${rateControl.toUpperCase()} / ${(bitrate / 1_000_000).toFixed(1)} Mbps`
+                            : `MJPEG / Q${ffmpegQuality}`}
+                        </strong>
                       </div>
-                      <div className="export-preset-grid">
-                        {isWebCodecsEncoder ? (
-                          webQualityPresets.map((preset) => (
+                      {isWebCodecsEncoder ? (
+                        <>
+                          <div className="export-chip-row">
                             <button
-                              key={preset.id}
                               type="button"
-                              className={`export-preset-card${rateControl === 'vbr' && bitrate === preset.value ? ' is-active' : ''}`}
-                              onClick={() => handleQuickBitratePreset(preset.value)}
+                              className={`export-chip${rateControl === 'vbr' ? ' is-active' : ''}`}
+                              onClick={() => setRateControl('vbr')}
                             >
-                              <strong>{preset.label}</strong>
-                              <span>{preset.detail}</span>
+                              VBR
                             </button>
-                          ))
-                        ) : (
-                          ffmpegWorkflowPresets.map((preset) => (
                             <button
-                              key={preset.id}
                               type="button"
-                              className={`export-preset-card${ffmpegPreset === preset.id ? ' is-active' : ''}`}
-                              onClick={() => applyFFmpegPreset(preset.id)}
+                              className={`export-chip${rateControl === 'cbr' ? ' is-active' : ''}`}
+                              onClick={() => setRateControl('cbr')}
                             >
-                              <strong>{preset.label}</strong>
-                              <span>{preset.detail}</span>
+                              CBR
                             </button>
-                          ))
-                        )}
-                      </div>
-                    </div>
-
-                    <div className="export-field-card export-subcard">
-                      <div className="export-field-head">
-                        <span>Codec & Quality</span>
-                        <strong>{currentCodecLabel}</strong>
-                      </div>
-
-                      {encoder === 'ffmpeg' && (
-                        <div className="control-row">
-                          <label>Preset</label>
-                          <select value={ffmpegPreset} onChange={(e) => applyFFmpegPreset(e.target.value)}>
-                            <option value="">Custom</option>
-                            <optgroup label="Professional NLEs">
-                              <option value="premiere">Adobe Premiere</option>
-                              <option value="finalcut">Final Cut Pro</option>
-                              <option value="davinci">DaVinci Resolve</option>
-                              <option value="avid">Avid Media Composer</option>
-                            </optgroup>
-                            <optgroup label="ProRes Quality">
-                              <option value="prores_proxy">ProRes Proxy</option>
-                              <option value="prores_lt">ProRes LT</option>
-                              <option value="prores_hq">ProRes HQ</option>
-                              <option value="prores_4444">ProRes 4444 (Alpha)</option>
-                            </optgroup>
-                            <optgroup label="Lossless / Archive">
-                              <option value="archive">Archive (FFV1)</option>
-                              <option value="utvideo_alpha">UTVideo (Alpha)</option>
-                            </optgroup>
-                            <optgroup label="Quick Export">
-                              <option value="mjpeg_preview">MJPEG Preview</option>
-                            </optgroup>
-                          </select>
+                          </div>
+                          <div className="export-chip-row">
+                            {webQualityPresets.map((preset) => (
+                              <button
+                                key={preset.id}
+                                type="button"
+                                className={`export-chip${bitrate === preset.value ? ' is-active' : ''}`}
+                                onClick={() => handleQuickBitratePreset(preset.value)}
+                              >
+                                {preset.detail}
+                              </button>
+                            ))}
+                          </div>
+                          <div className="export-slider-control">
+                            <div className="export-slider-head">
+                              <label>Fine Tune</label>
+                              <span className="export-slider-value">{(bitrate / 1_000_000).toFixed(1)} Mbps</span>
+                            </div>
+                            <input
+                              className="export-slider-input"
+                              type="range"
+                              min={1_000_000}
+                              max={100_000_000}
+                              step={500_000}
+                              value={bitrate}
+                              onChange={(e) => setBitrate(Number(e.target.value))}
+                            />
+                          </div>
+                          <div className="export-inline-note">
+                            {webCodecsRateNote}
+                          </div>
+                        </>
+                      ) : (
+                        <div className="export-slider-control">
+                          <div className="export-slider-head">
+                            <label>MJPEG</label>
+                            <span className="export-slider-value">
+                              {ffmpegQuality} {ffmpegQuality <= 5 ? '(High)' : ffmpegQuality <= 10 ? '(Good)' : ffmpegQuality <= 20 ? '(Med)' : '(Low)'}
+                            </span>
+                          </div>
+                          <input
+                            className="export-slider-input"
+                            type="range"
+                            min={1}
+                            max={31}
+                            value={ffmpegQuality}
+                            onChange={(e) => setFfmpegQuality(parseInt(e.target.value))}
+                          />
                         </div>
                       )}
+                    </div>
+                    )}
 
-                      <div className="control-row">
-                        <label>Codec</label>
-                        {isWebCodecsEncoder ? (
-                          <select
-                            value={videoCodec}
-                            onChange={(e) => setVideoCodec(e.target.value as VideoCodec)}
-                          >
-                            {FrameExporter.getVideoCodecs(containerFormat).map(({ id, label }) => (
-                              <option key={id} value={id} disabled={!codecSupport[id]}>
-                                {label} {!codecSupport[id] ? '(not supported)' : ''}
-                              </option>
+                    <div className="export-field-card export-subcard" data-export-target="video-codec">
+                      <div className="export-field-head">
+                        <span>Codec</span>
+                        <strong>{currentCodecLabel}</strong>
+                      </div>
+                      <div className="export-chip-row">
+                        {isWebCodecsEncoder
+                          ? FrameExporter.getVideoCodecs(containerFormat).map(({ id, label }) => (
+                              <button
+                                key={id}
+                                type="button"
+                                className={`export-chip${videoCodec === id ? ' is-active' : ''}`}
+                                onClick={() => setVideoCodec(id as VideoCodec)}
+                                disabled={!codecSupport[id]}
+                              >
+                                {label}
+                              </button>
+                            ))
+                          : getCodecsForContainer(ffmpegContainer).map((codec) => (
+                              <button
+                                key={codec.id}
+                                type="button"
+                                className={`export-chip${ffmpegCodec === codec.id ? ' is-active' : ''}`}
+                                onClick={() => handleFFmpegCodecChange(codec.id as FFmpegVideoCodec)}
+                              >
+                                {codec.name}
+                              </button>
                             ))}
-                          </select>
-                        ) : (
-                          <CodecSelector
-                            container={ffmpegContainer}
-                            value={ffmpegCodec}
-                            onChange={handleFFmpegCodecChange}
-                          />
-                        )}
                       </div>
 
                       {encoder === 'ffmpeg' && ffmpegCodecInfo && (
@@ -1217,105 +1778,37 @@ export function ExportPanel() {
                       )}
 
                       {encoder === 'ffmpeg' && ffmpegCodec === 'prores' && (
-                        <div className="control-row">
-                          <label>Profile</label>
-                          <select
-                            value={proresProfile}
-                            onChange={(e) => setProresProfile(e.target.value as ProResProfile)}
-                          >
-                            {PRORES_PROFILES.map((p) => (
-                              <option key={p.id} value={p.id}>
-                                {p.name} - {p.description}
-                              </option>
-                            ))}
-                          </select>
+                        <div className="export-chip-row">
+                          {PRORES_PROFILES.map((profile) => (
+                            <button
+                              key={profile.id}
+                              type="button"
+                              className={`export-chip${proresProfile === profile.id ? ' is-active' : ''}`}
+                              onClick={() => setProresProfile(profile.id as ProResProfile)}
+                            >
+                              {profile.name}
+                            </button>
+                          ))}
                         </div>
                       )}
 
                       {encoder === 'ffmpeg' && ffmpegCodec === 'dnxhd' && (
-                        <div className="control-row">
-                          <label>Profile</label>
-                          <select
-                            value={dnxhrProfile}
-                            onChange={(e) => setDnxhrProfile(e.target.value as DnxhrProfile)}
-                          >
-                            {DNXHR_PROFILES.map((p) => (
-                              <option key={p.id} value={p.id}>
-                                {p.name} - {p.description}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                      )}
-
-                      {isWebCodecsEncoder ? (
-                        <>
-                          <div className="control-row">
-                            <label>Rate Control</label>
-                            <select
-                              value={rateControl}
-                              onChange={(e) => setRateControl(e.target.value as 'vbr' | 'cbr')}
+                        <div className="export-chip-row">
+                          {DNXHR_PROFILES.map((profile) => (
+                            <button
+                              key={profile.id}
+                              type="button"
+                              className={`export-chip${dnxhrProfile === profile.id ? ' is-active' : ''}`}
+                              onClick={() => setDnxhrProfile(profile.id as DnxhrProfile)}
                             >
-                              <option value="vbr">VBR (Variable Bitrate)</option>
-                              <option value="cbr">CBR (Constant Bitrate)</option>
-                            </select>
-                          </div>
-
-                          <div className="control-row">
-                            <label>{rateControl === 'cbr' ? 'Bitrate' : 'Target Bitrate'}</label>
-                            <select
-                              value={bitrate}
-                              onChange={(e) => setBitrate(Number(e.target.value))}
-                            >
-                              <option value={5_000_000}>5 Mbps (Low)</option>
-                              <option value={10_000_000}>10 Mbps (Medium)</option>
-                              <option value={15_000_000}>15 Mbps (High)</option>
-                              <option value={20_000_000}>20 Mbps</option>
-                              <option value={25_000_000}>25 Mbps (Very High)</option>
-                              <option value={35_000_000}>35 Mbps</option>
-                              <option value={50_000_000}>50 Mbps (Max)</option>
-                            </select>
-                          </div>
-
-                          <div className="control-row">
-                            <label>Fine Tune</label>
-                            <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flex: 1 }}>
-                              <input
-                                type="range"
-                                min={1_000_000}
-                                max={100_000_000}
-                                step={500_000}
-                                value={bitrate}
-                                onChange={(e) => setBitrate(Number(e.target.value))}
-                                style={{ flex: 1 }}
-                              />
-                              <span style={{ minWidth: '70px', fontSize: '12px', textAlign: 'right' }}>
-                                {(bitrate / 1_000_000).toFixed(1)} Mbps
-                              </span>
-                            </div>
-                          </div>
-                        </>
-                      ) : showFFmpegQualityControl && (
-                        <div className="control-row">
-                          <label>Quality</label>
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flex: 1 }}>
-                            <input
-                              type="range"
-                              min={1}
-                              max={31}
-                              value={ffmpegQuality}
-                              onChange={(e) => setFfmpegQuality(parseInt(e.target.value))}
-                              style={{ flex: 1 }}
-                            />
-                            <span style={{ minWidth: '60px', textAlign: 'right', fontSize: '12px' }}>
-                              {ffmpegQuality} {ffmpegQuality <= 5 ? '(High)' : ffmpegQuality <= 10 ? '(Good)' : ffmpegQuality <= 20 ? '(Med)' : '(Low)'}
-                            </span>
-                          </div>
+                              {profile.name}
+                            </button>
+                          ))}
                         </div>
                       )}
                     </div>
 
-                    <div className="export-field-card export-subcard">
+                    <div className="export-field-card export-subcard" data-export-target="video-alpha">
                       <div className="export-field-head">
                         <span>Alpha</span>
                         <strong>{stackedAlpha ? 'Stacked' : 'Off'}</strong>
@@ -1355,7 +1848,7 @@ export function ExportPanel() {
                             <strong>{frameCount}</strong>
                           </div>
                           <div className="export-stat-card">
-                            <span>Est. Size</span>
+                            <span>{sizeStatLabel}</span>
                             <strong>{estimatedSizeLabel}</strong>
                           </div>
                         </div>
@@ -1364,100 +1857,79 @@ export function ExportPanel() {
                   </>
                 ) : (
                   <div className="export-inline-note">
-                    Video export is disabled. The primary action switches to audio export when audio is enabled.
+                    Visual export is disabled. Switch to Video or Image, or use Audio-only export.
                   </div>
                 )}
               </div>
 
-              <div className={`export-channel-card${includeAudio ? '' : ' is-disabled'}`}>
+              <div className={`export-channel-card${isImageMode || (!includeAudio && !isXmlMode) ? ' is-disabled' : ''}`} data-export-target="audio-section">
                 <div className="export-channel-head">
                   <div className="export-channel-title">
                     <span>Audio</span>
-                    <strong>{includeAudio ? `${audioSampleRate / 1000} kHz` : 'Disabled'}</strong>
+                    <strong>{isXmlMode ? (includeAudio ? 'Track references included' : 'No audio references') : !isImageMode && includeAudio ? `${currentAudioCodecLabel} / ${audioSampleRate / 1000} kHz` : 'Disabled'}</strong>
                   </div>
                   <button
                     type="button"
-                    className={`export-toggle${includeAudio ? ' is-active' : ''}`}
+                    className={`export-toggle${(isXmlMode ? includeAudio : !isImageMode && includeAudio) ? ' is-active' : ''}`}
                     onClick={() => setIncludeAudio(!includeAudio)}
-                    disabled={isWebCodecsEncoder && !isAudioSupported}
+                    disabled={isImageMode || (!isXmlMode && isWebCodecsEncoder && !isAudioSupported)}
                   >
-                    {includeAudio ? 'On' : 'Off'}
+                    {(isXmlMode ? includeAudio : !isImageMode && includeAudio) ? 'On' : 'Off'}
                   </button>
                 </div>
 
-                {includeAudio ? (
+                {isImageMode ? (
+                  <div className="export-inline-note">
+                    Image export ignores audio and renders only the current playhead frame.
+                  </div>
+                ) : isXmlMode ? (
+                  <div className="export-inline-note">
+                    XML export can include or omit audio track references, but it does not encode audio files.
+                  </div>
+                ) : includeAudio ? (
                   <>
-                    {showSharedFileInAudio && (
-                      <div className="export-field-card export-subcard">
-                        <div className="export-field-head">
-                          <span>Output</span>
-                          <strong>.{audioExtension}</strong>
-                        </div>
-                        <div className="control-row">
-                          <label>Name</label>
-                          <div className="export-input-group">
-                            <input
-                              type="text"
-                              value={filename}
-                              onChange={(e) => setFilename(e.target.value)}
-                              placeholder="export"
-                            />
-                          </div>
-                        </div>
-                      </div>
-                    )}
-
-                    <div className="export-chip-row">
-                      {audioSummaryBadges.map((badge) => (
-                        <span key={badge} className="export-chip export-chip-static">{badge}</span>
-                      ))}
-                    </div>
-
-                    <div className="export-field-card export-subcard">
+                    <div className="export-field-card export-subcard" data-export-target="audio-format">
                       <div className="export-field-head">
                         <span>Format</span>
-                        <strong>{audioCodecLabel}</strong>
+                        <strong>{currentAudioCodecLabel}</strong>
                       </div>
-                      <div className="export-audio-grid">
-                        <div className="control-row">
-                          <label>Sample Rate</label>
-                          <select
-                            value={audioSampleRate}
-                            onChange={(e) => setAudioSampleRate(Number(e.target.value) as 44100 | 48000)}
+                      <div className="export-chip-row">
+                        <span className="export-chip export-chip-static">
+                          {currentAudioCodecLabel}{videoEnabled && encoder === 'ffmpeg' ? ' auto' : ''}
+                        </span>
+                        {audioSampleRatePresets.map((preset) => (
+                          <button
+                            key={preset.value}
+                            type="button"
+                            className={`export-chip${audioSampleRate === preset.value ? ' is-active' : ''}`}
+                            onClick={() => setAudioSampleRate(preset.value)}
                           >
-                            <option value={48000}>48 kHz (Video)</option>
-                            <option value={44100}>44.1 kHz (CD)</option>
-                          </select>
-                        </div>
-
-                        <div className="control-row">
-                          <label>Quality</label>
-                          <select
-                            value={audioBitrate}
-                            onChange={(e) => setAudioBitrate(Number(e.target.value))}
-                          >
-                            <option value={128000}>128 kbps</option>
-                            <option value={192000}>192 kbps</option>
-                            <option value={256000}>256 kbps (High)</option>
-                            <option value={320000}>320 kbps (Max)</option>
-                          </select>
-                        </div>
-
-                        {encoder === 'ffmpeg' && (
-                          <div className="control-row">
-                            <label>Audio Codec</label>
-                            <span style={{ fontSize: '11px', color: 'var(--text-secondary)' }}>
-                              {ffmpegContainer === 'mov' ? 'AAC' :
-                               ffmpegContainer === 'mkv' ? 'FLAC' :
-                               ffmpegContainer === 'avi' ? 'PCM' :
-                               ffmpegContainer === 'mxf' ? 'PCM' : 'AAC'} (auto)
-                            </span>
-                          </div>
-                        )}
+                            {preset.label}
+                          </button>
+                        ))}
                       </div>
                     </div>
 
-                    <div className="export-field-card export-subcard">
+                    <div className="export-field-card export-subcard" data-export-target="audio-quality">
+                      <div className="export-field-head">
+                        <span>Quality</span>
+                        <strong>{Math.round(audioBitrate / 1000)} kbps</strong>
+                      </div>
+                      <div className="export-chip-row">
+                        {audioBitratePresets.map((preset) => (
+                          <button
+                            type="button"
+                            key={preset.value}
+                            className={`export-chip${audioBitrate === preset.value ? ' is-active' : ''}`}
+                            onClick={() => setAudioBitrate(preset.value)}
+                          >
+                            {preset.label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="export-field-card export-subcard" data-export-target="audio-processing">
                       <div className="export-field-head">
                         <span>Processing</span>
                         <strong>{normalizeAudio ? 'Normalized' : 'Direct'}</strong>
@@ -1491,14 +1963,14 @@ export function ExportPanel() {
                         <div className="export-stats-grid export-stats-grid-compact">
                           <div className="export-stat-card">
                             <span>Output</span>
-                            <strong>{audioCodecLabel} only</strong>
+                            <strong>{currentAudioCodecLabel} only</strong>
                           </div>
                           <div className="export-stat-card">
                             <span>Duration</span>
                             <strong>{formatTime(endTime - startTime)}</strong>
                           </div>
                           <div className="export-stat-card">
-                            <span>Est. Size</span>
+                            <span>{sizeStatLabel}</span>
                             <strong>{estimatedSizeLabel}</strong>
                           </div>
                         </div>
@@ -1507,7 +1979,7 @@ export function ExportPanel() {
                   </>
                 ) : (
                   <div className="export-inline-note">
-                    Audio export is disabled. The video export stays silent unless you turn audio back on.
+                    Audio export is disabled. Video export stays silent until you turn audio back on.
                   </div>
                 )}
               </div>
@@ -1553,35 +2025,6 @@ export function ExportPanel() {
                 </select>
               </div>
             </div>
-
-            {/* FFmpeg Preset - only for FFmpeg */}
-            {encoder === 'ffmpeg' && (
-              <div className="control-row">
-                <label>Preset</label>
-                <select value={ffmpegPreset} onChange={(e) => applyFFmpegPreset(e.target.value)}>
-                  <option value="">Custom</option>
-                  <optgroup label="Professional NLEs">
-                    <option value="premiere">Adobe Premiere</option>
-                    <option value="finalcut">Final Cut Pro</option>
-                    <option value="davinci">DaVinci Resolve</option>
-                    <option value="avid">Avid Media Composer</option>
-                  </optgroup>
-                  <optgroup label="ProRes Quality">
-                    <option value="prores_proxy">ProRes Proxy</option>
-                    <option value="prores_lt">ProRes LT</option>
-                    <option value="prores_hq">ProRes HQ</option>
-                    <option value="prores_4444">ProRes 4444 (Alpha)</option>
-                  </optgroup>
-                  <optgroup label="Lossless / Archive">
-                    <option value="archive">Archive (FFV1)</option>
-                    <option value="utvideo_alpha">UTVideo (Alpha)</option>
-                  </optgroup>
-                  <optgroup label="Quick Export">
-                    <option value="mjpeg_preview">MJPEG Preview</option>
-                  </optgroup>
-                </select>
-              </div>
-            )}
 
             {/* Video Codec */}
             <div className="control-row">

--- a/src/components/export/useExportState.ts
+++ b/src/components/export/useExportState.ts
@@ -1,6 +1,7 @@
-// Export state management hook - encapsulates all ExportPanel state and initialization effects
+// Export state management hook - uses the shared export store for undo/project persistence
 
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { Logger } from '../../services/logger';
 import { FrameExporter } from '../../engine/export';
 import type { ExportProgress, VideoCodec, ContainerFormat } from '../../engine/export';
@@ -19,80 +20,85 @@ import type {
   DnxhrProfile,
 } from '../../engine/ffmpeg';
 import type { Composition } from '../../stores/mediaStore';
+import {
+  useExportStore,
+  type ExportEncoderType,
+  type ExportImageFormat,
+  type ExportSpecialContainer,
+  type ExportVisualMode,
+} from '../../stores/exportStore';
 
 const log = Logger.create('ExportState');
 
-export type EncoderType = 'webcodecs' | 'htmlvideo' | 'ffmpeg';
+export type EncoderType = ExportEncoderType;
 
-export function useExportState(composition: Composition | undefined) {
-  // Encoder selection
-  const [encoder, setEncoder] = useState<EncoderType>('webcodecs');
+export function useExportState(_composition: Composition | undefined) {
+  const {
+    settings,
+    setSettings,
+  } = useExportStore(useShallow((state) => ({
+    settings: state.settings,
+    setSettings: state.setSettings,
+  })));
 
-  // Shared settings
-  const [width, setWidth] = useState(composition?.width ?? 1920);
-  const [height, setHeight] = useState(composition?.height ?? 1080);
-  const [customWidth, setCustomWidth] = useState(composition?.width ?? 1920);
-  const [customHeight, setCustomHeight] = useState(composition?.height ?? 1080);
-  const [useCustomResolution, setUseCustomResolution] = useState(false);
-  const [fps, setFps] = useState(composition?.frameRate ?? 30);
-  const [customFps, setCustomFps] = useState(30);
-  const [useCustomFps, setUseCustomFps] = useState(false);
-  const [useInOut, setUseInOut] = useState(true);
-  const [filename, setFilename] = useState('export');
+  const {
+    encoder,
+    width,
+    height,
+    customWidth,
+    customHeight,
+    useCustomResolution,
+    fps,
+    customFps,
+    useCustomFps,
+    useInOut,
+    filename,
+    bitrate,
+    containerFormat,
+    videoCodec,
+    rateControl,
+    ffmpegCodec,
+    ffmpegContainer,
+    ffmpegPreset,
+    proresProfile,
+    dnxhrProfile,
+    ffmpegQuality,
+    ffmpegBitrate,
+    ffmpegRateControl,
+    stackedAlpha,
+    includeAudio,
+    audioSampleRate,
+    audioBitrate,
+    normalizeAudio,
+    videoEnabled,
+    visualMode,
+    imageFormat,
+    imageQuality,
+    specialContainer,
+  } = settings;
 
-  // WebCodecs settings
-  const [bitrate, setBitrate] = useState(15_000_000);
-  const [containerFormat, setContainerFormat] = useState<ContainerFormat>('mp4');
-  const [videoCodec, setVideoCodec] = useState<VideoCodec>('h264');
   const [codecSupport, setCodecSupport] = useState<Record<VideoCodec, boolean>>({
-    h264: true, h265: false, vp9: false, av1: false
+    h264: true,
+    h265: false,
+    vp9: false,
+    av1: false,
   });
-  const [rateControl, setRateControl] = useState<'vbr' | 'cbr'>('vbr');
-
-  // FFmpeg settings (default to ProRes which is most universally useful)
-  const [ffmpegCodec, setFfmpegCodec] = useState<FFmpegVideoCodec>('prores');
-  const [ffmpegContainer, setFfmpegContainer] = useState<FFmpegContainer>('mov');
-  const [ffmpegPreset, setFfmpegPreset] = useState<string>('');
-  const [proresProfile, setProresProfile] = useState<ProResProfile>('hq');
-  const [dnxhrProfile, setDnxhrProfile] = useState<DnxhrProfile>('dnxhr_hq');
-  const [ffmpegQuality, setFfmpegQuality] = useState(18);
-  const [ffmpegBitrate, setFfmpegBitrate] = useState(20_000_000);
-  const [ffmpegRateControl, setFfmpegRateControl] = useState<'crf' | 'cbr' | 'vbr'>('crf');
-
-  // FFmpeg loading state
   const [isFFmpegLoading, setIsFFmpegLoading] = useState(false);
   const [isFFmpegReady, setIsFFmpegReady] = useState(false);
   const [ffmpegLoadError, setFfmpegLoadError] = useState<string | null>(null);
-
-  // Alpha settings
-  const [stackedAlpha, setStackedAlpha] = useState(false);
-
-  // Audio settings
-  const [includeAudio, setIncludeAudio] = useState(true);
-  const [audioSampleRate, setAudioSampleRate] = useState<44100 | 48000>(48000);
-  const [audioBitrate, setAudioBitrate] = useState(256000);
-  const [normalizeAudio, setNormalizeAudio] = useState(false);
-
-  // Export state
   const [isExporting, setIsExporting] = useState(false);
   const [progress, setProgress] = useState<ExportProgress | null>(null);
   const [ffmpegProgress, setFfmpegProgress] = useState<FFmpegProgress | null>(null);
   const [exportPhase, setExportPhase] = useState<'idle' | 'rendering' | 'audio' | 'encoding'>('idle');
   const [error, setError] = useState<string | null>(null);
   const [exporter, setExporter] = useState<FrameExporter | null>(null);
-
-  // Check WebCodecs support
   const [isSupported, setIsSupported] = useState(true);
   const [isAudioSupported, setIsAudioSupported] = useState(true);
   const [audioCodec, setAudioCodec] = useState<AudioCodec | null>(null);
 
-  // Check FFmpeg support
   const isFFmpegSupported = FFmpegBridge.isSupported();
   const isFFmpegMultiThreaded = FFmpegBridge.isMultiThreaded();
 
-  // --- Effects ---
-
-  // Detect WebCodecs and audio support on mount
   useEffect(() => {
     setIsSupported(FrameExporter.isSupported());
     AudioEncoderWrapper.detectSupportedCodec().then(result => {
@@ -102,18 +108,16 @@ export function useExportState(composition: Composition | undefined) {
         log.info(`Audio codec detected: ${result.codec.toUpperCase()}`);
       } else {
         setIsAudioSupported(false);
-        setIncludeAudio(false);
+        setSettings({ includeAudio: false });
         log.warn('No audio encoding supported in this browser');
       }
     });
-  }, []);
+  }, [setSettings]);
 
-  // Check codec support when resolution changes
   useEffect(() => {
     const checkSupport = async () => {
       const actualWidth = useCustomResolution ? customWidth : width;
       const actualHeight = useCustomResolution ? customHeight : height;
-
       const support: Record<VideoCodec, boolean> = {
         h264: await FrameExporter.checkCodecSupport('h264', actualWidth, actualHeight),
         h265: await FrameExporter.checkCodecSupport('h265', actualWidth, actualHeight),
@@ -122,38 +126,29 @@ export function useExportState(composition: Composition | undefined) {
       };
       setCodecSupport(support);
 
-      // If current codec is not supported, select first supported one
       const availableCodecs = FrameExporter.getVideoCodecs(containerFormat);
       if (!support[videoCodec]) {
         const firstSupported = availableCodecs.find(c => support[c.id]);
         if (firstSupported) {
-          setVideoCodec(firstSupported.id);
+          setSettings({ videoCodec: firstSupported.id });
         }
       }
     };
-    checkSupport();
-  }, [width, height, customWidth, customHeight, useCustomResolution, containerFormat, videoCodec]);
 
-  // Update video codec when container changes
+    void checkSupport();
+  }, [containerFormat, customHeight, customWidth, setSettings, useCustomResolution, videoCodec, width, height]);
+
   useEffect(() => {
     const availableCodecs = FrameExporter.getVideoCodecs(containerFormat);
     if (!availableCodecs.find(c => c.id === videoCodec)) {
-      setVideoCodec(availableCodecs[0].id);
+      setSettings({ videoCodec: availableCodecs[0].id });
     }
-  }, [containerFormat, videoCodec]);
-
-  // Update recommended bitrate when resolution changes
-  useEffect(() => {
-    setBitrate(FrameExporter.getRecommendedBitrate(width, height, fps));
-  }, [width, height, fps]);
-
-  // --- Handlers ---
+  }, [containerFormat, setSettings, videoCodec]);
 
   const handleResolutionChange = useCallback((value: string) => {
-    const [w, h] = value.split('x').map(Number);
-    setWidth(w);
-    setHeight(h);
-  }, []);
+    const [nextWidth, nextHeight] = value.split('x').map(Number);
+    setSettings({ width: nextWidth, height: nextHeight });
+  }, [setSettings]);
 
   const loadFFmpeg = useCallback(async () => {
     if (isFFmpegReady) return;
@@ -177,99 +172,159 @@ export function useExportState(composition: Composition | undefined) {
   const applyFFmpegPreset = useCallback((presetId: string) => {
     const presetConfig = PLATFORM_PRESETS[presetId];
     if (!presetConfig) {
-      setFfmpegPreset('');
+      setSettings({ ffmpegPreset: '' });
       return;
     }
 
-    setFfmpegCodec(presetConfig.codec);
-    setFfmpegContainer(presetConfig.container);
+    const patch: Partial<typeof settings> = {
+      ffmpegCodec: presetConfig.codec,
+      ffmpegContainer: presetConfig.container,
+      ffmpegPreset: presetId,
+    };
 
     if (presetConfig.quality !== undefined) {
-      setFfmpegRateControl('crf');
-      setFfmpegQuality(presetConfig.quality);
+      patch.ffmpegRateControl = 'crf';
+      patch.ffmpegQuality = presetConfig.quality;
     }
     if (presetConfig.bitrate !== undefined) {
-      setFfmpegRateControl('vbr');
-      setFfmpegBitrate(presetConfig.bitrate);
+      patch.ffmpegRateControl = 'vbr';
+      patch.ffmpegBitrate = presetConfig.bitrate;
     }
     if (presetConfig.proresProfile) {
-      setProresProfile(presetConfig.proresProfile);
+      patch.proresProfile = presetConfig.proresProfile;
     }
     if (presetConfig.dnxhrProfile) {
-      setDnxhrProfile(presetConfig.dnxhrProfile);
+      patch.dnxhrProfile = presetConfig.dnxhrProfile;
     }
 
-    setFfmpegPreset(presetId);
-  }, []);
+    setSettings(patch);
+  }, [setSettings, settings]);
 
   const handleFFmpegContainerChange = useCallback((newContainer: FFmpegContainer) => {
-    setFfmpegContainer(newContainer);
-    setFfmpegPreset('');
+    const patch: Partial<typeof settings> = {
+      ffmpegContainer: newContainer,
+      ffmpegPreset: '',
+    };
 
     const codecInfo = getCodecInfo(ffmpegCodec);
     if (codecInfo && !codecInfo.containers.includes(newContainer)) {
       if (newContainer === 'mxf') {
-        setFfmpegCodec('dnxhd');
+        patch.ffmpegCodec = 'dnxhd';
       } else if (newContainer === 'mov') {
-        setFfmpegCodec('prores');
+        patch.ffmpegCodec = 'prores';
       } else if (newContainer === 'mkv' || newContainer === 'avi') {
-        setFfmpegCodec('mjpeg');
+        patch.ffmpegCodec = 'mjpeg';
       }
     }
-  }, [ffmpegCodec]);
+
+    setSettings(patch);
+  }, [ffmpegCodec, setSettings, settings]);
 
   const handleFFmpegCodecChange = useCallback((newCodec: FFmpegVideoCodec) => {
-    setFfmpegCodec(newCodec);
-    setFfmpegPreset('');
+    const patch: Partial<typeof settings> = {
+      ffmpegCodec: newCodec,
+      ffmpegPreset: '',
+    };
 
     const codecInfo = getCodecInfo(newCodec);
     if (codecInfo && !codecInfo.containers.includes(ffmpegContainer)) {
-      setFfmpegContainer(codecInfo.containers[0]);
+      patch.ffmpegContainer = codecInfo.containers[0];
     }
-  }, [ffmpegContainer]);
+
+    setSettings(patch);
+  }, [ffmpegContainer, setSettings, settings]);
 
   return {
-    // Encoder
-    encoder, setEncoder,
-    // Resolution
-    width, setWidth, height, setHeight,
-    customWidth, setCustomWidth, customHeight, setCustomHeight,
-    useCustomResolution, setUseCustomResolution,
-    // Frame rate
-    fps, setFps, customFps, setCustomFps, useCustomFps, setUseCustomFps,
-    // Range
-    useInOut, setUseInOut,
-    // Filename
-    filename, setFilename,
-    // WebCodecs
-    bitrate, setBitrate, containerFormat, setContainerFormat,
-    videoCodec, setVideoCodec, codecSupport, rateControl, setRateControl,
-    // FFmpeg
-    ffmpegCodec, ffmpegContainer, ffmpegPreset,
-    proresProfile, setProresProfile, dnxhrProfile, setDnxhrProfile,
-    ffmpegQuality, setFfmpegQuality, ffmpegBitrate, setFfmpegBitrate,
-    ffmpegRateControl, setFfmpegRateControl,
-    // FFmpeg loading
-    isFFmpegLoading, isFFmpegReady, ffmpegLoadError,
-    // Alpha
-    stackedAlpha, setStackedAlpha,
-    // Audio
-    includeAudio, setIncludeAudio,
-    audioSampleRate, setAudioSampleRate,
-    audioBitrate, setAudioBitrate,
-    normalizeAudio, setNormalizeAudio,
-    // Export state
-    isExporting, setIsExporting,
-    progress, setProgress,
-    ffmpegProgress, setFfmpegProgress,
-    exportPhase, setExportPhase,
-    error, setError,
-    exporter, setExporter,
-    // Support detection
-    isSupported, isAudioSupported, audioCodec,
-    isFFmpegSupported, isFFmpegMultiThreaded,
-    // Handlers
-    handleResolutionChange, loadFFmpeg, applyFFmpegPreset,
-    handleFFmpegContainerChange, handleFFmpegCodecChange,
+    encoder,
+    setEncoder: (value: EncoderType) => setSettings({ encoder: value }),
+    width,
+    setWidth: (value: number) => setSettings({ width: value }),
+    height,
+    setHeight: (value: number) => setSettings({ height: value }),
+    customWidth,
+    setCustomWidth: (value: number) => setSettings({ customWidth: value }),
+    customHeight,
+    setCustomHeight: (value: number) => setSettings({ customHeight: value }),
+    useCustomResolution,
+    setUseCustomResolution: (value: boolean) => setSettings({ useCustomResolution: value }),
+    fps,
+    setFps: (value: number) => setSettings({ fps: value }),
+    customFps,
+    setCustomFps: (value: number) => setSettings({ customFps: value }),
+    useCustomFps,
+    setUseCustomFps: (value: boolean) => setSettings({ useCustomFps: value }),
+    useInOut,
+    setUseInOut: (value: boolean) => setSettings({ useInOut: value }),
+    filename,
+    setFilename: (value: string) => setSettings({ filename: value }),
+    bitrate,
+    setBitrate: (value: number) => setSettings({ bitrate: value }),
+    containerFormat,
+    setContainerFormat: (value: ContainerFormat) => setSettings({ containerFormat: value }),
+    videoCodec,
+    setVideoCodec: (value: VideoCodec) => setSettings({ videoCodec: value }),
+    codecSupport,
+    rateControl,
+    setRateControl: (value: 'vbr' | 'cbr') => setSettings({ rateControl: value }),
+    ffmpegCodec,
+    setFfmpegCodec: (value: FFmpegVideoCodec) => setSettings({ ffmpegCodec: value }),
+    ffmpegContainer,
+    setFfmpegContainer: (value: FFmpegContainer) => setSettings({ ffmpegContainer: value }),
+    ffmpegPreset,
+    proresProfile,
+    setProresProfile: (value: ProResProfile) => setSettings({ proresProfile: value }),
+    dnxhrProfile,
+    setDnxhrProfile: (value: DnxhrProfile) => setSettings({ dnxhrProfile: value }),
+    ffmpegQuality,
+    setFfmpegQuality: (value: number) => setSettings({ ffmpegQuality: value }),
+    ffmpegBitrate,
+    setFfmpegBitrate: (value: number) => setSettings({ ffmpegBitrate: value }),
+    ffmpegRateControl,
+    setFfmpegRateControl: (value: 'crf' | 'cbr' | 'vbr') => setSettings({ ffmpegRateControl: value }),
+    isFFmpegLoading,
+    isFFmpegReady,
+    ffmpegLoadError,
+    stackedAlpha,
+    setStackedAlpha: (value: boolean) => setSettings({ stackedAlpha: value }),
+    includeAudio,
+    setIncludeAudio: (value: boolean) => setSettings({ includeAudio: value }),
+    audioSampleRate,
+    setAudioSampleRate: (value: 44100 | 48000) => setSettings({ audioSampleRate: value }),
+    audioBitrate,
+    setAudioBitrate: (value: number) => setSettings({ audioBitrate: value }),
+    normalizeAudio,
+    setNormalizeAudio: (value: boolean) => setSettings({ normalizeAudio: value }),
+    videoEnabled,
+    setVideoEnabled: (value: boolean) => setSettings({ videoEnabled: value }),
+    visualMode,
+    setVisualMode: (value: ExportVisualMode) => setSettings({ visualMode: value }),
+    imageFormat,
+    setImageFormat: (value: ExportImageFormat) => setSettings({ imageFormat: value }),
+    imageQuality,
+    setImageQuality: (value: number) => setSettings({ imageQuality: value }),
+    specialContainer,
+    setSpecialContainer: (value: ExportSpecialContainer) => setSettings({ specialContainer: value }),
+    isExporting,
+    setIsExporting,
+    progress,
+    setProgress,
+    ffmpegProgress,
+    setFfmpegProgress,
+    exportPhase,
+    setExportPhase,
+    error,
+    setError,
+    exporter,
+    setExporter,
+    isSupported,
+    isAudioSupported,
+    audioCodec,
+    isFFmpegSupported,
+    isFFmpegMultiThreaded,
+    handleResolutionChange,
+    loadFFmpeg,
+    applyFFmpegPreset,
+    handleFFmpegContainerChange,
+    handleFFmpegCodecChange,
   };
 }

--- a/src/components/mobile/MobileMediaPanel.tsx
+++ b/src/components/mobile/MobileMediaPanel.tsx
@@ -13,6 +13,7 @@ export function MobileMediaPanel({ isOpen, onClose }: MobileMediaPanelProps) {
   const files = useMediaStore((s) => s.files);
   const compositions = useMediaStore((s) => s.compositions);
   const importFiles = useMediaStore((s) => s.importFiles);
+  const refreshFileUrls = useMediaStore((s) => s.refreshFileUrls);
   const tracks = useTimelineStore((s) => s.tracks);
   const addClip = useTimelineStore((s) => s.addClip);
   const playheadPosition = useTimelineStore((s) => s.playheadPosition);
@@ -112,7 +113,11 @@ export function MobileMediaPanel({ isOpen, onClose }: MobileMediaPanelProps) {
                 >
                   <div className="media-thumbnail">
                     {file.thumbnailUrl ? (
-                      <img src={file.thumbnailUrl} alt="" />
+                      <img
+                        src={file.thumbnailUrl}
+                        alt=""
+                        onError={() => { void refreshFileUrls(file.id); }}
+                      />
                     ) : (
                       <div className="media-icon">
                         {file.type === 'video' ? '🎥' : file.type === 'audio' ? '🎵' : '🖼️'}

--- a/src/components/panels/MediaPanel.tsx
+++ b/src/components/panels/MediaPanel.tsx
@@ -94,6 +94,7 @@ export function MediaPanel() {
   const fileSystemSupported = useMediaStore(state => state.fileSystemSupported);
   const proxyFolderName = useMediaStore(state => state.proxyFolderName);
   const activeCompositionId = useMediaStore(state => state.activeCompositionId);
+  const refreshFileUrls = useMediaStore(state => state.refreshFileUrls);
 
   // Actions from getState() - stable, no subscription needed
   const {
@@ -1295,7 +1296,12 @@ export function MediaPanel() {
         >
           <div className="media-grid-thumb">
             {thumbUrl ? (
-              <img src={thumbUrl} alt="" draggable={false} />
+              <img
+                src={thumbUrl}
+                alt=""
+                draggable={false}
+                onError={mediaFile ? () => { void refreshFileUrls(mediaFile.id); } : undefined}
+              />
             ) : (
               <div className="media-grid-thumb-placeholder">
                 <FileTypeIcon type={isFolder ? 'folder' : isComp ? 'composition' : getProjectItemIconType(item)} large />

--- a/src/components/panels/flashboard/FlashBoardNode.tsx
+++ b/src/components/panels/flashboard/FlashBoardNode.tsx
@@ -283,6 +283,7 @@ function FlashBoardNodeComponent({
     if (!mediaFileId) return undefined;
     return s.files.find((f) => f.id === mediaFileId);
   });
+  const refreshFileUrls = useMediaStore((s) => s.refreshFileUrls);
   const mediaType = mediaFile?.type ?? node.result?.mediaType;
   const isVideoPreview = mediaType === 'video' && Boolean(mediaFile?.url);
   const videoUrl = isVideoPreview ? mediaFile?.url : undefined;
@@ -310,6 +311,12 @@ function FlashBoardNodeComponent({
     ? videoPreviewState.duration
     : (mediaFile?.duration ?? node.result?.duration ?? 0);
   const resolvedIsVideoPlaying = videoStateMatchesMedia ? videoPreviewState.isPlaying : false;
+  const handleThumbnailError = useCallback(() => {
+    if (!mediaFileId) {
+      return;
+    }
+    void refreshFileUrls(mediaFileId);
+  }, [mediaFileId, refreshFileUrls]);
   const shouldRenderLiveVideo = isVideoPreview && (resolvedIsVideoPlaying || isHovered || isSelected || !thumbnailUrl);
   const hasReferenceRole = referenceRoles.length > 0;
   const isComposerReferenceHovered = Boolean(hoveredComposerReferenceRole);
@@ -883,7 +890,14 @@ function FlashBoardNodeComponent({
               </div>
             ) : thumbnailUrl ? (
               <div className="flashboard-node-preview">
-                <img className="flashboard-node-thumbnail" src={thumbnailUrl} alt="" draggable={false} loading="lazy" />
+                <img
+                  className="flashboard-node-thumbnail"
+                  src={thumbnailUrl}
+                  alt=""
+                  draggable={false}
+                  loading="lazy"
+                  onError={handleThumbnailError}
+                />
               </div>
             ) : null}
             {mediaFileId && (

--- a/src/components/panels/media/FileTypeIcon.tsx
+++ b/src/components/panels/media/FileTypeIcon.tsx
@@ -44,6 +44,24 @@ export const FileTypeIcon = memo(({ type, large }: FileTypeIconProps) => {
           <path d="M1.5 11l3.5-3 2.5 2 3-4 4 5v0.5c0 .55-.45 1-1 1h-12c-.55 0-1-.45-1-1z" fill="#7a9aba" opacity="0.8"/>
         </svg>
       );
+    case 'lottie':
+      return (
+        <svg style={style} viewBox="0 0 16 16" fill="none">
+          <rect x="1" y="2" width="14" height="12" rx="1.5" fill="#4d5a74" stroke="#8cc7ff" strokeWidth="0.7"/>
+          <path d="M4 10.5c1.1-2.8 3.1-4.8 5.9-5.9" stroke="#8cc7ff" strokeWidth="1.1" strokeLinecap="round"/>
+          <path d="M7.2 11.7c.8-1.8 2.1-3.1 3.9-3.9" stroke="#cce9ff" strokeWidth="1" strokeLinecap="round"/>
+          <circle cx="4" cy="10.5" r="1" fill="#8cc7ff"/>
+          <circle cx="10" cy="4.5" r="1" fill="#8cc7ff"/>
+          <circle cx="11.1" cy="7.8" r="0.8" fill="#cce9ff"/>
+        </svg>
+      );
+    case 'rive':
+      return (
+        <svg style={style} viewBox="0 0 16 16" fill="none">
+          <rect x="1" y="2" width="14" height="12" rx="1.5" fill="#5b4d72" stroke="#d8b6ff" strokeWidth="0.7"/>
+          <path d="M5 12V4h3.2c1.8 0 2.8.9 2.8 2.3 0 .9-.5 1.7-1.4 2.1L12 12H10l-2.2-3H7v3H5zm2-4.7h1.1c1 0 1.6-.4 1.6-1.1 0-.7-.5-1-1.6-1H7v2.1z" fill="#f1e4ff"/>
+        </svg>
+      );
     case 'composition':
       return (
         <svg style={style} viewBox="0 0 16 16" fill="none">
@@ -216,6 +234,26 @@ const LargeIcon = memo(({ type, style }: { type?: string; style: React.CSSProper
           <rect x="4" y="8" width="40" height="32" rx="3" stroke="#6a8aaa" strokeWidth="1"/>
           <circle cx="16" cy="18" r="4" fill="#8abbee" opacity="0.7"/>
           <path d="M4.5 32l10-8 7 5.5 8.5-11L44 35v3c0 1.38-1.12 2.5-2.5 2.5h-35c-1.38 0-2.5-1.12-2.5-2.5V32z" fill="#6a8aaa" opacity="0.6"/>
+        </svg>
+      );
+    case 'lottie':
+      return (
+        <svg style={style} viewBox="0 0 48 48" fill="none">
+          <rect x="4" y="8" width="40" height="32" rx="3" fill="#33455f"/>
+          <rect x="4" y="8" width="40" height="32" rx="3" stroke="#8cc7ff" strokeWidth="1"/>
+          <path d="M12 30c3.5-9 10-15.5 19-19" stroke="#8cc7ff" strokeWidth="2.4" strokeLinecap="round"/>
+          <path d="M21 34c2.3-5.3 6-9 11.3-11.3" stroke="#d9f0ff" strokeWidth="2.1" strokeLinecap="round"/>
+          <circle cx="12" cy="30" r="2.5" fill="#8cc7ff"/>
+          <circle cx="31" cy="11" r="2.5" fill="#8cc7ff"/>
+          <circle cx="33.5" cy="22.5" r="2" fill="#d9f0ff"/>
+        </svg>
+      );
+    case 'rive':
+      return (
+        <svg style={style} viewBox="0 0 48 48" fill="none">
+          <rect x="4" y="8" width="40" height="32" rx="3" fill="#4d3f63"/>
+          <rect x="4" y="8" width="40" height="32" rx="3" stroke="#d8b6ff" strokeWidth="1"/>
+          <path d="M15 35V13h10.2c5.4 0 8.8 2.8 8.8 7 0 2.7-1.5 4.9-4.1 6l6.1 9H30.4l-5-7.5H21V35h-6zm6-12.3h3.7c2.8 0 4.4-1 4.4-2.8 0-1.8-1.5-2.7-4.4-2.7H21v5.5z" fill="#f1e4ff"/>
         </svg>
       );
     case 'text':

--- a/src/components/panels/media/dropImport.ts
+++ b/src/components/panels/media/dropImport.ts
@@ -1,4 +1,4 @@
-import { detectMediaType } from '../../../stores/timeline/helpers/mediaTypeHelpers';
+import { classifyMediaType } from '../../../stores/timeline/helpers/mediaTypeHelpers';
 
 export interface MediaFolderLike {
   id: string;
@@ -58,10 +58,6 @@ interface FileSystemDirectoryEntryLike extends FileSystemEntryLike {
 interface FileSystemDirectoryHandleIteratorLike {
   values?: () => AsyncIterable<FileSystemHandle>;
   entries?: () => AsyncIterable<[string, FileSystemHandle]>;
-}
-
-function isSupportedImportFile(file: File): boolean {
-  return detectMediaType(file) !== 'unknown';
 }
 
 function buildDropRecordKey(record: DroppedMediaFileRecord): string {
@@ -185,10 +181,6 @@ export async function collectDroppedMediaFiles(dataTransfer: DataTransfer): Prom
   const seenLooseFileKeys = new Set<string>();
 
   const pushRecord = (record: DroppedMediaFileRecord): void => {
-    if (!isSupportedImportFile(record.file)) {
-      return;
-    }
-
     const key = buildDropRecordKey(record);
     if (seenRecordKeys.has(key)) {
       return;
@@ -211,11 +203,14 @@ export async function collectDroppedMediaFiles(dataTransfer: DataTransfer): Prom
         const handle = await itemWithHandle.getAsFileSystemHandle();
         if (handle?.kind === 'file') {
           const fileHandle = handle as FileSystemFileHandle;
-          pushRecord({
-            file: await fileHandle.getFile(),
-            handle: fileHandle,
-            folderSegments: [],
-          });
+          const file = await fileHandle.getFile();
+          if ((await classifyMediaType(file)) !== 'unknown') {
+            pushRecord({
+              file,
+              handle: fileHandle,
+              folderSegments: [],
+            });
+          }
           continue;
         }
 
@@ -234,10 +229,13 @@ export async function collectDroppedMediaFiles(dataTransfer: DataTransfer): Prom
     if (typeof itemWithHandle.webkitGetAsEntry === 'function') {
       const entry = itemWithHandle.webkitGetAsEntry();
       if (entry?.isFile) {
-        pushRecord({
-          file: await getFileFromEntry(entry as unknown as FileSystemFileEntryLike),
-          folderSegments: [],
-        });
+        const file = await getFileFromEntry(entry as unknown as FileSystemFileEntryLike);
+        if ((await classifyMediaType(file)) !== 'unknown') {
+          pushRecord({
+            file,
+            folderSegments: [],
+          });
+        }
         continue;
       }
 
@@ -253,7 +251,7 @@ export async function collectDroppedMediaFiles(dataTransfer: DataTransfer): Prom
     }
 
     const file = item.getAsFile();
-    if (file) {
+    if (file && (await classifyMediaType(file)) !== 'unknown') {
       pushRecord({
         file,
         folderSegments: [],
@@ -266,10 +264,12 @@ export async function collectDroppedMediaFiles(dataTransfer: DataTransfer): Prom
       continue;
     }
 
-    pushRecord({
-      file,
-      folderSegments: [],
-    });
+    if ((await classifyMediaType(file)) !== 'unknown') {
+      pushRecord({
+        file,
+        folderSegments: [],
+      });
+    }
   }
 
   return records;
@@ -289,10 +289,6 @@ export function planDroppedMediaImports(
   }
 
   for (const record of records) {
-    if (!isSupportedImportFile(record.file)) {
-      continue;
-    }
-
     let parentId = targetParentId;
     for (const segment of record.folderSegments) {
       const trimmedSegment = segment.trim();

--- a/src/components/panels/properties/LottieTab.tsx
+++ b/src/components/panels/properties/LottieTab.tsx
@@ -1,0 +1,142 @@
+import { useCallback } from 'react';
+import { useMediaStore } from '../../../stores/mediaStore';
+import { useTimelineStore } from '../../../stores/timeline';
+import {
+  DEFAULT_VECTOR_ANIMATION_CLIP_SETTINGS,
+  type VectorAnimationClipSettings,
+} from '../../../types/vectorAnimation';
+
+interface LottieTabProps {
+  clipId: string;
+}
+
+function cleanBackgroundColor(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function LottieTab({ clipId }: LottieTabProps) {
+  const clip = useTimelineStore((state) => state.clips.find((current) => current.id === clipId));
+  const files = useMediaStore((state) => state.files);
+
+  const mediaFile = clip?.source?.mediaFileId
+    ? files.find((file) => file.id === clip.source?.mediaFileId)
+    : undefined;
+  const metadata = mediaFile?.vectorAnimation;
+  const settings: VectorAnimationClipSettings = {
+    ...DEFAULT_VECTOR_ANIMATION_CLIP_SETTINGS,
+    ...clip?.source?.vectorAnimationSettings,
+  };
+  const animationNames = metadata?.animationNames ?? [];
+
+  const updateSettings = useCallback((updates: Partial<VectorAnimationClipSettings>) => {
+    const { clips } = useTimelineStore.getState();
+    const current = clips.find((candidate) => candidate.id === clipId);
+    if (!current?.source || current.source.type !== 'lottie') {
+      return;
+    }
+
+    useTimelineStore.setState({
+      clips: clips.map((candidate) =>
+        candidate.id === clipId
+          ? {
+              ...candidate,
+              source: {
+                ...candidate.source!,
+                vectorAnimationSettings: {
+                  ...DEFAULT_VECTOR_ANIMATION_CLIP_SETTINGS,
+                  ...candidate.source?.vectorAnimationSettings,
+                  ...updates,
+                },
+              },
+            }
+          : candidate
+      ),
+    });
+  }, [clipId]);
+
+  if (!clip || clip.source?.type !== 'lottie') {
+    return null;
+  }
+
+  return (
+    <div className="properties-tab-content" style={{ padding: '10px', display: 'grid', gap: '12px' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '8px' }}>
+        <div>
+          <div style={{ color: '#ddd', fontSize: '12px', fontWeight: 600 }}>{clip.name}</div>
+          <div style={{ color: '#888', fontSize: '11px' }}>
+            {metadata?.width && metadata?.height ? `${metadata.width} x ${metadata.height}` : 'Canvas-backed animation'}
+            {metadata?.fps ? ` • ${metadata.fps.toFixed(2)} fps` : ''}
+          </div>
+        </div>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '6px', color: '#bbb', fontSize: '11px' }}>
+          <input
+            type="checkbox"
+            checked={settings.loop}
+            onChange={(event) => updateSettings({ loop: event.target.checked })}
+          />
+          Loop
+        </label>
+      </div>
+
+      <label style={{ display: 'grid', gap: '4px', fontSize: '11px', color: '#999' }}>
+        End Behavior
+        <select
+          value={settings.endBehavior}
+          onChange={(event) => updateSettings({ endBehavior: event.target.value as VectorAnimationClipSettings['endBehavior'] })}
+        >
+          <option value="hold">Hold last frame</option>
+          <option value="clear">Clear</option>
+          <option value="loop">Loop</option>
+        </select>
+      </label>
+
+      <label style={{ display: 'grid', gap: '4px', fontSize: '11px', color: '#999' }}>
+        Fit
+        <select
+          value={settings.fit}
+          onChange={(event) => updateSettings({ fit: event.target.value as VectorAnimationClipSettings['fit'] })}
+        >
+          <option value="contain">Contain</option>
+          <option value="cover">Cover</option>
+          <option value="fill">Fill</option>
+        </select>
+      </label>
+
+      {animationNames.length > 0 && (
+        <label style={{ display: 'grid', gap: '4px', fontSize: '11px', color: '#999' }}>
+          Animation
+          <select
+            value={settings.animationName ?? metadata?.defaultAnimationName ?? animationNames[0]}
+            onChange={(event) => updateSettings({ animationName: event.target.value || undefined })}
+          >
+            {animationNames.map((animationName) => (
+              <option key={animationName} value={animationName}>
+                {animationName}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      <div style={{ display: 'grid', gap: '4px' }}>
+        <span style={{ fontSize: '11px', color: '#999' }}>Background</span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <input
+            type="color"
+            value={settings.backgroundColor ?? '#000000'}
+            onChange={(event) => updateSettings({ backgroundColor: event.target.value })}
+            style={{ width: '32px', height: '24px', padding: 0, border: '1px solid #3a3a3a', borderRadius: '4px', background: 'transparent' }}
+          />
+          <input
+            type="text"
+            value={settings.backgroundColor ?? ''}
+            onChange={(event) => updateSettings({ backgroundColor: cleanBackgroundColor(event.target.value) })}
+            placeholder="transparent"
+            style={{ flex: 1 }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/panels/properties/index.tsx
+++ b/src/components/panels/properties/index.tsx
@@ -6,7 +6,7 @@ import { DEFAULT_TEXT_3D_PROPERTIES } from '../../../stores/timeline/constants';
 import { TextTab } from '../TextTab';
 
 // Tab type
-type PropertiesTab = 'transform' | 'effects' | 'masks' | 'transcript' | 'analysis' | 'text' | '3d-text' | 'blendshapes' | 'gaussian-splat' | 'camera' | 'splat-effector' | 'slot-clip';
+type PropertiesTab = 'transform' | 'effects' | 'masks' | 'transcript' | 'analysis' | 'text' | '3d-text' | 'blendshapes' | 'gaussian-splat' | 'camera' | 'splat-effector' | 'lottie' | 'slot-clip';
 
 // Lazy load tab components for code splitting
 const TransformTab = lazy(() => import('./TransformTab').then(m => ({ default: m.TransformTab })));
@@ -19,6 +19,7 @@ const GaussianSplatTab = lazy(() => import('./GaussianSplatTab').then(m => ({ de
 const CameraTab = lazy(() => import('./CameraTab').then(m => ({ default: m.CameraTab })));
 const SplatEffectorTab = lazy(() => import('./SplatEffectorTab').then(m => ({ default: m.SplatEffectorTab })));
 const ThreeDTextTab = lazy(() => import('./ThreeDTextTab').then(m => ({ default: m.ThreeDTextTab })));
+const LottieTab = lazy(() => import('./LottieTab').then(m => ({ default: m.LottieTab })));
 const SlotClipTab = lazy(() => import('./SlotClipTab').then(m => ({ default: m.SlotClipTab })));
 
 // Tab loading fallback
@@ -66,6 +67,7 @@ export function PropertiesPanel() {
 
   // Check if it's a solid clip
   const isSolidClip = selectedClip?.source?.type === 'solid';
+  const isLottieClip = selectedClip?.source?.type === 'lottie';
   const selectedMeshType = selectedClip?.meshType ?? selectedClip?.source?.meshType;
   const is3DTextClip = selectedClip?.source?.type === 'model' && selectedMeshType === 'text3d';
   const selectedText3DProperties = is3DTextClip
@@ -117,6 +119,8 @@ export function PropertiesPanel() {
       // Set appropriate default tab based on clip type
       if (isGaussianAvatar) {
         setActiveTab('blendshapes');
+      } else if (isLottieClip) {
+        setActiveTab('lottie');
       } else if (isCameraClip) {
         setActiveTab('transform');
       } else if (isSplatEffectorClip) {
@@ -141,13 +145,14 @@ export function PropertiesPanel() {
           (!isGaussianAvatar && activeTab === 'blendshapes') ||
           (!isGaussianSplat && activeTab === 'gaussian-splat') ||
           (!isCameraClip && activeTab === 'camera') ||
-          (!isSplatEffectorClip && activeTab === 'splat-effector')
+          (!isSplatEffectorClip && activeTab === 'splat-effector') ||
+          (!isLottieClip && activeTab === 'lottie')
         )
       ) {
         setActiveTab('transform');
       }
     }
-  }, [selectedClipId, isAudioClip, isTextClip, is3DTextClip, isSolidClip, isGaussianAvatar, isGaussianSplat, isCameraClip, isSplatEffectorClip, isSlotMode, lastClipId, activeTab]);
+  }, [selectedClipId, isAudioClip, isTextClip, is3DTextClip, isSolidClip, isLottieClip, isGaussianAvatar, isGaussianSplat, isCameraClip, isSplatEffectorClip, isSlotMode, lastClipId, activeTab]);
 
   // Listen for external tab navigation requests (e.g. badge clicks in MediaPanel)
   useEffect(() => {
@@ -274,6 +279,11 @@ export function PropertiesPanel() {
           </>
         ) : (
           <>
+            {isLottieClip && (
+              <button className={`tab-btn ${activeTab === 'lottie' ? 'active' : ''}`} onClick={() => setActiveTab('lottie')}>
+                Lottie
+              </button>
+            )}
             <button className={`tab-btn ${activeTab === 'transform' ? 'active' : ''}`} onClick={() => setActiveTab('transform')}>Transform</button>
             {isGaussianAvatar && (
               <button className={`tab-btn ${activeTab === 'blendshapes' ? 'active' : ''}`} onClick={() => setActiveTab('blendshapes')}>
@@ -296,7 +306,7 @@ export function PropertiesPanel() {
             <button className={`tab-btn ${activeTab === 'masks' ? 'active' : ''}`} onClick={() => setActiveTab('masks')}>
               Masks {selectedClip.masks && selectedClip.masks.length > 0 && <span className="badge">{selectedClip.masks.length}</span>}
             </button>
-            {!isSolidClip && (
+            {!isSolidClip && !isLottieClip && (
               <>
                 <button className={`tab-btn ${activeTab === 'transcript' ? 'active' : ''}`} onClick={() => setActiveTab('transcript')}>
                   Transcript {selectedClip.transcript && selectedClip.transcript.length > 0 && <span className="badge">{selectedClip.transcript.length}</span>}
@@ -317,6 +327,9 @@ export function PropertiesPanel() {
           )}
           {activeTab === '3d-text' && is3DTextClip && selectedText3DProperties && (
             <ThreeDTextTab clipId={selectedClip.id} text3DProperties={selectedText3DProperties} />
+          )}
+          {activeTab === 'lottie' && isLottieClip && (
+            <LottieTab clipId={selectedClip.id} />
           )}
           {activeTab === 'transform' && !isAudioClip && <TransformTab clipId={selectedClip.id} transform={transform} speed={interpolatedSpeed} is3D={selectedClip.is3D} hasKeyframes={hasKeyframes} />}
           {activeTab === 'camera' && isCameraClip && <CameraTab clipId={selectedClip.id} />}

--- a/src/components/timeline/TimelineClip.tsx
+++ b/src/components/timeline/TimelineClip.tsx
@@ -8,12 +8,18 @@ import { useMediaStore } from '../../stores/mediaStore';
 import { getLabelHex } from '../panels/MediaPanel';
 // PickWhip disabled
 import { Logger } from '../../services/logger';
+import { shouldLoopVectorAnimation } from '../../types/vectorAnimation';
 import { ClipWaveform } from './components/ClipWaveform';
 import { ClipAnalysisOverlay } from './components/ClipAnalysisOverlay';
 import { FadeCurve } from './components/FadeCurve';
 import { useThumbnailCache } from '../../hooks/useThumbnailCache';
 
 const log = Logger.create('TimelineClip');
+
+function canLoopExtendVectorClip(clip: TimelineClipProps['clip']): boolean {
+  return clip.source?.type === 'lottie' &&
+    shouldLoopVectorAnimation(clip.source.vectorAnimationSettings);
+}
 
 type StaticClipIconKind = 'camera' | 'gaussian-splat' | 'model';
 
@@ -265,6 +271,7 @@ function TimelineClipComponent({
 
   // Determine if this is a solid clip
   const isSolidClip = clip.source?.type === 'solid';
+  const isLottieClip = clip.source?.type === 'lottie';
   const isCameraClip = clip.source?.type === 'camera';
   const isGaussianSplatClip = clip.source?.type === 'gaussian-splat';
   const isSplatEffectorClip = clip.source?.type === 'splat-effector';
@@ -299,6 +306,7 @@ function TimelineClipComponent({
     const deltaTime = pixelToTime(deltaX);
     const sourceType = clip.source?.type;
     const isInfiniteClip = sourceType === 'text' || sourceType === 'image' || sourceType === 'solid' || sourceType === 'camera' || sourceType === 'splat-effector';
+    const canLoopExtendRight = canLoopExtendVectorClip(clip);
     const maxDuration = isInfiniteClip
       ? Number.MAX_SAFE_INTEGER
       : (clip.source?.naturalDuration || clip.duration);
@@ -314,7 +322,9 @@ function TimelineClipComponent({
       // Update inPoint when trimming left edge
       displayInPoint = clipTrim.originalInPoint + clampedDelta;
     } else {
-      const maxExtend = maxDuration - clipTrim.originalOutPoint;
+      const maxExtend = canLoopExtendRight
+        ? Number.MAX_SAFE_INTEGER
+        : maxDuration - clipTrim.originalOutPoint;
       const minTrim = -(clipTrim.originalDuration - 0.1);
       const clampedDelta = Math.max(minTrim, Math.min(maxExtend, deltaTime));
       displayDuration = clipTrim.originalDuration + clampedDelta;
@@ -325,6 +335,7 @@ function TimelineClipComponent({
     // Apply same trim to linked clip visually
     const deltaX = clipTrim.currentX - clipTrim.startX;
     const deltaTime = pixelToTime(deltaX);
+    const canLoopExtendRight = canLoopExtendVectorClip(clip);
     const maxDuration = clip.source?.naturalDuration || clip.duration;
 
     if (clipTrim.edge === 'left') {
@@ -335,7 +346,9 @@ function TimelineClipComponent({
       displayDuration = clip.duration - clampedDelta;
       displayInPoint = clip.inPoint + clampedDelta;
     } else {
-      const maxExtend = maxDuration - clip.outPoint;
+      const maxExtend = canLoopExtendRight
+        ? Number.MAX_SAFE_INTEGER
+        : maxDuration - clip.outPoint;
       const minTrim = -(clip.duration - 0.1);
       const clampedDelta = Math.max(minTrim, Math.min(maxExtend, deltaTime));
       displayDuration = clip.duration + clampedDelta;
@@ -846,6 +859,9 @@ function TimelineClipComponent({
               <span className="clip-text-icon" title={isText3DClip ? '3D Text Clip' : 'Text Clip'}>
                 {isText3DClip ? '3T' : 'T'}
               </span>
+            )}
+            {isLottieClip && (
+              <span className="clip-text-icon" title="Lottie Clip">L</span>
             )}
             {staticClipIconKind && (
               <StaticClipIcon

--- a/src/components/timeline/hooks/useClipDrag.ts
+++ b/src/components/timeline/hooks/useClipDrag.ts
@@ -146,7 +146,7 @@ export function useClipDrag({
         const sourceType = clipForTrackCheck?.source?.type;
         const requiredTrackType: 'video' | 'audio' | null =
           sourceType === 'audio' ? 'audio' :
-          (sourceType === 'video' || sourceType === 'image' || sourceType === 'text' || sourceType === 'solid' || sourceType === 'model' || sourceType === 'gaussian-splat' || sourceType === 'camera' || sourceType === 'splat-effector') ? 'video' :
+          (sourceType === 'video' || sourceType === 'image' || sourceType === 'lottie' || sourceType === 'text' || sourceType === 'solid' || sourceType === 'model' || sourceType === 'gaussian-splat' || sourceType === 'camera' || sourceType === 'splat-effector') ? 'video' :
           null;
 
         let currentY = 24;

--- a/src/components/timeline/hooks/useClipTrim.ts
+++ b/src/components/timeline/hooks/useClipTrim.ts
@@ -3,6 +3,7 @@
 
 import { useState, useCallback, useRef } from 'react';
 import type { TimelineClip } from '../../../types';
+import { shouldLoopVectorAnimation } from '../../../types/vectorAnimation';
 import type { ClipTrimState } from '../types';
 
 interface UseClipTrimProps {
@@ -22,6 +23,11 @@ interface UseClipTrimReturn {
   clipTrim: ClipTrimState | null;
   clipTrimRef: React.MutableRefObject<ClipTrimState | null>;
   handleTrimStart: (e: React.MouseEvent, clipId: string, edge: 'left' | 'right') => void;
+}
+
+function canLoopExtendVectorClip(clip: TimelineClip): boolean {
+  return clip.source?.type === 'lottie' &&
+    shouldLoopVectorAnimation(clip.source.vectorAnimationSettings);
 }
 
 export function useClipTrim({
@@ -96,6 +102,7 @@ export function useClipTrim({
         // Generated clips can be extended infinitely (no natural duration limit)
         const sourceType = clipToTrim.source?.type;
         const isInfiniteClip = sourceType === 'text' || sourceType === 'image' || sourceType === 'solid' || sourceType === 'camera';
+        const canLoopExtendRight = canLoopExtendVectorClip(clipToTrim);
         const maxDuration = isInfiniteClip
           ? Number.MAX_SAFE_INTEGER
           : (clipToTrim.source?.naturalDuration || clipToTrim.duration);
@@ -115,7 +122,9 @@ export function useClipTrim({
           newStartTime = trim.originalStartTime + clampedDelta;
           newInPoint = trim.originalInPoint + clampedDelta;
         } else {
-          const maxExtend = maxDuration - trim.originalOutPoint;
+          const maxExtend = canLoopExtendRight
+            ? Number.MAX_SAFE_INTEGER
+            : maxDuration - trim.originalOutPoint;
           const minTrim = -(trim.originalDuration - 0.1);
           const clampedDelta = Math.max(minTrim, Math.min(maxExtend, deltaTime));
           newOutPoint = trim.originalOutPoint + clampedDelta;
@@ -130,8 +139,11 @@ export function useClipTrim({
         if (!trim.altKey && clipToTrim.linkedClipId) {
           const linkedClip = clipMap.get(clipToTrim.linkedClipId);
           if (linkedClip) {
+            const linkedCanLoopExtendRight = canLoopExtendVectorClip(linkedClip);
             const linkedMaxDuration =
-              linkedClip.source?.naturalDuration || linkedClip.duration;
+              linkedCanLoopExtendRight
+                ? Number.MAX_SAFE_INTEGER
+                : (linkedClip.source?.naturalDuration || linkedClip.duration);
             if (trim.edge === 'left') {
               const linkedNewInPoint = Math.max(
                 0,

--- a/src/components/timeline/hooks/useExternalDrop.ts
+++ b/src/components/timeline/hooks/useExternalDrop.ts
@@ -9,6 +9,7 @@ import {
   isGaussianSplatFile,
   getVideoMetadataQuick,
 } from '../utils/fileTypeHelpers';
+import { classifyMediaType } from '../../../stores/timeline/helpers/mediaTypeHelpers';
 import {
   findClosestNonOverlappingStartTime,
   findFirstTrackWithoutOverlap,
@@ -1112,7 +1113,7 @@ export function useExternalDrop({
         const mediaFile = mediaStore.files.find((f) => f.id === mediaFileId);
         if (mediaFile?.file) {
           // Pass mediaType override for formats that are intentionally clip-typed.
-          const typeOverride = mediaFile.type === 'gaussian-splat'
+          const typeOverride = mediaFile.type === 'gaussian-splat' || mediaFile.type === 'lottie' || mediaFile.type === 'rive'
             ? mediaFile.type
             : undefined;
           addClip(newTrackId, mediaFile.file, startTime, mediaFile.duration, mediaFileId, typeOverride);
@@ -1135,8 +1136,12 @@ export function useExternalDrop({
                 const file = await handle.getFile();
                 if (filePath) (file as any).path = filePath;
                 if (isMediaFile(file)) {
+                  const typeOverride = await classifyMediaType(file);
+                  if (typeOverride === 'unknown') {
+                    return;
+                  }
                   // Add clip immediately for instant visual feedback
-                  addClip(newTrackId, file, startTime, cachedDuration);
+                  addClip(newTrackId, file, startTime, cachedDuration, undefined, typeOverride);
                   // Fire-and-forget media import (loadVideoMedia will pick it up)
                   mediaStore.importFilesWithHandles([{ file, handle, absolutePath: filePath }]);
                   log.debug('Imported file with handle:', { name: file.name, absolutePath: filePath });
@@ -1152,8 +1157,12 @@ export function useExternalDrop({
           const file = item.getAsFile();
           if (file && filePath) (file as any).path = filePath;
           if (file && isMediaFile(file)) {
+            const typeOverride = await classifyMediaType(file);
+            if (typeOverride === 'unknown') {
+              return;
+            }
             // Add clip immediately for instant visual feedback
-            addClip(newTrackId, file, startTime, cachedDuration);
+            addClip(newTrackId, file, startTime, cachedDuration, undefined, typeOverride);
             // Fire-and-forget media import (loadVideoMedia will pick it up)
             mediaStore.importFile(file);
           }
@@ -1261,7 +1270,7 @@ export function useExternalDrop({
           // Video+audio files are allowed on both track types
 
           // Pass mediaType override for formats that are intentionally clip-typed.
-          const typeOverride = mediaFile.type === 'gaussian-splat'
+          const typeOverride = mediaFile.type === 'gaussian-splat' || mediaFile.type === 'lottie' || mediaFile.type === 'rive'
             ? mediaFile.type
             : undefined;
           addClip(trackId, mediaFile.file, resolveDropStartTime(mediaFile.duration), mediaFile.duration, mediaFileId, typeOverride);
@@ -1294,6 +1303,10 @@ export function useExternalDrop({
                 }
                 log.debug('File from handle:', { name: file.name, type: file.type, size: file.size, path: filePath });
                 if (isMediaFile(file)) {
+                  const typeOverride = await classifyMediaType(file);
+                  if (typeOverride === 'unknown') {
+                    return;
+                  }
                   // Audio-only files can only go on audio tracks
                   const fileIsAudio = isAudioFile(file);
                   if (fileIsAudio && isVideoTrack) {
@@ -1302,7 +1315,7 @@ export function useExternalDrop({
                   }
 
                   // Add clip immediately for instant visual feedback
-                  addClip(trackId, file, resolveDropStartTime(cachedDuration), cachedDuration);
+                  addClip(trackId, file, resolveDropStartTime(cachedDuration), cachedDuration, undefined, typeOverride);
                   // Fire-and-forget media import (loadVideoMedia will pick it up)
                   mediaStore.importFilesWithHandles([{ file, handle, absolutePath: filePath }]);
                   log.debug('Imported file with handle:', { name: file.name, absolutePath: filePath });
@@ -1321,6 +1334,10 @@ export function useExternalDrop({
           }
           log.debug('Fallback file:', { name: file?.name, type: file?.type, path: filePath });
           if (file && isMediaFile(file)) {
+            const typeOverride = await classifyMediaType(file);
+            if (typeOverride === 'unknown') {
+              return;
+            }
             // Audio-only files can only go on audio tracks
             const fileIsAudio = isAudioFile(file);
             if (fileIsAudio && isVideoTrack) {
@@ -1329,7 +1346,7 @@ export function useExternalDrop({
             }
 
             // Add clip immediately for instant visual feedback
-            addClip(trackId, file, resolveDropStartTime(cachedDuration), cachedDuration);
+            addClip(trackId, file, resolveDropStartTime(cachedDuration), cachedDuration, undefined, typeOverride);
             // Fire-and-forget media import (loadVideoMedia will pick it up)
             mediaStore.importFile(file);
           }

--- a/src/components/timeline/hooks/useLayerSync.ts
+++ b/src/components/timeline/hooks/useLayerSync.ts
@@ -12,6 +12,7 @@ import { audioManager, audioStatusTracker } from '../../../services/audioManager
 import { Logger } from '../../../services/logger';
 import { getInterpolatedClipTransform } from '../../../utils/keyframeInterpolation';
 import { DEFAULT_TRANSFORM } from '../../../stores/timeline/constants';
+import { lottieRuntimeManager } from '../../../services/vectorAnimation/LottieRuntimeManager';
 
 const log = Logger.create('useLayerSync');
 
@@ -240,6 +241,37 @@ export function useLayerSync({
             source: {
               type: 'image',
               imageElement: nestedClip.source.imageElement,
+            },
+            effects,
+            position: {
+              x: transform.position?.x || 0,
+              y: transform.position?.y || 0,
+              z: transform.position?.z || 0,
+            },
+            scale: {
+              x: transform.scale?.x ?? 1,
+              y: transform.scale?.y ?? 1,
+            },
+            rotation: {
+              x: ((transform.rotation?.x || 0) * Math.PI) / 180,
+              y: ((transform.rotation?.y || 0) * Math.PI) / 180,
+              z: ((transform.rotation?.z || 0) * Math.PI) / 180,
+            },
+          });
+        } else if (nestedClip.source?.textCanvas) {
+          if (nestedClip.source.type === 'lottie') {
+            lottieRuntimeManager.renderClipAtTime(nestedClip, nestedClip.startTime + nestedLocalTime);
+          }
+
+          layers.push({
+            id: `nested-layer-${nestedClip.id}`,
+            name: nestedClip.name,
+            visible: true,
+            opacity: transform.opacity ?? 1,
+            blendMode: transform.blendMode || 'normal',
+            source: {
+              type: 'text',
+              textCanvas: nestedClip.source.textCanvas,
             },
             effects,
             position: {
@@ -759,7 +791,11 @@ export function useLayerSync({
           layersChanged = true;
         }
       } else if (clip?.source?.textCanvas) {
-        // Text/Solid clip handling (both use canvas)
+        if (clip.source.type === 'lottie') {
+          lottieRuntimeManager.renderClipAtTime(clip, playheadPosition);
+        }
+
+        // Text/Solid/Lottie clip handling (all use canvas)
         const textCanvas = clip.source.textCanvas;
         const textClipLocalTime = playheadPosition - clip.startTime;
         const transform = getInterpolatedTransform(clip.id, textClipLocalTime);

--- a/src/components/timeline/utils/fileTypeHelpers.ts
+++ b/src/components/timeline/utils/fileTypeHelpers.ts
@@ -19,6 +19,7 @@ const IMAGE_EXTENSIONS = [
 ];
 
 const GAUSSIAN_SPLAT_EXTENSIONS = ['ply', 'splat'];
+const VECTOR_ANIMATION_EXTENSIONS = ['lottie', 'riv', 'json'];
 
 /**
  * Check if file is a video by MIME type or extension
@@ -62,7 +63,8 @@ export function isMediaFile(file: File): boolean {
     VIDEO_EXTENSIONS.includes(ext) ||
     AUDIO_EXTENSIONS.includes(ext) ||
     IMAGE_EXTENSIONS.includes(ext) ||
-    GAUSSIAN_SPLAT_EXTENSIONS.includes(ext)
+    GAUSSIAN_SPLAT_EXTENSIONS.includes(ext) ||
+    VECTOR_ANIMATION_EXTENSIONS.includes(ext)
   );
 }
 

--- a/src/engine/export/ClipPreparation.ts
+++ b/src/engine/export/ClipPreparation.ts
@@ -15,6 +15,7 @@ import { bindSourceRuntimeForOwner } from '../../services/mediaRuntime/clipBindi
 import { mediaRuntimeRegistry } from '../../services/mediaRuntime/registry';
 import { ParallelDecodeManager } from '../ParallelDecodeManager';
 import type { WebCodecsPlayer } from '../WebCodecsPlayer';
+import { lottieRuntimeManager } from '../../services/vectorAnimation/LottieRuntimeManager';
 
 const log = Logger.create('ClipPreparation');
 const FAST_EXPORT_SINGLE_FILE_LIMIT_BYTES = 1536 * 1024 * 1024; // 1.5 GB
@@ -300,6 +301,29 @@ export async function prepareClipsForExport(
     const clipEnd = clip.startTime + clip.duration;
     return clip.startTime < endTime && clipEnd > startTime;
   });
+
+  const lottieClips: TimelineClip[] = [];
+  for (const clip of videoClips) {
+    if (clip.source?.type === 'lottie') {
+      lottieClips.push(clip);
+    }
+    if (clip.isComposition && clip.nestedClips?.length) {
+      for (const nestedClip of clip.nestedClips) {
+        if (nestedClip.source?.type === 'lottie') {
+          lottieClips.push(nestedClip);
+        }
+      }
+    }
+  }
+
+  if (lottieClips.length > 0) {
+    await Promise.all(lottieClips.map(async (clip) => {
+      if (!clip.file) {
+        return;
+      }
+      await lottieRuntimeManager.prepareClipSource(clip, clip.file);
+    }));
+  }
 
   log.info(`Preparing ${videoClips.length} video clips for ${exportMode.toUpperCase()} export...`);
 

--- a/src/engine/export/ExportLayerBuilder.ts
+++ b/src/engine/export/ExportLayerBuilder.ts
@@ -12,6 +12,7 @@ import { ParallelDecodeManager } from '../ParallelDecodeManager';
 import { getInterpolatedClipTransform } from '../../utils/keyframeInterpolation';
 import { DEFAULT_TEXT_3D_PROPERTIES, DEFAULT_TRANSFORM } from '../../stores/timeline/constants';
 import { DEFAULT_GAUSSIAN_SPLAT_SETTINGS, type GaussianSplatSettings } from '../gaussian/types';
+import { lottieRuntimeManager } from '../../services/vectorAnimation/LottieRuntimeManager';
 
 // Cache video tracks and solo state at export start (don't change during export)
 let cachedVideoTracks: TimelineTrack[] | null = null;
@@ -204,8 +205,11 @@ export function buildLayersAtTime(
         is3D: true,
       });
     }
-    // Handle text and solid clips
-    else if ((clip.source?.type === 'text' || clip.source?.type === 'solid') && clip.source.textCanvas) {
+    // Handle text, solid, and Lottie clips
+    else if ((clip.source?.type === 'text' || clip.source?.type === 'solid' || clip.source?.type === 'lottie') && clip.source.textCanvas) {
+      if (clip.source.type === 'lottie') {
+        lottieRuntimeManager.renderClipAtTime(clip, time);
+      }
       layers.push({
         ...baseLayerProps,
         source: { type: 'text', textCanvas: clip.source.textCanvas },
@@ -549,7 +553,10 @@ function buildNestedLayerForExport(
     } as Layer;
   }
 
-  if ((nestedClip.source?.type === 'text' || nestedClip.source?.type === 'solid') && nestedClip.source.textCanvas) {
+  if ((nestedClip.source?.type === 'text' || nestedClip.source?.type === 'solid' || nestedClip.source?.type === 'lottie') && nestedClip.source.textCanvas) {
+    if (nestedClip.source.type === 'lottie') {
+      lottieRuntimeManager.renderClipAtTime(nestedClip, nestedClip.startTime + nestedClipLocalTime);
+    }
     return {
       ...baseLayer,
       source: { type: 'text', textCanvas: nestedClip.source.textCanvas },

--- a/src/engine/export/VideoEncoderWrapper.ts
+++ b/src/engine/export/VideoEncoderWrapper.ts
@@ -18,6 +18,7 @@ export class VideoEncoderWrapper {
   private audioCodec: AudioCodec = 'aac';
   private containerFormat: ContainerFormat = 'mp4';
   private effectiveVideoCodec: VideoCodec = 'h264';
+  private effectiveBitrateMode: VideoEncoderBitrateMode = 'variable';
 
   constructor(settings: ExportSettings) {
     this.settings = settings;
@@ -43,18 +44,49 @@ export class VideoEncoderWrapper {
 
     // Check codec support
     const codecString = getCodecString(this.effectiveVideoCodec);
+    const requestedBitrateMode: VideoEncoderBitrateMode =
+      this.settings.rateControl === 'cbr' ? 'constant' : 'variable';
+    const supportCheckConfig = {
+      codec: codecString,
+      width: this.settings.width,
+      height: this.settings.height,
+      bitrate: this.settings.bitrate,
+      framerate: this.settings.fps,
+    };
     try {
-      const support = await VideoEncoder.isConfigSupported({
-        codec: codecString,
-        width: this.settings.width,
-        height: this.settings.height,
-        bitrate: this.settings.bitrate,
-        framerate: this.settings.fps,
+      const requestedSupport = await VideoEncoder.isConfigSupported({
+        ...supportCheckConfig,
+        bitrateMode: requestedBitrateMode,
       });
 
-      if (!support.supported) {
-        log.error(`Codec not supported: ${codecString}`);
-        return false;
+      this.effectiveBitrateMode = requestedBitrateMode;
+
+      if (!requestedSupport.supported) {
+        if (requestedBitrateMode !== 'constant') {
+          log.error(`Codec not supported: ${codecString}`);
+          return false;
+        }
+
+        log.warn('Constant bitrate support check failed for this encoder config, will try configure() and fall back to variable if needed');
+
+        const fallbackSupport = await VideoEncoder.isConfigSupported({
+          ...supportCheckConfig,
+          bitrateMode: 'variable',
+        });
+        if (!fallbackSupport.supported) {
+          this.effectiveBitrateMode = 'variable';
+          log.error(`Codec not supported: ${codecString}`);
+          return false;
+        }
+      } else if (requestedBitrateMode === 'constant') {
+        const fallbackSupport = await VideoEncoder.isConfigSupported({
+          ...supportCheckConfig,
+          bitrateMode: 'variable',
+        });
+        if (!fallbackSupport.supported) {
+          log.error(`Codec not supported: ${codecString}`);
+          return false;
+        }
       }
     } catch (e) {
       log.error('Codec support check failed:', e);
@@ -78,17 +110,28 @@ export class VideoEncoderWrapper {
       },
     });
 
-    await this.encoder.configure({
-      codec: codecString,
-      width: this.settings.width,
-      height: this.settings.height,
-      bitrate: this.settings.bitrate,
-      framerate: this.settings.fps,
+    const buildEncoderConfig = (bitrateMode: VideoEncoderBitrateMode): VideoEncoderConfig => ({
+      ...supportCheckConfig,
       latencyMode: 'quality',
-      bitrateMode: 'variable',
+      bitrateMode,
     });
 
-    log.info(`Initialized: ${this.settings.width}x${this.settings.height} @ ${this.settings.fps}fps (${this.effectiveVideoCodec.toUpperCase()})`);
+    try {
+      this.encoder.configure(buildEncoderConfig(requestedBitrateMode));
+      this.effectiveBitrateMode = requestedBitrateMode;
+    } catch (error) {
+      if (requestedBitrateMode !== 'constant') {
+        throw error;
+      }
+
+      log.warn('Constant bitrate configure() failed, falling back to variable bitrate', error);
+      this.encoder.configure(buildEncoderConfig('variable'));
+      this.effectiveBitrateMode = 'variable';
+    }
+
+    log.info(
+      `Initialized: ${this.settings.width}x${this.settings.height} @ ${this.settings.fps}fps (${this.effectiveVideoCodec.toUpperCase()}, ${(this.settings.bitrate / 1_000_000).toFixed(1)} Mbps, ${this.effectiveBitrateMode})`
+    );
     return true;
   }
 

--- a/src/engine/export/types.ts
+++ b/src/engine/export/types.ts
@@ -19,6 +19,7 @@ export interface ExportSettings {
   codec: VideoCodec;
   container: ContainerFormat;
   bitrate: number;
+  rateControl?: 'vbr' | 'cbr';
   startTime: number;
   endTime: number;
   // Audio settings

--- a/src/engine/structuralSharing/types.ts
+++ b/src/engine/structuralSharing/types.ts
@@ -1,6 +1,6 @@
 // Structural Sharing types — efficient undo/redo snapshots
 
-import type { TimelineClip, TimelineTrack, Keyframe } from '../../types/index.ts';
+import type { TimelineClip, TimelineTrack, Keyframe, SerializableClip } from '../../types/index.ts';
 import type { TimelineMarker } from '../../stores/timeline/types.ts';
 
 /**
@@ -15,7 +15,7 @@ export interface SerializedClipState {
   duration: number;
   inPoint: number;
   outPoint: number;
-  sourceType: 'video' | 'audio' | 'image' | 'text' | 'solid' | 'model' | 'camera' | 'gaussian-avatar' | 'gaussian-splat' | 'splat-effector';
+  sourceType: SerializableClip['sourceType'];
   mediaFileId?: string;
   transform: TimelineClip['transform'];
   effects: TimelineClip['effects'];

--- a/src/engine/texture/TextureManager.ts
+++ b/src/engine/texture/TextureManager.ts
@@ -4,6 +4,10 @@ import { Logger } from '../../services/logger';
 
 const log = Logger.create('TextureManager');
 
+function isDynamicCanvas(canvas: HTMLCanvasElement): boolean {
+  return Boolean(canvas.dataset.masterselectsDynamic);
+}
+
 export class TextureManager {
   private device: GPUDevice;
 
@@ -71,7 +75,17 @@ export class TextureManager {
 
     // Check cache first
     const cached = this.canvasTextures.get(canvas);
-    if (cached) return cached;
+    if (cached) {
+      if (!isDynamicCanvas(canvas)) {
+        return cached;
+      }
+
+      if (this.updateCanvasTexture(canvas)) {
+        return cached;
+      }
+
+      this.removeCanvasTexture(canvas);
+    }
 
     try {
       const texture = this.device.createTexture({

--- a/src/hooks/useGlobalHistory.ts
+++ b/src/hooks/useGlobalHistory.ts
@@ -5,6 +5,7 @@ import { useTimelineStore } from '../stores/timeline';
 import { useMediaStore } from '../stores/mediaStore';
 import { useDockStore } from '../stores/dockStore';
 import { useFlashBoardStore } from '../stores/flashboardStore';
+import { useExportStore } from '../stores/exportStore';
 import type {
   FlashBoard,
   FlashBoardComposerState,
@@ -107,6 +108,10 @@ export function useGlobalHistory() {
       flashboard: {
         getState: useFlashBoardStore.getState,
         setState: useFlashBoardStore.setState,
+      },
+      export: {
+        getState: useExportStore.getState,
+        setState: useExportStore.setState,
       },
     });
 
@@ -251,6 +256,26 @@ export function useGlobalHistory() {
       { equalityFn: shallowEqual, fireImmediately: false }
     );
 
+    const unsubExport = useExportStore.subscribe(
+      (state) => ({
+        settings: state.settings,
+        presets: state.presets,
+        selectedPresetId: state.selectedPresetId,
+      }),
+      (curr, prev) => {
+        if (useHistoryStore.getState().isApplying) return;
+
+        if (curr.presets !== prev.presets) {
+          debouncedCapture('Modify export presets');
+        } else if (curr.selectedPresetId !== prev.selectedPresetId) {
+          debouncedCapture('Select export preset');
+        } else if (curr.settings !== prev.settings) {
+          debouncedCapture('Modify export settings');
+        }
+      },
+      { equalityFn: shallowEqual, fireImmediately: false }
+    );
+
     return () => {
       if (pendingTimer.current) {
         clearTimeout(pendingTimer.current);
@@ -260,6 +285,7 @@ export function useGlobalHistory() {
       unsubMedia();
       unsubDock();
       unsubFlashBoard();
+      unsubExport();
     };
   }, []);
 

--- a/src/services/compositionRenderer.ts
+++ b/src/services/compositionRenderer.ts
@@ -24,15 +24,17 @@ import {
   updateRuntimePlaybackTime,
 } from './mediaRuntime/runtimePlayback';
 import { mediaRuntimeRegistry } from './mediaRuntime/registry';
+import { lottieRuntimeManager } from './vectorAnimation/LottieRuntimeManager';
 
 type CompositionClipSourceEntry = {
   clipId: string;
-  type: 'video' | 'image' | 'audio' | 'text';
+  type: 'video' | 'image' | 'audio' | 'text' | 'lottie';
   videoElement?: HTMLVideoElement;
   webCodecsPlayer?: LayerSource['webCodecsPlayer'];
   imageElement?: HTMLImageElement;
   textCanvas?: HTMLCanvasElement;
   file?: File;
+  lottieClip?: TimelineClip;
   naturalDuration: number;
   runtimeSourceId?: string;
   runtimeSessionKey?: string;
@@ -105,6 +107,29 @@ class CompositionRendererService {
       type: 'text',
       textCanvas: entry.textCanvas,
     };
+  }
+
+  private buildSerializableLottieClip(clip: SerializableClip, file: File): TimelineClip {
+    return {
+      id: clip.id,
+      trackId: clip.trackId,
+      name: clip.name,
+      file,
+      startTime: clip.startTime,
+      duration: clip.duration,
+      inPoint: clip.inPoint,
+      outPoint: clip.outPoint,
+      source: {
+        type: 'lottie',
+        mediaFileId: clip.mediaFileId,
+        naturalDuration: clip.naturalDuration ?? clip.duration,
+        vectorAnimationSettings: clip.vectorAnimationSettings,
+      },
+      effects: clip.effects || [],
+      transform: clip.transform,
+      reversed: clip.reversed,
+      isLoading: false,
+    } as TimelineClip;
   }
 
   private buildBackgroundVideoLayerSource(
@@ -281,12 +306,13 @@ class CompositionRendererService {
           continue;
         }
 
-        if (sourceType === 'text' && timelineClip.source.textCanvas) {
+        if ((sourceType === 'text' || sourceType === 'lottie') && timelineClip.source.textCanvas) {
           sources.clipSources.set(clip.id, {
             clipId: clip.id,
-            type: 'text',
+            type: sourceType,
             textCanvas: timelineClip.source.textCanvas,
             naturalDuration: clip.duration,
+            ...(sourceType === 'lottie' ? { lottieClip: timelineClip } : {}),
           });
           continue;
         }
@@ -324,12 +350,13 @@ class CompositionRendererService {
                 timelineClip.source
               ),
             });
-          } else if (sourceType === 'text' && timelineClip.source.textCanvas) {
+          } else if ((sourceType === 'text' || sourceType === 'lottie') && timelineClip.source.textCanvas) {
             sources.clipSources.set(clip.id, {
               clipId: clip.id,
-              type: 'text',
+              type: sourceType,
               textCanvas: timelineClip.source.textCanvas,
               naturalDuration: clip.duration,
+              ...(sourceType === 'lottie' ? { lottieClip: timelineClip } : {}),
             });
           }
         }
@@ -368,6 +395,8 @@ class CompositionRendererService {
         loadPromises.push(this.loadVideoSource(sources, serializableClip, mediaFile.file));
       } else if (sourceType === 'image') {
         loadPromises.push(this.loadImageSource(sources, serializableClip, mediaFile.file));
+      } else if (sourceType === 'lottie') {
+        loadPromises.push(this.loadLottieSource(sources, serializableClip, mediaFile.file));
       }
     }
 
@@ -483,6 +512,29 @@ class CompositionRendererService {
         resolve();
       };
     });
+  }
+
+  private async loadLottieSource(sources: CompositionSources, clip: SerializableClip, file: File): Promise<void> {
+    try {
+      const lottieClip = this.buildSerializableLottieClip(clip, file);
+      const runtime = await lottieRuntimeManager.prepareClipSource(lottieClip, file);
+      lottieClip.source = {
+        ...lottieClip.source!,
+        textCanvas: runtime.canvas,
+        naturalDuration: runtime.metadata.duration ?? clip.naturalDuration ?? clip.duration,
+      };
+
+      sources.clipSources.set(clip.id, {
+        clipId: clip.id,
+        type: 'lottie',
+        textCanvas: runtime.canvas,
+        file,
+        lottieClip,
+        naturalDuration: runtime.metadata.duration ?? clip.naturalDuration ?? clip.duration,
+      });
+    } catch (error) {
+      log.error(`Failed to load lottie: ${file.name}`, error);
+    }
   }
 
   /**
@@ -602,6 +654,18 @@ class CompositionRendererService {
         );
       } else if (source.imageElement) {
         layerSource = this.getBaseLayerSource(source);
+      } else if (source.type === 'lottie') {
+        const runtimeClip =
+          isActiveComp && timelineClip.source?.type === 'lottie'
+            ? timelineClip
+            : source.lottieClip;
+        if (runtimeClip) {
+          lottieRuntimeManager.renderClipAtTime(runtimeClip, time);
+          layerSource = {
+            type: 'text',
+            textCanvas: runtimeClip.source?.textCanvas ?? source.textCanvas,
+          };
+        }
       } else if (source.textCanvas) {
         layerSource = this.getBaseLayerSource(source);
       }
@@ -761,6 +825,9 @@ class CompositionRendererService {
           },
         } as Layer);
       } else if (nestedClip.source?.textCanvas) {
+        if (nestedClip.source.type === 'lottie') {
+          lottieRuntimeManager.renderClipAtTime(nestedClip, nestedTime);
+        }
         nestedLayers.push({
           ...baseLayer,
           source: {

--- a/src/services/layerBuilder/LayerBuilderService.ts
+++ b/src/services/layerBuilder/LayerBuilderService.ts
@@ -26,6 +26,7 @@ import { useTimelineStore } from '../../stores/timeline';
 import { useMediaStore } from '../../stores/mediaStore';
 import { DEFAULT_TRANSFORM, MAX_NESTING_DEPTH } from '../../stores/timeline/constants';
 import { prewarmGaussianSplatRuntime } from '../../engine/three/splatRuntimeCache';
+import { lottieRuntimeManager } from '../vectorAnimation/LottieRuntimeManager';
 
 const log = Logger.create('LayerBuilder');
 
@@ -175,6 +176,7 @@ export class LayerBuilderService {
   buildLayersFromStore(): Layer[] {
     // Create frame context (single store read)
     const ctx = createFrameContext();
+    this.syncActiveLottieClips(ctx);
     const { activeLayerSlots = {}, activeCompositionId } = useMediaStore.getState();
     const slotGridActive = useTimelineStore.getState().slotGridProgress > 0.5;
     const hasActiveLayerSlots = Object.keys(activeLayerSlots).length > 0;
@@ -240,6 +242,34 @@ export class LayerBuilderService {
 
     // Merge background layers from active layer slots
     return this.mergeBackgroundLayers(primaryLayers, ctx.playheadPosition);
+  }
+
+  private collectKnownClipIds(clips: TimelineClip[]): string[] {
+    const ids: string[] = [];
+    const visit = (clip: TimelineClip) => {
+      ids.push(clip.id);
+      if (clip.nestedClips?.length) {
+        for (const nestedClip of clip.nestedClips) {
+          visit(nestedClip);
+        }
+      }
+    };
+
+    for (const clip of clips) {
+      visit(clip);
+    }
+
+    return ids;
+  }
+
+  private syncActiveLottieClips(ctx: FrameContext): void {
+    for (const clip of ctx.clipsAtTime) {
+      if (clip.source?.type === 'lottie') {
+        lottieRuntimeManager.renderClipAtTime(clip, ctx.playheadPosition);
+      }
+    }
+
+    lottieRuntimeManager.pruneClipRuntimes(this.collectKnownClipIds(ctx.clips));
   }
 
   /**
@@ -406,6 +436,13 @@ export class LayerBuilderService {
     // Image clip
     else if (clip.source?.imageElement) {
       layer = this.buildImageLayer(clip, layerIndex, ctx, opacityOverride);
+    }
+    // Lottie/vector canvas-backed clip
+    else if (clip.source?.type === 'lottie') {
+      lottieRuntimeManager.renderClipAtTime(clip, ctx.playheadPosition);
+      if (clip.source?.textCanvas) {
+        layer = this.buildTextLayer(clip, layerIndex, ctx, opacityOverride);
+      }
     }
     // Text clip
     else if (clip.source?.textCanvas) {
@@ -1225,6 +1262,14 @@ export class LayerBuilderService {
         ...baseLayer,
         source: { type: 'image', imageElement: nestedClip.source.imageElement },
       } as Layer;
+    } else if (nestedClip.source?.type === 'lottie') {
+      lottieRuntimeManager.renderClipAtTime(nestedClip, nestedClip.startTime + nestedClipLocalTime);
+      if (nestedClip.source?.textCanvas) {
+        return {
+          ...baseLayer,
+          source: { type: 'text', textCanvas: nestedClip.source.textCanvas },
+        } as Layer;
+      }
     } else if (nestedClip.source?.type === 'model') {
       return {
         ...baseLayer,

--- a/src/services/layerPlaybackManager.ts
+++ b/src/services/layerPlaybackManager.ts
@@ -16,6 +16,7 @@ import {
 import { flags } from '../engine/featureFlags';
 import { Logger } from './logger';
 import { slotDeckManager } from './slotDeckManager';
+import { lottieRuntimeManager } from './vectorAnimation/LottieRuntimeManager';
 
 const log = Logger.create('LayerPlayback');
 
@@ -122,11 +123,12 @@ class LayerPlaybackManager {
     const hydratedClips: TimelineClip[] = [];
 
     for (const serializedClip of timelineData.clips) {
+      const mediaFile = files.find(f => f.id === serializedClip.mediaFileId);
       const clip: TimelineClip = {
         id: serializedClip.id,
         trackId: serializedClip.trackId,
         name: serializedClip.name,
-        file: null as any,
+        file: (mediaFile?.file ?? null) as any,
         startTime: serializedClip.startTime,
         duration: serializedClip.duration,
         inPoint: serializedClip.inPoint,
@@ -141,8 +143,6 @@ class LayerPlaybackManager {
         masks: serializedClip.masks,
       };
 
-      // Find media file
-      const mediaFile = files.find(f => f.id === serializedClip.mediaFileId);
       if (!mediaFile && !serializedClip.isComposition) {
         // Can't load without media file (unless it's a nested comp)
         clip.isLoading = false;
@@ -162,6 +162,15 @@ class LayerPlaybackManager {
       } else if (sourceType === 'image' && fileUrl) {
         clip.isLoading = true;
         this.loadImageForClip(clip, layerIndex, fileUrl);
+      } else if (sourceType === 'lottie' && mediaFile?.file) {
+        clip.isLoading = true;
+        clip.source = {
+          type: 'lottie',
+          mediaFileId: serializedClip.mediaFileId,
+          naturalDuration: serializedClip.naturalDuration,
+          vectorAnimationSettings: serializedClip.vectorAnimationSettings,
+        };
+        this.loadLottieForClip(clip, mediaFile.file);
       } else {
         clip.isLoading = false;
       }
@@ -215,6 +224,9 @@ class LayerPlaybackManager {
         clip.source.audioElement.pause();
         clip.source.audioElement.src = '';
         clip.source.audioElement.load();
+      }
+      if (clip.source?.type === 'lottie') {
+        lottieRuntimeManager.destroyClipRuntime(clip.id);
       }
       if (clip.source?.runtimeSourceId && clip.source.runtimeSessionKey) {
         mediaRuntimeRegistry.releaseSession(
@@ -528,6 +540,9 @@ class LayerPlaybackManager {
 
       // Build transform
       const transform = clip.transform || DEFAULT_TRANSFORM;
+      if (clip.source?.type === 'lottie') {
+        lottieRuntimeManager.renderClipAtTime(clip, time);
+      }
       const clipTime = clip.reversed
         ? clip.outPoint - clipLocalTime
         : clipLocalTime + clip.inPoint;
@@ -792,6 +807,38 @@ class LayerPlaybackManager {
       clip.isLoading = false;
       log.warn(`Failed to load image for background clip ${clip.name}`);
     }, { once: true });
+  }
+
+  private loadLottieForClip(clip: TimelineClip, file: File): void {
+    void (async () => {
+      try {
+        if (clip.source?.type !== 'lottie') {
+          clip.source = {
+            type: 'lottie',
+            mediaFileId: clip.mediaFileId,
+            naturalDuration: clip.duration,
+          };
+        }
+        const runtime = await lottieRuntimeManager.prepareClipSource(clip, file);
+        const naturalDuration =
+          runtime.metadata.duration ??
+          clip.source?.naturalDuration ??
+          clip.duration;
+        clip.file = file;
+        clip.source = {
+          type: 'lottie',
+          textCanvas: runtime.canvas,
+          mediaFileId: clip.mediaFileId,
+          naturalDuration,
+          vectorAnimationSettings: clip.source?.vectorAnimationSettings,
+        };
+        clip.isLoading = false;
+        lottieRuntimeManager.renderClipAtTime(clip, clip.startTime);
+      } catch (error) {
+        clip.isLoading = false;
+        log.warn(`Failed to load lottie for background clip ${clip.name}`, error);
+      }
+    })();
   }
 }
 

--- a/src/services/project/domains/RawMediaService.ts
+++ b/src/services/project/domains/RawMediaService.ts
@@ -164,9 +164,11 @@ export class RawMediaService {
     const id = `media-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 
     // Determine file type
-    let type: 'video' | 'audio' | 'image' = 'video';
+    let type: 'video' | 'audio' | 'image' | 'lottie' | 'rive' = 'video';
     if (file.type.startsWith('audio/')) type = 'audio';
     else if (file.type.startsWith('image/')) type = 'image';
+    else if (file.name.toLowerCase().endsWith('.lottie')) type = 'lottie';
+    else if (file.name.toLowerCase().endsWith('.riv')) type = 'rive';
 
     // Get source path (if available from File System Access API)
     let sourcePath = file.name;

--- a/src/services/project/projectLifecycle.ts
+++ b/src/services/project/projectLifecycle.ts
@@ -7,6 +7,7 @@ import { useYouTubeStore } from '../../stores/youtubeStore';
 import { useDockStore } from '../../stores/dockStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useFlashBoardStore } from '../../stores/flashboardStore';
+import { useExportStore } from '../../stores/exportStore';
 import { projectFileService } from '../projectFileService';
 import { isProjectStoreSyncInProgress, syncStoresToProject, saveCurrentProject } from './projectSave';
 import { loadProjectToStores } from './projectLoad';
@@ -158,6 +159,7 @@ export function closeCurrentProject(): void {
       referenceMediaFileIds: [],
     },
   });
+  useExportStore.getState().reset();
   useMediaStore.getState().newProject();
 }
 
@@ -207,6 +209,16 @@ export function setupAutoSync(): void {
 
   useFlashBoardStore.subscribe(
     (state) => [state.boards, state.activeBoardId],
+    () => {
+      if (projectFileService.isProjectOpen() && !isProjectStoreSyncInProgress()) {
+        projectFileService.markDirty();
+        triggerContinuousSaveIfEnabled();
+      }
+    }
+  );
+
+  useExportStore.subscribe(
+    (state) => [state.settings, state.presets, state.selectedPresetId],
     () => {
       if (projectFileService.isProjectOpen() && !isProjectStoreSyncInProgress()) {
         projectFileService.markDirty();

--- a/src/services/project/projectLoad.ts
+++ b/src/services/project/projectLoad.ts
@@ -32,6 +32,7 @@ import {
   getStoredProjectFileHandle,
 } from './mediaSourceResolver';
 import { fromProjectTransform } from './transformSerialization';
+import { lottieRuntimeManager } from '../vectorAnimation/LottieRuntimeManager';
 
 const log = Logger.create('ProjectSync');
 
@@ -216,6 +217,7 @@ async function convertProjectMediaToStore(projectMedia: ProjectMediaFile[]): Pro
       hasFileHandle: !!handle,
       filePath: pm.sourcePath,
       projectPath: resolvedProjectPath,
+      vectorAnimation: pm.vectorAnimation,
       labelColor: pm.labelColor as import('../../stores/mediaStore/types').LabelColor | undefined,
       transcriptStatus,
       transcript,
@@ -296,6 +298,7 @@ function convertProjectCompositionToStore(
         text3DProperties: c.text3DProperties,
         // Solid clip support
         solidColor: c.solidColor,
+        vectorAnimationSettings: c.vectorAnimationSettings,
         // 3D layer support
         is3D: c.is3D,
         // Transcript data
@@ -568,6 +571,7 @@ async function refreshMediaMetadata(): Promise<void> {
   const mediaState = useMediaStore.getState();
   // Refresh files that have a file object but are missing important metadata
   const filesToRefresh = mediaState.files.filter(f =>
+    (f.type === 'video' || f.type === 'audio' || f.type === 'image') &&
     f.file && (
       f.codec === undefined ||
       f.container === undefined ||
@@ -590,8 +594,6 @@ async function refreshMediaMetadata(): Promise<void> {
 
     await Promise.all(batch.map(async (mediaFile) => {
       if (!mediaFile.file) return;
-      // Skip 3D models — they have no video/audio metadata
-      if (mediaFile.type === 'model') return;
 
       try {
         const info = await getMediaInfo(mediaFile.file, mediaFile.type as 'video' | 'audio' | 'image');
@@ -862,17 +864,61 @@ async function reloadNestedCompositionClips(): Promise<void> {
         inPoint: nestedSerializedClip.inPoint,
         outPoint: nestedSerializedClip.outPoint,
         source: null,
+        mediaFileId: nestedSerializedClip.mediaFileId,
         thumbnails: nestedSerializedClip.thumbnails,
         transform: nestedSerializedClip.transform,
         effects: nestedSerializedClip.effects || [],
         masks: nestedSerializedClip.masks || [],
+        reversed: nestedSerializedClip.reversed,
+        speed: nestedSerializedClip.speed,
+        preservesPitch: nestedSerializedClip.preservesPitch,
         isLoading: true,
       };
 
       nestedClips.push(nestedClip);
 
-      // Load the video/audio/image element
       const sourceType = nestedSerializedClip.sourceType;
+      const notifyNestedReload = () => {
+        useTimelineStore.setState((state) => ({
+          clips: [...state.clips],
+        }));
+      };
+
+      if (sourceType === 'lottie') {
+        try {
+          nestedClip.source = {
+            type: 'lottie',
+            mediaFileId: nestedSerializedClip.mediaFileId,
+            naturalDuration: nestedSerializedClip.naturalDuration,
+            vectorAnimationSettings: nestedSerializedClip.vectorAnimationSettings,
+          };
+          const runtime = await lottieRuntimeManager.prepareClipSource(nestedClip, nestedMediaFile.file);
+          const naturalDuration =
+            runtime.metadata.duration ??
+            nestedSerializedClip.naturalDuration ??
+            nestedSerializedClip.duration;
+
+          nestedClip.source = {
+            type: 'lottie',
+            textCanvas: runtime.canvas,
+            mediaFileId: nestedSerializedClip.mediaFileId,
+            naturalDuration,
+            vectorAnimationSettings: nestedSerializedClip.vectorAnimationSettings,
+          };
+          nestedClip.isLoading = false;
+          lottieRuntimeManager.renderClipAtTime(nestedClip, nestedClip.startTime);
+          notifyNestedReload();
+        } catch (error) {
+          nestedClip.isLoading = false;
+          log.warn('Failed to reload nested lottie clip', {
+            compClipId: compClip.id,
+            nestedClipId: nestedClip.id,
+            error,
+          });
+        }
+        continue;
+      }
+
       const fileUrl = URL.createObjectURL(nestedMediaFile.file);
 
       if (sourceType === 'video') {
@@ -892,8 +938,7 @@ async function reloadNestedCompositionClips(): Promise<void> {
           nestedClip.isLoading = false;
 
           // Trigger state update
-          const currentClips = timelineStore.clips;
-          useTimelineStore.setState({ clips: [...currentClips] });
+          notifyNestedReload();
 
           // Pre-cache frame via createImageBitmap for immediate scrubbing without play()
           engine.preCacheVideoFrame(video);
@@ -913,8 +958,7 @@ async function reloadNestedCompositionClips(): Promise<void> {
           };
           nestedClip.isLoading = false;
 
-          const currentClips = timelineStore.clips;
-          useTimelineStore.setState({ clips: [...currentClips] });
+          notifyNestedReload();
         }, { once: true });
 
         audio.load();
@@ -930,8 +974,7 @@ async function reloadNestedCompositionClips(): Promise<void> {
           };
           nestedClip.isLoading = false;
 
-          const currentClips = timelineStore.clips;
-          useTimelineStore.setState({ clips: [...currentClips] });
+          notifyNestedReload();
         }, { once: true });
       }
     }

--- a/src/services/project/projectLoad.ts
+++ b/src/services/project/projectLoad.ts
@@ -11,6 +11,7 @@ import { useYouTubeStore } from '../../stores/youtubeStore';
 import { useDockStore } from '../../stores/dockStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useFlashBoardStore } from '../../stores/flashboardStore';
+import { useExportStore } from '../../stores/exportStore';
 import { flashBoardMediaBridge } from '../flashboard/FlashBoardMediaBridge';
 import type {
   FlashBoard,
@@ -545,6 +546,8 @@ export async function loadProjectToStores(): Promise<void> {
       useSettingsStore.setState(changelogSettings);
     }
   }
+
+  useExportStore.getState().hydrateFromProject(projectData.uiState?.exportState);
 
   // Reload API keys (may have been restored from .keys.enc during loadProject)
   await useSettingsStore.getState().loadApiKeys();

--- a/src/services/project/projectSave.ts
+++ b/src/services/project/projectSave.ts
@@ -43,7 +43,7 @@ function convertMediaFiles(files: MediaFile[]): ProjectMediaFile[] {
   return files.map((file) => ({
     id: file.id,
     name: file.name,
-    type: file.type as 'video' | 'audio' | 'image',
+    type: file.type as 'video' | 'audio' | 'image' | 'lottie' | 'rive',
     sourcePath: file.filePath || file.name,
     projectPath: file.projectPath,
     duration: file.duration,
@@ -57,6 +57,7 @@ function convertMediaFiles(files: MediaFile[]): ProjectMediaFile[] {
     fileSize: file.fileSize,
     hasAudio: file.hasAudio,
     hasProxy: file.proxyStatus === 'ready',
+    vectorAnimation: file.vectorAnimation,
     folderId: file.parentId,
     labelColor: file.labelColor && file.labelColor !== 'none' ? file.labelColor : undefined,
     importedAt: new Date(file.createdAt).toISOString(),
@@ -152,6 +153,7 @@ function convertCompositions(compositions: Composition[]): ProjectComposition[] 
       textProperties: c.textProperties || undefined,
       // Solid clip support
       solidColor: c.solidColor || undefined,
+      vectorAnimationSettings: c.source?.vectorAnimationSettings || c.vectorAnimationSettings || undefined,
       // Transcript data
       transcript: c.transcript || undefined,
       transcriptStatus: c.transcriptStatus || undefined,

--- a/src/services/project/projectSave.ts
+++ b/src/services/project/projectSave.ts
@@ -7,6 +7,7 @@ import { useYouTubeStore } from '../../stores/youtubeStore';
 import { useDockStore } from '../../stores/dockStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useFlashBoardStore } from '../../stores/flashboardStore';
+import { getExportStoreData, useExportStore } from '../../stores/exportStore';
 import type {
   FlashBoardGenerationMetadata,
   FlashBoardStoreState,
@@ -347,6 +348,7 @@ export async function syncStoresToProject(): Promise<void> {
         showTranscriptMarkers: timelineState.showTranscriptMarkers,
         showChangelogOnStartup: settingsState.showChangelogOnStartup,
         lastSeenChangelogVersion: settingsState.lastSeenChangelogVersion,
+        exportState: getExportStoreData(useExportStore.getState()),
       };
 
       // Save generated media items

--- a/src/services/project/types/composition.types.ts
+++ b/src/services/project/types/composition.types.ts
@@ -5,6 +5,7 @@ import type { MeshPrimitiveType, SceneCameraSettings } from '../../../stores/med
 import type { GaussianSplatSettings } from '../../../engine/gaussian/types';
 import type { SplatEffectorSettings } from '../../../types/splatEffector';
 import type { Text3DProperties } from '../../../types';
+import type { VectorAnimationClipSettings } from '../../../types/vectorAnimation';
 
 export interface ProjectTrack {
   id: string;
@@ -60,7 +61,7 @@ export interface ProjectClip {
   compositionId?: string;
 
   // Additional clip metadata (for restoration)
-  sourceType?: 'video' | 'audio' | 'image' | 'text' | 'solid' | 'model' | 'camera' | 'gaussian-avatar' | 'gaussian-splat' | 'splat-effector';
+  sourceType?: 'video' | 'audio' | 'image' | 'text' | 'solid' | 'model' | 'camera' | 'gaussian-avatar' | 'gaussian-splat' | 'splat-effector' | 'lottie' | 'rive';
   naturalDuration?: number;
   linkedClipId?: string;
   linkedGroupId?: string;
@@ -79,6 +80,8 @@ export interface ProjectClip {
 
   // Solid clip support
   solidColor?: string;
+
+  vectorAnimationSettings?: VectorAnimationClipSettings;
 
   // Transcript data
   transcript?: any[];

--- a/src/services/project/types/media.types.ts
+++ b/src/services/project/types/media.types.ts
@@ -1,9 +1,11 @@
 // Media-related types
 
+import type { VectorAnimationMetadata } from '../../../types/vectorAnimation';
+
 export interface ProjectMediaFile {
   id: string;
   name: string;
-  type: 'video' | 'audio' | 'image';
+  type: 'video' | 'audio' | 'image' | 'lottie' | 'rive';
 
   // Path to original file (absolute or relative to Raw/)
   sourcePath: string;
@@ -25,6 +27,8 @@ export interface ProjectMediaFile {
 
   // Proxy status
   hasProxy: boolean;
+
+  vectorAnimation?: VectorAnimationMetadata;
 
   // Folder organization
   folderId: string | null;

--- a/src/services/project/types/project.types.ts
+++ b/src/services/project/types/project.types.ts
@@ -5,6 +5,7 @@ import type { ProjectComposition } from './composition.types';
 import type { ProjectFolder } from './folder.types';
 import type { DockLayout } from '../../../types/dock';
 import type { ProjectFlashBoardState } from '../../../stores/flashboardStore/types';
+import type { ExportStoreData } from '../../../stores/exportStore';
 
 export interface ProjectYouTubeVideo {
   id: string;
@@ -53,6 +54,7 @@ export interface ProjectUIState {
   showTranscriptMarkers?: boolean;
   showChangelogOnStartup?: boolean;
   lastSeenChangelogVersion?: string | null;
+  exportState?: ExportStoreData;
 }
 
 export interface ProjectFile {

--- a/src/services/projectDB.ts
+++ b/src/services/projectDB.ts
@@ -40,7 +40,7 @@ export interface StoredThumbnail {
 export interface StoredMediaFile {
   id: string;
   name: string;
-  type: 'video' | 'audio' | 'image';
+  type: 'video' | 'audio' | 'image' | 'lottie' | 'rive';
   // No longer storing blob - only metadata and file hash for deduplication
   fileHash?: string; // SHA-256 hash for proxy/thumbnail deduplication
   duration?: number;

--- a/src/services/slotDeckManager.ts
+++ b/src/services/slotDeckManager.ts
@@ -6,6 +6,7 @@ import { useMediaStore } from '../stores/mediaStore';
 import { DEFAULT_TRANSFORM } from '../stores/timeline/constants';
 import { bindSourceRuntimeForOwner } from './mediaRuntime/clipBindings';
 import { mediaRuntimeRegistry } from './mediaRuntime/registry';
+import { lottieRuntimeManager } from './vectorAnimation/LottieRuntimeManager';
 
 type DecoderMode = SlotDeckState['decoderMode'];
 type SlotDeckStatus = SlotDeckState['status'];
@@ -225,6 +226,9 @@ class SlotDeckManager {
         clip.source.audioElement.src = '';
         clip.source.audioElement.load();
       }
+      if (clip.source?.type === 'lottie') {
+        lottieRuntimeManager.destroyClipRuntime(clip.id);
+      }
     }
     this.decks.delete(entry.slotIndex);
     this.pushDisposedState(entry.slotIndex);
@@ -335,6 +339,45 @@ class SlotDeckManager {
     }, { once: true });
   }
 
+  private loadLottieForClip(entry: SlotDeckEntry, clip: TimelineClip, file: File): void {
+    void (async () => {
+      try {
+        if (clip.source?.type !== 'lottie') {
+          clip.source = {
+            type: 'lottie',
+            mediaFileId: clip.mediaFileId,
+            naturalDuration: clip.duration,
+          };
+        }
+
+        const runtime = await lottieRuntimeManager.prepareClipSource(clip, file);
+        if (this.decks.get(entry.slotIndex) !== entry || entry.pendingDispose) {
+          lottieRuntimeManager.destroyClipRuntime(clip.id);
+          return;
+        }
+
+        const naturalDuration =
+          runtime.metadata.duration ??
+          clip.source?.naturalDuration ??
+          clip.duration;
+        clip.file = file;
+        clip.source = {
+          type: 'lottie',
+          textCanvas: runtime.canvas,
+          mediaFileId: clip.mediaFileId,
+          naturalDuration,
+          vectorAnimationSettings: clip.source?.vectorAnimationSettings,
+        };
+        clip.isLoading = false;
+        lottieRuntimeManager.renderClipAtTime(clip, clip.startTime);
+        this.markClipReady(entry, 'html', { visual: true });
+      } catch (error) {
+        clip.isLoading = false;
+        this.markDeckFailure(entry, error);
+      }
+    })();
+  }
+
   prepareSlot(slotIndex: number, compositionId: string): void {
     if (!flags.useWarmSlotDecks) {
       return;
@@ -419,11 +462,12 @@ class SlotDeckManager {
     const { files } = useMediaStore.getState();
 
     for (const serializedClip of timelineData.clips) {
+      const mediaFile = files.find((file) => file.id === serializedClip.mediaFileId);
       const clip: TimelineClip = {
         id: serializedClip.id,
         trackId: serializedClip.trackId,
         name: serializedClip.name,
-        file: null as never,
+        file: (mediaFile?.file ?? null) as never,
         startTime: serializedClip.startTime,
         duration: serializedClip.duration,
         inPoint: serializedClip.inPoint,
@@ -438,7 +482,6 @@ class SlotDeckManager {
         masks: serializedClip.masks,
       };
 
-      const mediaFile = files.find((file) => file.id === serializedClip.mediaFileId);
       const sourceType = serializedClip.sourceType;
       const fileUrl = mediaFile?.url;
 
@@ -454,6 +497,16 @@ class SlotDeckManager {
         entry.preparedClipCount += 1;
         clip.isLoading = true;
         this.loadImageForClip(entry, clip, fileUrl);
+      } else if (sourceType === 'lottie' && mediaFile?.file) {
+        entry.preparedClipCount += 1;
+        clip.isLoading = true;
+        clip.source = {
+          type: 'lottie',
+          mediaFileId: serializedClip.mediaFileId,
+          naturalDuration: serializedClip.naturalDuration,
+          vectorAnimationSettings: serializedClip.vectorAnimationSettings,
+        };
+        this.loadLottieForClip(entry, clip, mediaFile.file);
       } else {
         clip.isLoading = false;
       }

--- a/src/services/thumbnailRenderer.ts
+++ b/src/services/thumbnailRenderer.ts
@@ -371,7 +371,13 @@ class ThumbnailRendererService {
     // Note: sourceType might be undefined, so we include clips without it too
     const videoClips = clips.filter((c: { trackId: string; sourceType?: string }) => {
       const isOnVideoTrack = videoTrackIds.has(c.trackId);
-      const isVisualType = !c.sourceType || c.sourceType === 'video' || c.sourceType === 'image' || c.sourceType === 'text';
+      const isVisualType =
+        !c.sourceType ||
+        c.sourceType === 'video' ||
+        c.sourceType === 'image' ||
+        c.sourceType === 'text' ||
+        c.sourceType === 'solid' ||
+        c.sourceType === 'lottie';
       return isOnVideoTrack && isVisualType;
     });
 

--- a/src/services/vectorAnimation/LottieRuntimeManager.ts
+++ b/src/services/vectorAnimation/LottieRuntimeManager.ts
@@ -1,0 +1,328 @@
+import { DotLottie } from '@lottiefiles/dotlottie-web';
+
+import type { TimelineClip } from '../../types';
+import {
+  mergeVectorAnimationSettings,
+  shouldLoopVectorAnimation,
+  type VectorAnimationClipSettings,
+} from '../../types/vectorAnimation';
+import { Logger } from '../logger';
+import { prepareLottieAsset } from './lottieMetadata';
+import type {
+  LottieRuntimePrepareResult,
+  PreparedLottieAsset,
+} from './types';
+
+const log = Logger.create('LottieRuntime');
+const DEFAULT_CANVAS_SIZE = 512;
+const FRAME_EPSILON = 1 / 120;
+
+interface LottieRuntimeEntry {
+  asset: PreparedLottieAsset;
+  canvas: HTMLCanvasElement;
+  clipId: string;
+  isReady: boolean;
+  player: DotLottie;
+  settingsKey: string;
+}
+
+function createCanvas(width?: number, height?: number): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = width && width > 0 ? width : DEFAULT_CANVAS_SIZE;
+  canvas.height = height && height > 0 ? height : DEFAULT_CANVAS_SIZE;
+  canvas.dataset.masterselectsDynamic = 'lottie';
+  return canvas;
+}
+
+function waitForDotLottieLoad(player: DotLottie): Promise<void> {
+  if (player.isLoaded) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      player.removeEventListener('load', onLoad);
+      player.removeEventListener('loadError', onError);
+    };
+
+    const onLoad = () => {
+      cleanup();
+      resolve();
+    };
+
+    const onError = (event: { error?: Error }) => {
+      cleanup();
+      reject(event.error ?? new Error('Failed to load Lottie runtime'));
+    };
+
+    player.addEventListener('load', onLoad);
+    player.addEventListener('loadError', onError);
+  });
+}
+
+function getSettingsKey(settings: VectorAnimationClipSettings): string {
+  return JSON.stringify({
+    animationName: settings.animationName ?? null,
+    backgroundColor: settings.backgroundColor ?? null,
+    fit: settings.fit,
+    loop: settings.loop,
+    endBehavior: settings.endBehavior,
+  });
+}
+
+function clearCanvas(canvas: HTMLCanvasElement): void {
+  const context = canvas.getContext('2d');
+  context?.clearRect(0, 0, canvas.width, canvas.height);
+}
+
+function getSourceDuration(clip: TimelineClip, duration: number): number {
+  if (Number.isFinite(duration) && duration > 0) {
+    return duration;
+  }
+  if (Number.isFinite(clip.source?.naturalDuration) && (clip.source?.naturalDuration ?? 0) > 0) {
+    return clip.source!.naturalDuration!;
+  }
+  return Math.max(clip.duration, FRAME_EPSILON);
+}
+
+function normalizeModulo(value: number, divisor: number): number {
+  if (!Number.isFinite(divisor) || divisor <= 0) {
+    return 0;
+  }
+  const result = value % divisor;
+  return result < 0 ? result + divisor : result;
+}
+
+function resolveAnimationTime(
+  clip: TimelineClip,
+  animationDuration: number,
+  settings: VectorAnimationClipSettings,
+  timelineTime: number,
+): number | null {
+  const clipLocalTime = Math.max(0, timelineTime - clip.startTime);
+  const sourceDuration = getSourceDuration(clip, animationDuration);
+  const sourceMaxTime = Math.max(0, sourceDuration - FRAME_EPSILON);
+  const sourceInPoint = Math.max(0, Math.min(clip.inPoint, sourceMaxTime));
+  const rawSourceOutPoint =
+    Number.isFinite(clip.outPoint) && clip.outPoint > sourceInPoint
+      ? clip.outPoint
+      : sourceDuration;
+  const sourceOutPoint = Math.max(
+    sourceInPoint + FRAME_EPSILON,
+    Math.min(rawSourceOutPoint, sourceDuration),
+  );
+  const sourceWindowDuration = Math.max(sourceOutPoint - sourceInPoint, FRAME_EPSILON);
+  const shouldLoop = shouldLoopVectorAnimation(settings);
+
+  if (!shouldLoop && settings.endBehavior === 'clear' && clipLocalTime >= sourceWindowDuration) {
+    return null;
+  }
+
+  const wrappedLocalTime = shouldLoop
+    ? normalizeModulo(clipLocalTime, sourceWindowDuration)
+    : Math.max(0, Math.min(clipLocalTime, Math.max(0, sourceWindowDuration - FRAME_EPSILON)));
+
+  const sourceTime = clip.reversed
+    ? sourceOutPoint - wrappedLocalTime
+    : sourceInPoint + wrappedLocalTime;
+
+  const maxTime = Math.max(0, animationDuration - FRAME_EPSILON);
+  return Math.max(0, Math.min(sourceTime, maxTime));
+}
+
+function getFrameForTime(duration: number, totalFrames: number, time: number): number {
+  if (!Number.isFinite(duration) || duration <= 0 || !Number.isFinite(totalFrames) || totalFrames <= 1) {
+    return 0;
+  }
+
+  const frame = (time / duration) * totalFrames;
+  return Math.max(0, Math.min(frame, totalFrames - FRAME_EPSILON));
+}
+
+export class LottieRuntimeManager {
+  private entries = new Map<string, LottieRuntimeEntry>();
+  private preparePromises = new Map<string, Promise<LottieRuntimePrepareResult>>();
+
+  async prepareClipSource(
+    clip: TimelineClip,
+    fileOverride?: File,
+  ): Promise<LottieRuntimePrepareResult> {
+    if (clip.source?.type !== 'lottie') {
+      throw new Error(`prepareClipSource called for non-Lottie clip ${clip.id}`);
+    }
+
+    const existingPromise = this.preparePromises.get(clip.id);
+    if (existingPromise) {
+      return existingPromise;
+    }
+
+    const preparePromise = this.prepareClipSourceInternal(clip, fileOverride).finally(() => {
+      this.preparePromises.delete(clip.id);
+    });
+
+    this.preparePromises.set(clip.id, preparePromise);
+    return preparePromise;
+  }
+
+  private async prepareClipSourceInternal(
+    clip: TimelineClip,
+    fileOverride?: File,
+  ): Promise<LottieRuntimePrepareResult> {
+    const file = fileOverride ?? clip.file;
+    if (!file) {
+      throw new Error(`Missing file for Lottie clip ${clip.id}`);
+    }
+
+    const asset = await prepareLottieAsset(file);
+    const existing = this.entries.get(clip.id);
+    if (existing && existing.asset.payload.sourceKey === asset.payload.sourceKey) {
+      this.applySettings(existing, clip);
+      return {
+        canvas: existing.canvas,
+        metadata: existing.asset.metadata,
+      };
+    }
+
+    if (existing) {
+      this.destroyClipRuntime(clip.id);
+    }
+
+    const canvas = createCanvas(asset.metadata.width, asset.metadata.height);
+    const player = new DotLottie({
+      canvas,
+      autoplay: false,
+      data: asset.payload.kind === 'dotlottie'
+        ? asset.payload.data.slice(0)
+        : asset.payload.data,
+      loop: false,
+      renderConfig: {
+        autoResize: false,
+        devicePixelRatio: 1,
+        freezeOnOffscreen: false,
+      },
+    });
+
+    await waitForDotLottieLoad(player);
+    player.setUseFrameInterpolation(false);
+    player.pause();
+
+    const entry: LottieRuntimeEntry = {
+      asset,
+      canvas,
+      clipId: clip.id,
+      isReady: true,
+      player,
+      settingsKey: '',
+    };
+
+    this.applySettings(entry, clip);
+    this.entries.set(clip.id, entry);
+
+    return {
+      canvas,
+      metadata: asset.metadata,
+    };
+  }
+
+  private applySettings(entry: LottieRuntimeEntry, clip: TimelineClip): void {
+    const settings = mergeVectorAnimationSettings(clip.source?.vectorAnimationSettings);
+    const settingsKey = getSettingsKey(settings);
+    if (settingsKey === entry.settingsKey) {
+      return;
+    }
+
+    if (
+      settings.animationName &&
+      settings.animationName !== entry.player.activeAnimationId &&
+      entry.asset.payload.kind === 'dotlottie'
+    ) {
+      try {
+        entry.player.loadAnimation(settings.animationName);
+      } catch (error) {
+        log.warn('Failed to switch Lottie animation', {
+          clipId: clip.id,
+          animationName: settings.animationName,
+          error,
+        });
+      }
+    }
+
+    entry.player.setLoop(shouldLoopVectorAnimation(settings));
+    entry.player.setBackgroundColor(settings.backgroundColor ?? 'transparent');
+    entry.player.setLayout({
+      align: [0.5, 0.5],
+      fit: settings.fit,
+    });
+    entry.player.resize();
+    entry.settingsKey = settingsKey;
+  }
+
+  renderClipAtTime(clip: TimelineClip, timelineTime: number): HTMLCanvasElement | null {
+    if (clip.source?.type !== 'lottie') {
+      return clip.source?.textCanvas ?? null;
+    }
+
+    const entry = this.entries.get(clip.id);
+    if (!entry?.isReady) {
+      if (clip.file) {
+        void this.prepareClipSource(clip).catch((error) => {
+          log.warn('Failed to prepare Lottie runtime during render', { clipId: clip.id, error });
+        });
+      }
+      return clip.source?.textCanvas ?? null;
+    }
+
+    this.applySettings(entry, clip);
+    const settings = mergeVectorAnimationSettings(clip.source?.vectorAnimationSettings);
+    const animationDuration =
+      entry.asset.metadata.duration ??
+      clip.source?.naturalDuration ??
+      clip.outPoint ??
+      clip.duration;
+    const animationTime = resolveAnimationTime(clip, animationDuration, settings, timelineTime);
+
+    if (animationTime == null) {
+      clearCanvas(entry.canvas);
+      return entry.canvas;
+    }
+
+    const totalFrames =
+      entry.player.totalFrames ||
+      entry.asset.metadata.totalFrames ||
+      0;
+    const targetFrame = getFrameForTime(animationDuration, totalFrames, animationTime);
+    entry.player.setFrame(targetFrame);
+    return entry.canvas;
+  }
+
+  pruneClipRuntimes(knownClipIds: Iterable<string>): void {
+    const keep = new Set(knownClipIds);
+    for (const clipId of this.entries.keys()) {
+      if (!keep.has(clipId)) {
+        this.destroyClipRuntime(clipId);
+      }
+    }
+  }
+
+  destroyClipRuntime(clipId: string): void {
+    const entry = this.entries.get(clipId);
+    if (!entry) {
+      return;
+    }
+
+    try {
+      entry.player.destroy();
+    } catch (error) {
+      log.warn('Failed to destroy Lottie runtime', { clipId, error });
+    }
+    this.entries.delete(clipId);
+  }
+
+  destroyAll(): void {
+    for (const clipId of this.entries.keys()) {
+      this.destroyClipRuntime(clipId);
+    }
+  }
+}
+
+export const lottieRuntimeManager = new LottieRuntimeManager();

--- a/src/services/vectorAnimation/lottieJsonSniffer.ts
+++ b/src/services/vectorAnimation/lottieJsonSniffer.ts
@@ -1,0 +1,65 @@
+export interface LottieJsonRoot extends Record<string, unknown> {
+  v?: string;
+  fr?: number;
+  ip?: number;
+  op?: number;
+  w?: number;
+  h?: number;
+  nm?: string;
+  layers?: unknown[];
+  assets?: unknown[];
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+export function isPotentialLottieJsonFile(file: File): boolean {
+  const lowerName = file.name.toLowerCase();
+  return (
+    lowerName.endsWith('.json') ||
+    file.type === 'application/json' ||
+    file.type.endsWith('+json')
+  );
+}
+
+export function isLottieJsonData(value: unknown): value is LottieJsonRoot {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const candidate = value as LottieJsonRoot;
+  return (
+    typeof candidate.v === 'string' &&
+    isFiniteNumber(candidate.fr) &&
+    isFiniteNumber(candidate.ip) &&
+    isFiniteNumber(candidate.op) &&
+    Array.isArray(candidate.layers)
+  );
+}
+
+export function parseLottieJsonText(text: string): LottieJsonRoot | null {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return isLottieJsonData(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function readLottieJsonFile(file: File): Promise<{
+  data: LottieJsonRoot;
+  text: string;
+} | null> {
+  if (!isPotentialLottieJsonFile(file)) {
+    return null;
+  }
+
+  const text = await file.text();
+  const data = parseLottieJsonText(text);
+  if (!data) {
+    return null;
+  }
+
+  return { data, text };
+}

--- a/src/services/vectorAnimation/lottieMetadata.ts
+++ b/src/services/vectorAnimation/lottieMetadata.ts
@@ -1,0 +1,181 @@
+import { DotLottie } from '@lottiefiles/dotlottie-web';
+
+import type { VectorAnimationMetadata } from '../../types/vectorAnimation';
+import { Logger } from '../logger';
+import {
+  readLottieJsonFile,
+  type LottieJsonRoot,
+} from './lottieJsonSniffer';
+import type { PreparedLottieAsset } from './types';
+
+const log = Logger.create('LottieMetadata');
+
+const preparedAssetCache = new Map<string, Promise<PreparedLottieAsset>>();
+
+function getAssetCacheKey(file: File): string {
+  return `${file.name}:${file.size}:${file.lastModified}`;
+}
+
+function createMetadataCanvas(): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = 1;
+  return canvas;
+}
+
+function waitForDotLottieLoad(player: DotLottie): Promise<void> {
+  if (player.isLoaded) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      player.removeEventListener('load', onLoad);
+      player.removeEventListener('loadError', onError);
+    };
+
+    const onLoad = () => {
+      cleanup();
+      resolve();
+    };
+
+    const onError = (event: { error?: Error }) => {
+      cleanup();
+      reject(event.error ?? new Error('Failed to load Lottie asset'));
+    };
+
+    player.addEventListener('load', onLoad);
+    player.addEventListener('loadError', onError);
+  });
+}
+
+function getDurationFromFrames(
+  fps: number | undefined,
+  inPoint: number | undefined,
+  outPoint: number | undefined,
+): { duration?: number; totalFrames?: number } {
+  if (
+    typeof fps !== 'number' ||
+    !Number.isFinite(fps) ||
+    fps <= 0 ||
+    typeof inPoint !== 'number' ||
+    typeof outPoint !== 'number' ||
+    !Number.isFinite(inPoint) ||
+    !Number.isFinite(outPoint)
+  ) {
+    return {};
+  }
+
+  const totalFrames = Math.max(0, outPoint - inPoint);
+  return {
+    duration: totalFrames / fps,
+    totalFrames,
+  };
+}
+
+function buildJsonMetadata(data: LottieJsonRoot): VectorAnimationMetadata {
+  const fps = typeof data.fr === 'number' && Number.isFinite(data.fr) ? data.fr : undefined;
+  const width = typeof data.w === 'number' && Number.isFinite(data.w) ? data.w : undefined;
+  const height = typeof data.h === 'number' && Number.isFinite(data.h) ? data.h : undefined;
+  const timing = getDurationFromFrames(fps, data.ip, data.op);
+
+  return {
+    provider: 'lottie',
+    width,
+    height,
+    fps,
+    duration: timing.duration,
+    totalFrames: timing.totalFrames,
+    defaultAnimationName: typeof data.nm === 'string' && data.nm.trim() ? data.nm : undefined,
+  };
+}
+
+async function readDotLottieMetadata(buffer: ArrayBuffer): Promise<VectorAnimationMetadata> {
+  const canvas = createMetadataCanvas();
+  const player = new DotLottie({
+    canvas,
+    data: buffer.slice(0),
+    autoplay: false,
+    loop: false,
+    renderConfig: {
+      autoResize: false,
+      devicePixelRatio: 1,
+      freezeOnOffscreen: false,
+    },
+  });
+
+  try {
+    await waitForDotLottieLoad(player);
+    const animationSize = player.animationSize();
+    const totalFrames = Number.isFinite(player.totalFrames) ? player.totalFrames : undefined;
+    const duration = Number.isFinite(player.duration) ? player.duration : undefined;
+    const fps = totalFrames && duration && duration > 0 ? totalFrames / duration : undefined;
+    const manifest = player.manifest;
+
+    return {
+      provider: 'lottie',
+      width: animationSize.width || undefined,
+      height: animationSize.height || undefined,
+      fps,
+      duration,
+      totalFrames,
+      animationNames: manifest?.animations?.map((animation) => animation.id) ?? undefined,
+      defaultAnimationName: player.activeAnimationId ?? manifest?.animations?.[0]?.id,
+      stateMachineNames: manifest?.stateMachines?.map((stateMachine) => stateMachine.id) ?? undefined,
+    };
+  } finally {
+    player.destroy();
+  }
+}
+
+async function prepareLottieAssetInternal(file: File): Promise<PreparedLottieAsset> {
+  const lowerName = file.name.toLowerCase();
+
+  if (lowerName.endsWith('.lottie')) {
+    const buffer = await file.arrayBuffer();
+    const metadata = await readDotLottieMetadata(buffer);
+    return {
+      metadata,
+      payload: {
+        kind: 'dotlottie',
+        data: buffer,
+        sourceKey: getAssetCacheKey(file),
+      },
+    };
+  }
+
+  const json = await readLottieJsonFile(file);
+  if (!json) {
+    throw new Error(`Unsupported Lottie JSON: ${file.name}`);
+  }
+
+  return {
+    metadata: buildJsonMetadata(json.data),
+    payload: {
+      kind: 'json',
+      data: json.text,
+      sourceKey: getAssetCacheKey(file),
+    },
+  };
+}
+
+export async function prepareLottieAsset(file: File): Promise<PreparedLottieAsset> {
+  const cacheKey = getAssetCacheKey(file);
+  const existing = preparedAssetCache.get(cacheKey);
+  if (existing) {
+    return existing;
+  }
+
+  const promise = prepareLottieAssetInternal(file).catch((error) => {
+    preparedAssetCache.delete(cacheKey);
+    log.warn('Failed to prepare Lottie asset', { file: file.name, error });
+    throw error;
+  });
+
+  preparedAssetCache.set(cacheKey, promise);
+  return promise;
+}
+
+export async function readLottieMetadata(file: File): Promise<VectorAnimationMetadata> {
+  return (await prepareLottieAsset(file)).metadata;
+}

--- a/src/services/vectorAnimation/types.ts
+++ b/src/services/vectorAnimation/types.ts
@@ -1,0 +1,23 @@
+import type { VectorAnimationMetadata } from '../../types/vectorAnimation';
+
+export type LottieRuntimePayload =
+  | {
+    kind: 'json';
+    data: string;
+    sourceKey: string;
+  }
+  | {
+    kind: 'dotlottie';
+    data: ArrayBuffer;
+    sourceKey: string;
+  };
+
+export interface PreparedLottieAsset {
+  metadata: VectorAnimationMetadata;
+  payload: LottieRuntimePayload;
+}
+
+export interface LottieRuntimePrepareResult {
+  canvas: HTMLCanvasElement;
+  metadata: VectorAnimationMetadata;
+}

--- a/src/stores/exportStore.ts
+++ b/src/stores/exportStore.ts
@@ -1,0 +1,378 @@
+import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
+import type { ContainerFormat, VideoCodec } from '../engine/export';
+import type {
+  DnxhrProfile,
+  FFmpegContainer,
+  FFmpegVideoCodec,
+  ProResProfile,
+} from '../engine/ffmpeg';
+
+export type ExportEncoderType = 'webcodecs' | 'htmlvideo' | 'ffmpeg';
+export type ExportVisualMode = 'video' | 'image';
+export type ExportImageFormat = 'png' | 'jpg' | 'webp' | 'bmp';
+export type ExportSpecialContainer = 'none' | 'xml';
+
+export interface ExportSettings {
+  encoder: ExportEncoderType;
+  width: number;
+  height: number;
+  customWidth: number;
+  customHeight: number;
+  useCustomResolution: boolean;
+  fps: number;
+  customFps: number;
+  useCustomFps: boolean;
+  useInOut: boolean;
+  filename: string;
+  bitrate: number;
+  containerFormat: ContainerFormat;
+  videoCodec: VideoCodec;
+  rateControl: 'vbr' | 'cbr';
+  ffmpegCodec: FFmpegVideoCodec;
+  ffmpegContainer: FFmpegContainer;
+  ffmpegPreset: string;
+  proresProfile: ProResProfile;
+  dnxhrProfile: DnxhrProfile;
+  ffmpegQuality: number;
+  ffmpegBitrate: number;
+  ffmpegRateControl: 'crf' | 'cbr' | 'vbr';
+  stackedAlpha: boolean;
+  includeAudio: boolean;
+  audioSampleRate: 44100 | 48000;
+  audioBitrate: number;
+  normalizeAudio: boolean;
+  videoEnabled: boolean;
+  visualMode: ExportVisualMode;
+  imageFormat: ExportImageFormat;
+  imageQuality: number;
+  specialContainer: ExportSpecialContainer;
+}
+
+export interface ExportPreset {
+  id: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+  settings: ExportSettings;
+}
+
+export interface ExportStoreData {
+  settings: ExportSettings;
+  presets: ExportPreset[];
+  selectedPresetId: string | null;
+}
+
+interface SavePresetResult {
+  preset: ExportPreset;
+  overwritten: boolean;
+}
+
+interface ExportStoreState extends ExportStoreData {
+  setSettings: (patch: Partial<ExportSettings>) => void;
+  replaceSettings: (settings: Partial<ExportSettings>) => void;
+  reset: () => void;
+  setSelectedPresetId: (presetId: string | null) => void;
+  savePreset: (name: string) => SavePresetResult | null;
+  updatePreset: (presetId: string) => ExportPreset | null;
+  loadPreset: (presetId: string) => boolean;
+  deletePreset: (presetId: string) => void;
+  hydrateFromProject: (data?: Partial<ExportStoreData> | null) => void;
+}
+
+const ENCODERS: ExportEncoderType[] = ['webcodecs', 'htmlvideo', 'ffmpeg'];
+const VIDEO_CODECS: VideoCodec[] = ['h264', 'h265', 'vp9', 'av1'];
+const WEB_CONTAINERS: ContainerFormat[] = ['mp4', 'webm'];
+const FFMPEG_CONTAINERS: FFmpegContainer[] = ['mov', 'mkv', 'avi', 'mxf'];
+const FFMPEG_CODECS: FFmpegVideoCodec[] = ['prores', 'dnxhd', 'ffv1', 'utvideo', 'mjpeg'];
+const PRORES_PROFILES: ProResProfile[] = ['proxy', 'lt', 'standard', 'hq', '4444', '4444xq'];
+const DNXHR_PROFILES: DnxhrProfile[] = ['dnxhr_lb', 'dnxhr_sq', 'dnxhr_hq', 'dnxhr_hqx', 'dnxhr_444'];
+const IMAGE_FORMATS: ExportImageFormat[] = ['png', 'jpg', 'webp', 'bmp'];
+const VISUAL_MODES: ExportVisualMode[] = ['video', 'image'];
+const SPECIAL_CONTAINERS: ExportSpecialContainer[] = ['none', 'xml'];
+
+function createPresetId(): string {
+  return `export-preset-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function createDefaultExportSettings(): ExportSettings {
+  return {
+    encoder: 'webcodecs',
+    width: 1920,
+    height: 1080,
+    customWidth: 1920,
+    customHeight: 1080,
+    useCustomResolution: false,
+    fps: 30,
+    customFps: 30,
+    useCustomFps: false,
+    useInOut: true,
+    filename: 'export',
+    bitrate: 15_000_000,
+    containerFormat: 'mp4',
+    videoCodec: 'h264',
+    rateControl: 'vbr',
+    ffmpegCodec: 'prores',
+    ffmpegContainer: 'mov',
+    ffmpegPreset: '',
+    proresProfile: 'hq',
+    dnxhrProfile: 'dnxhr_hq',
+    ffmpegQuality: 18,
+    ffmpegBitrate: 20_000_000,
+    ffmpegRateControl: 'crf',
+    stackedAlpha: false,
+    includeAudio: true,
+    audioSampleRate: 48000,
+    audioBitrate: 256_000,
+    normalizeAudio: false,
+    videoEnabled: true,
+    visualMode: 'video',
+    imageFormat: 'png',
+    imageQuality: 0.92,
+    specialContainer: 'none',
+  };
+}
+
+export function createDefaultExportStoreData(): ExportStoreData {
+  return {
+    settings: createDefaultExportSettings(),
+    presets: [],
+    selectedPresetId: null,
+  };
+}
+
+function cloneExportSettings(settings: ExportSettings): ExportSettings {
+  return { ...settings };
+}
+
+function clonePreset(preset: ExportPreset): ExportPreset {
+  return {
+    ...preset,
+    settings: cloneExportSettings(preset.settings),
+  };
+}
+
+function pickEnumValue<T extends string>(value: unknown, allowed: readonly T[], fallback: T): T {
+  return typeof value === 'string' && allowed.includes(value as T) ? value as T : fallback;
+}
+
+function pickNumber(value: unknown, fallback: number, options?: { min?: number; max?: number }): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return fallback;
+  }
+
+  let next = value;
+  if (options?.min !== undefined) {
+    next = Math.max(options.min, next);
+  }
+  if (options?.max !== undefined) {
+    next = Math.min(options.max, next);
+  }
+  return next;
+}
+
+function sanitizeSettings(input?: Partial<ExportSettings> | null): ExportSettings {
+  const defaults = createDefaultExportSettings();
+  if (!input) {
+    return defaults;
+  }
+
+  return {
+    encoder: pickEnumValue(input.encoder, ENCODERS, defaults.encoder),
+    width: Math.round(pickNumber(input.width, defaults.width, { min: 1, max: 7680 })),
+    height: Math.round(pickNumber(input.height, defaults.height, { min: 1, max: 4320 })),
+    customWidth: Math.round(pickNumber(input.customWidth, defaults.customWidth, { min: 1, max: 7680 })),
+    customHeight: Math.round(pickNumber(input.customHeight, defaults.customHeight, { min: 1, max: 4320 })),
+    useCustomResolution: typeof input.useCustomResolution === 'boolean' ? input.useCustomResolution : defaults.useCustomResolution,
+    fps: pickNumber(input.fps, defaults.fps, { min: 1, max: 240 }),
+    customFps: pickNumber(input.customFps, defaults.customFps, { min: 1, max: 240 }),
+    useCustomFps: typeof input.useCustomFps === 'boolean' ? input.useCustomFps : defaults.useCustomFps,
+    useInOut: typeof input.useInOut === 'boolean' ? input.useInOut : defaults.useInOut,
+    filename: typeof input.filename === 'string' ? input.filename : defaults.filename,
+    bitrate: Math.round(pickNumber(input.bitrate, defaults.bitrate, { min: 1_000_000, max: 100_000_000 })),
+    containerFormat: pickEnumValue(input.containerFormat, WEB_CONTAINERS, defaults.containerFormat),
+    videoCodec: pickEnumValue(input.videoCodec, VIDEO_CODECS, defaults.videoCodec),
+    rateControl: pickEnumValue(input.rateControl, ['vbr', 'cbr'] as const, defaults.rateControl),
+    ffmpegCodec: pickEnumValue(input.ffmpegCodec, FFMPEG_CODECS, defaults.ffmpegCodec),
+    ffmpegContainer: pickEnumValue(input.ffmpegContainer, FFMPEG_CONTAINERS, defaults.ffmpegContainer),
+    ffmpegPreset: typeof input.ffmpegPreset === 'string' ? input.ffmpegPreset : defaults.ffmpegPreset,
+    proresProfile: pickEnumValue(input.proresProfile, PRORES_PROFILES, defaults.proresProfile),
+    dnxhrProfile: pickEnumValue(input.dnxhrProfile, DNXHR_PROFILES, defaults.dnxhrProfile),
+    ffmpegQuality: Math.round(pickNumber(input.ffmpegQuality, defaults.ffmpegQuality, { min: 1, max: 31 })),
+    ffmpegBitrate: Math.round(pickNumber(input.ffmpegBitrate, defaults.ffmpegBitrate, { min: 1_000_000, max: 100_000_000 })),
+    ffmpegRateControl: pickEnumValue(input.ffmpegRateControl, ['crf', 'cbr', 'vbr'] as const, defaults.ffmpegRateControl),
+    stackedAlpha: typeof input.stackedAlpha === 'boolean' ? input.stackedAlpha : defaults.stackedAlpha,
+    includeAudio: typeof input.includeAudio === 'boolean' ? input.includeAudio : defaults.includeAudio,
+    audioSampleRate: input.audioSampleRate === 44100 || input.audioSampleRate === 48000
+      ? input.audioSampleRate
+      : defaults.audioSampleRate,
+    audioBitrate: Math.round(pickNumber(input.audioBitrate, defaults.audioBitrate, { min: 64_000, max: 512_000 })),
+    normalizeAudio: typeof input.normalizeAudio === 'boolean' ? input.normalizeAudio : defaults.normalizeAudio,
+    videoEnabled: typeof input.videoEnabled === 'boolean' ? input.videoEnabled : defaults.videoEnabled,
+    visualMode: pickEnumValue(input.visualMode, VISUAL_MODES, defaults.visualMode),
+    imageFormat: pickEnumValue(input.imageFormat, IMAGE_FORMATS, defaults.imageFormat),
+    imageQuality: pickNumber(input.imageQuality, defaults.imageQuality, { min: 0.4, max: 1 }),
+    specialContainer: pickEnumValue(input.specialContainer, SPECIAL_CONTAINERS, defaults.specialContainer),
+  };
+}
+
+function sanitizePreset(input: Partial<ExportPreset> | null | undefined): ExportPreset | null {
+  if (!input || typeof input.name !== 'string' || !input.name.trim()) {
+    return null;
+  }
+
+  const now = Date.now();
+  return {
+    id: typeof input.id === 'string' && input.id ? input.id : createPresetId(),
+    name: input.name.trim(),
+    createdAt: pickNumber(input.createdAt, now, { min: 0 }),
+    updatedAt: pickNumber(input.updatedAt, now, { min: 0 }),
+    settings: sanitizeSettings(input.settings),
+  };
+}
+
+function sanitizeStoreData(input?: Partial<ExportStoreData> | null): ExportStoreData {
+  const defaults = createDefaultExportStoreData();
+  if (!input) {
+    return defaults;
+  }
+
+  const presets = Array.isArray(input.presets)
+    ? input.presets
+        .map((preset) => sanitizePreset(preset))
+        .filter((preset): preset is ExportPreset => preset !== null)
+    : defaults.presets;
+  const selectedPresetId = typeof input.selectedPresetId === 'string' && presets.some((preset) => preset.id === input.selectedPresetId)
+    ? input.selectedPresetId
+    : null;
+
+  return {
+    settings: sanitizeSettings(input.settings),
+    presets,
+    selectedPresetId,
+  };
+}
+
+export function getExportStoreData(state: Pick<ExportStoreState, 'settings' | 'presets' | 'selectedPresetId'>): ExportStoreData {
+  return {
+    settings: cloneExportSettings(state.settings),
+    presets: state.presets.map(clonePreset),
+    selectedPresetId: state.selectedPresetId,
+  };
+}
+
+export const useExportStore = create<ExportStoreState>()(
+  subscribeWithSelector((set, get) => ({
+    ...createDefaultExportStoreData(),
+
+    setSettings: (patch) => {
+      set((state) => ({
+        settings: sanitizeSettings({
+          ...state.settings,
+          ...patch,
+        }),
+      }));
+    },
+
+    replaceSettings: (settings) => {
+      set(() => ({
+        settings: sanitizeSettings(settings),
+      }));
+    },
+
+    reset: () => {
+      set(() => createDefaultExportStoreData());
+    },
+
+    setSelectedPresetId: (presetId) => {
+      set((state) => ({
+        selectedPresetId: presetId && state.presets.some((preset) => preset.id === presetId)
+          ? presetId
+          : null,
+      }));
+    },
+
+    savePreset: (name) => {
+      const trimmedName = name.trim();
+      if (!trimmedName) {
+        return null;
+      }
+
+      const now = Date.now();
+      const { presets, settings } = get();
+      const normalizedName = trimmedName.toLowerCase();
+      const existingPreset = presets.find((preset) => preset.name.toLowerCase() === normalizedName);
+      const nextPreset: ExportPreset = existingPreset
+        ? {
+            ...existingPreset,
+            name: trimmedName,
+            updatedAt: now,
+            settings: cloneExportSettings(settings),
+          }
+        : {
+            id: createPresetId(),
+            name: trimmedName,
+            createdAt: now,
+            updatedAt: now,
+            settings: cloneExportSettings(settings),
+          };
+
+      set((state) => ({
+        presets: existingPreset
+          ? state.presets.map((preset) => preset.id === nextPreset.id ? nextPreset : preset)
+          : [...state.presets, nextPreset],
+        selectedPresetId: nextPreset.id,
+      }));
+
+      return {
+        preset: nextPreset,
+        overwritten: !!existingPreset,
+      };
+    },
+
+    updatePreset: (presetId) => {
+      const { presets, settings } = get();
+      const existingPreset = presets.find((preset) => preset.id === presetId);
+      if (!existingPreset) {
+        return null;
+      }
+
+      const nextPreset: ExportPreset = {
+        ...existingPreset,
+        updatedAt: Date.now(),
+        settings: cloneExportSettings(settings),
+      };
+
+      set((state) => ({
+        presets: state.presets.map((preset) => preset.id === presetId ? nextPreset : preset),
+        selectedPresetId: presetId,
+      }));
+
+      return nextPreset;
+    },
+
+    loadPreset: (presetId) => {
+      const preset = get().presets.find((entry) => entry.id === presetId);
+      if (!preset) {
+        return false;
+      }
+
+      set(() => ({
+        settings: cloneExportSettings(preset.settings),
+        selectedPresetId: preset.id,
+      }));
+      return true;
+    },
+
+    deletePreset: (presetId) => {
+      set((state) => ({
+        presets: state.presets.filter((preset) => preset.id !== presetId),
+        selectedPresetId: state.selectedPresetId === presetId ? null : state.selectedPresetId,
+      }));
+    },
+
+    hydrateFromProject: (data) => {
+      set(() => sanitizeStoreData(data));
+    },
+  }))
+);

--- a/src/stores/historyStore.ts
+++ b/src/stores/historyStore.ts
@@ -14,6 +14,8 @@ import type {
   FlashBoardComposerState,
   FlashBoardGenerationMetadata,
 } from './flashboardStore/types';
+import type { ExportStoreData } from './exportStore';
+import { createDefaultExportStoreData, getExportStoreData } from './exportStore';
 
 const log = Logger.create('History');
 
@@ -58,6 +60,8 @@ interface StateSnapshot {
     composer: FlashBoardComposerState;
     generationMetadataByMediaId: Record<string, FlashBoardGenerationMetadata>;
   };
+
+  export: ExportStoreData;
 }
 
 interface HistoryState {
@@ -124,6 +128,8 @@ interface FlashBoardStoreSnapshot {
   composer: FlashBoardComposerState;
 }
 
+type ExportStoreSnapshot = ExportStoreData;
+
 // Callback to flush pending debounced captures before undo/redo (set by useGlobalHistory)
 // Flush = execute the pending capture immediately so its state isn't lost
 let flushPendingCaptureCallback: (() => void) | null = null;
@@ -145,6 +151,8 @@ let getDockState: (() => any) | undefined;
 let setDockState: ((state: any) => void) | undefined;
 let getFlashBoardState: (() => FlashBoardStoreSnapshot) | undefined;
 let setFlashBoardState: ((state: Partial<FlashBoardStoreSnapshot>) => void) | undefined;
+let getExportState: (() => ExportStoreSnapshot) | undefined;
+let setExportState: ((state: Partial<ExportStoreSnapshot>) => void) | undefined;
 
 // Initialize store references (called from useGlobalHistory)
 export function initHistoryStoreRefs(stores: {
@@ -152,6 +160,7 @@ export function initHistoryStoreRefs(stores: {
   media: { getState: () => MediaStoreState; setState: (state: Partial<MediaStoreState>) => void };
   dock: { getState: () => any; setState: (state: any) => void };
   flashboard?: { getState: () => FlashBoardStoreSnapshot; setState: (state: Partial<FlashBoardStoreSnapshot>) => void };
+  export?: { getState: () => ExportStoreSnapshot; setState: (state: Partial<ExportStoreSnapshot>) => void };
 }) {
   getTimelineState = stores.timeline.getState;
   setTimelineState = stores.timeline.setState;
@@ -161,6 +170,8 @@ export function initHistoryStoreRefs(stores: {
   setDockState = stores.dock.setState;
   getFlashBoardState = stores.flashboard?.getState;
   setFlashBoardState = stores.flashboard?.setState;
+  getExportState = stores.export?.getState;
+  setExportState = stores.export?.setState;
 }
 
 // Deep clone helper (handles most objects, excluding DOM elements and functions)
@@ -270,6 +281,7 @@ function createSnapshot(label: string): StateSnapshot {
       composer: deepClone(flashboard.composer || createDefaultFlashBoardComposer()),
       generationMetadataByMediaId: deepClone(flashBoardMediaBridge.serializeMetadata()),
     },
+    export: deepClone(getExportStoreData(getExportState?.() || createDefaultExportStoreData())),
   };
 }
 
@@ -351,6 +363,10 @@ function applySnapshot(snapshot: StateSnapshot) {
   flashBoardMediaBridge.hydrateMetadata(
     deepClone(snapshot.flashboard?.generationMetadataByMediaId || {})
   );
+
+  if (setExportState) {
+    setExportState(deepClone(snapshot.export));
+  }
 }
 
 export const useHistoryStore = create<HistoryState>()(

--- a/src/stores/mediaStore/helpers/importPipeline.ts
+++ b/src/stores/mediaStore/helpers/importPipeline.ts
@@ -2,7 +2,7 @@
 
 import type { MediaFile, ProxyStatus } from '../types';
 import { PROXY_FPS } from '../constants';
-import { detectMediaType } from '../../timeline/helpers/mediaTypeHelpers';
+import { classifyMediaType } from '../../timeline/helpers/mediaTypeHelpers';
 import { calculateFileHash } from './fileHashHelpers';
 import { getMediaInfo } from './mediaInfoHelpers';
 import { createThumbnail, handleThumbnailDedup } from './thumbnailHelpers';
@@ -12,6 +12,7 @@ import { projectDB } from '../../../services/projectDB';
 import { useSettingsStore } from '../../settingsStore';
 import { Logger } from '../../../services/logger';
 import { prewarmGaussianSplatRuntime } from '../../../engine/three/splatRuntimeCache';
+import { prepareLottieAsset } from '../../../services/vectorAnimation/lottieMetadata';
 
 const log = Logger.create('Import');
 
@@ -52,15 +53,35 @@ export async function processImport(params: ImportParams): Promise<ImportResult>
   }
 
   // Detect type using shared helper from clipSlice, or use override if provided
-  const type: MediaFile['type'] = typeOverride ?? ((detectMediaType(file) === 'model' ? 'model' : detectMediaType(file)) as MediaFile['type']);
+  const detectedType = await classifyMediaType(file);
+  if (detectedType === 'unknown' && !typeOverride) {
+    throw new Error(`Unsupported media type: ${file.name}`);
+  }
+
+  const type: MediaFile['type'] = typeOverride ?? detectedType as MediaFile['type'];
   let canonicalFile = file;
   let url = URL.createObjectURL(file);
 
-  // Get info and thumbnail in parallel (skip for 3D models — no video/audio metadata)
+  const vectorAnimationInfo = type === 'lottie'
+    ? await prepareLottieAsset(file).then((prepared) => ({
+      duration: prepared.metadata.duration,
+      fileSize: file.size,
+      fps: prepared.metadata.fps,
+      height: prepared.metadata.height,
+      vectorAnimation: prepared.metadata,
+      width: prepared.metadata.width,
+    }))
+    : null;
+
+  // Get info and thumbnail in parallel (skip for 3D/vector formats - no HTML media metadata)
   const isMediaType = type === 'video' || type === 'audio' || type === 'image';
   const [info, rawThumbnail] = await Promise.all([
-    isMediaType ? getMediaInfo(file, type as 'video' | 'audio' | 'image') : Promise.resolve({ duration: 10, fileSize: file.size }),
-    type === 'video' || type === 'image' ? createThumbnail(file, type as 'video' | 'image') : Promise.resolve(undefined),
+    isMediaType
+      ? getMediaInfo(file, type as 'video' | 'audio' | 'image')
+      : Promise.resolve(vectorAnimationInfo ?? { duration: 10, fileSize: file.size }),
+    type === 'video' || type === 'image'
+      ? createThumbnail(file, type as 'video' | 'image')
+      : Promise.resolve(undefined),
   ]);
 
   // Calculate hash for deduplication

--- a/src/stores/mediaStore/slices/fileImportSlice.ts
+++ b/src/stores/mediaStore/slices/fileImportSlice.ts
@@ -2,12 +2,14 @@
 
 import type { MediaFile, MediaSliceCreator } from '../types';
 import { generateId, processImport } from '../helpers/importPipeline';
-import { detectMediaType } from '../../timeline/helpers/mediaTypeHelpers';
+import { classifyMediaType } from '../../timeline/helpers/mediaTypeHelpers';
 import { fileSystemService } from '../../../services/fileSystemService';
 import { projectDB } from '../../../services/projectDB';
 import { Logger } from '../../../services/logger';
 
 const log = Logger.create('Import');
+
+type ImportableMediaType = MediaFile['type'];
 
 export interface FileImportActions {
   importFile: (file: File, parentId?: string | null, options?: { forceCopyToProject?: boolean }) => Promise<MediaFile>;
@@ -22,12 +24,19 @@ export interface FileImportActions {
   importGaussianSplat: (file: File, parentId?: string | null) => Promise<MediaFile>;
 }
 
+async function resolveImportType(file: File): Promise<ImportableMediaType> {
+  const type = await classifyMediaType(file);
+  if (type === 'unknown') {
+    throw new Error(`Unsupported media type: ${file.name}`);
+  }
+  return type as ImportableMediaType;
+}
+
 /**
  * Create a placeholder MediaFile that appears instantly in the media panel.
  * Shows as grey/loading while the full import runs in the background.
  */
-function createPlaceholder(file: File, id: string, parentId?: string | null): MediaFile {
-  const type = detectMediaType(file) as 'video' | 'audio' | 'image' | 'model' | 'gaussian-splat';
+function createPlaceholder(file: File, id: string, type: ImportableMediaType, parentId?: string | null): MediaFile {
   return {
     id,
     name: file.name,
@@ -47,10 +56,8 @@ function createPlaceholder(file: File, id: string, parentId?: string | null): Me
  */
 function finalizePlaceholder(state: { files: MediaFile[] }, id: string, result: MediaFile): { files: MediaFile[] } {
   return {
-    files: state.files.map(f => {
+    files: state.files.map((f) => {
       if (f.id !== id) return f;
-      // Merge: keep parentId/labelColor from current state (user may have moved it),
-      // but take everything else from import result
       return {
         ...result,
         parentId: f.parentId,
@@ -63,40 +70,38 @@ function finalizePlaceholder(state: { files: MediaFile[] }, id: string, result: 
 
 export const createFileImportSlice: MediaSliceCreator<FileImportActions> = (set, get) => ({
   importFile: async (file: File, parentId?: string | null, options?: { forceCopyToProject?: boolean }) => {
-    // Deduplication: check if file with same name + size already exists
-    const existing = get().files.find(f =>
+    const existing = get().files.find((f) =>
       f.name === file.name && f.fileSize === file.size && !f.isImporting
     );
     if (existing) {
-      log.info(`Skipping duplicate: ${file.name} (${file.size} bytes) — already exists as ${existing.id}`);
+      log.info(`Skipping duplicate: ${file.name} (${file.size} bytes) - already exists as ${existing.id}`);
       return existing;
     }
 
     const id = generateId();
-    log.info(`Starting: ${file.name} type: ${file.type} size: ${file.size}`);
+    const type = await resolveImportType(file);
+    log.info(`Starting: ${file.name} type: ${type} size: ${file.size}`);
 
-    // Phase 1: Add placeholder instantly
-    const placeholder = createPlaceholder(file, id, parentId);
+    const placeholder = createPlaceholder(file, id, type, parentId);
     set((state) => ({
       files: [...state.files, placeholder],
     }));
 
-    // Phase 2: Full import in background
     try {
       const result = await processImport({
         file,
         id,
         parentId,
         forceCopyToProject: options?.forceCopyToProject === true,
+        typeOverride: type,
       });
       set((state) => finalizePlaceholder(state, id, result.mediaFile));
       log.info('Complete:', result.mediaFile.name);
       return result.mediaFile;
     } catch (err) {
       log.error(`Import failed: ${file.name}`, err);
-      // Remove placeholder on failure
       set((state) => ({
-        files: state.files.filter(f => f.id !== id),
+        files: state.files.filter((f) => f.id !== id),
       }));
       throw err;
     }
@@ -106,39 +111,38 @@ export const createFileImportSlice: MediaSliceCreator<FileImportActions> = (set,
     const fileArray = Array.from(files);
     const imported: MediaFile[] = [];
 
-    // Phase 1: Add all placeholders instantly
-    const entries = fileArray.map(file => ({
+    const entries = await Promise.all(fileArray.map(async (file) => ({
       file,
       id: generateId(),
-    }));
+      type: await resolveImportType(file),
+    })));
 
     set((state) => ({
       files: [
         ...state.files,
-        ...entries.map(e => createPlaceholder(e.file, e.id, parentId)),
+        ...entries.map((entry) => createPlaceholder(entry.file, entry.id, entry.type, parentId)),
       ],
     }));
 
-    // Phase 2: Process in parallel batches of 3
     const batchSize = 3;
     for (let i = 0; i < entries.length; i += batchSize) {
       const batch = entries.slice(i, i + batchSize);
       const results = await Promise.all(
-        batch.map(async ({ file, id }) => {
+        batch.map(async ({ file, id, type }) => {
           try {
-            const result = await processImport({ file, id, parentId });
+            const result = await processImport({ file, id, parentId, typeOverride: type });
             set((state) => finalizePlaceholder(state, id, result.mediaFile));
             return result.mediaFile;
           } catch (err) {
             log.error(`Import failed: ${file.name}`, err);
             set((state) => ({
-              files: state.files.filter(f => f.id !== id),
+              files: state.files.filter((f) => f.id !== id),
             }));
             return null;
           }
         })
       );
-      imported.push(...results.filter((r): r is MediaFile => r !== null));
+      imported.push(...results.filter((result): result is MediaFile => result !== null));
     }
 
     return imported;
@@ -149,36 +153,33 @@ export const createFileImportSlice: MediaSliceCreator<FileImportActions> = (set,
     if (!result || result.length === 0) return [];
 
     const imported: MediaFile[] = [];
-
-    // Phase 1: Add all placeholders instantly
-    const entries = result.map(({ file, handle }) => ({
+    const entries = await Promise.all(result.map(async ({ file, handle }) => ({
       file,
       handle,
       id: generateId(),
-    }));
+      type: await resolveImportType(file),
+    })));
 
     set((state) => ({
       files: [
         ...state.files,
-        ...entries.map(e => createPlaceholder(e.file, e.id)),
+        ...entries.map((entry) => createPlaceholder(entry.file, entry.id, entry.type)),
       ],
     }));
 
-    // Phase 2: Process each file
-    for (const { file, handle, id } of entries) {
-      // Store original handle
+    for (const { file, handle, id, type } of entries) {
       fileSystemService.storeFileHandle(id, handle);
       await projectDB.storeHandle(`media_${id}`, handle);
       log.debug('Stored file handle for ID:', id);
 
       try {
-        const importResult = await processImport({ file, id, handle });
+        const importResult = await processImport({ file, id, handle, typeOverride: type });
         set((state) => finalizePlaceholder(state, id, importResult.mediaFile));
         imported.push(importResult.mediaFile);
       } catch (err) {
         log.error(`Import failed: ${file.name}`, err);
         set((state) => ({
-          files: state.files.filter(f => f.id !== id),
+          files: state.files.filter((f) => f.id !== id),
         }));
       }
     }
@@ -189,36 +190,34 @@ export const createFileImportSlice: MediaSliceCreator<FileImportActions> = (set,
   importFilesWithHandles: async (filesWithHandles, parentId?: string | null) => {
     const imported: MediaFile[] = [];
 
-    // Phase 1: Add all placeholders instantly
-    const entries = filesWithHandles.map(({ file, handle, absolutePath }) => ({
+    const entries = await Promise.all(filesWithHandles.map(async ({ file, handle, absolutePath }) => ({
       file,
       handle,
       absolutePath,
       id: generateId(),
-    }));
+      type: await resolveImportType(file),
+    })));
 
     set((state) => ({
       files: [
         ...state.files,
-        ...entries.map(e => createPlaceholder(e.file, e.id, parentId)),
+        ...entries.map((entry) => createPlaceholder(entry.file, entry.id, entry.type, parentId)),
       ],
     }));
 
-    // Phase 2: Process each file
-    for (const { file, handle, absolutePath, id } of entries) {
-      // Store original handle
+    for (const { file, handle, absolutePath, id, type } of entries) {
       fileSystemService.storeFileHandle(id, handle);
       await projectDB.storeHandle(`media_${id}`, handle);
       log.debug('Stored file handle for ID:', id);
 
       try {
-        const importResult = await processImport({ file, id, handle, absolutePath, parentId });
+        const importResult = await processImport({ file, id, handle, absolutePath, parentId, typeOverride: type });
         set((state) => finalizePlaceholder(state, id, importResult.mediaFile));
         imported.push(importResult.mediaFile);
       } catch (err) {
         log.error(`Import failed: ${file.name}`, err);
         set((state) => ({
-          files: state.files.filter(f => f.id !== id),
+          files: state.files.filter((f) => f.id !== id),
         }));
       }
     }
@@ -237,7 +236,7 @@ export const createFileImportSlice: MediaSliceCreator<FileImportActions> = (set,
       f.name === file.name && f.fileSize === file.size && !f.isImporting
     );
     if (existing) {
-      log.info(`Skipping duplicate gaussian avatar: ${file.name} (${file.size} bytes) — already exists as ${existing.id}`);
+      log.info(`Skipping duplicate gaussian avatar: ${file.name} (${file.size} bytes) - already exists as ${existing.id}`);
       return existing;
     }
 
@@ -278,19 +277,17 @@ export const createFileImportSlice: MediaSliceCreator<FileImportActions> = (set,
   },
 
   importGaussianSplat: async (file: File, parentId?: string | null) => {
-    // Deduplication: check if file with same name + size already exists
-    const existing = get().files.find(f =>
+    const existing = get().files.find((f) =>
       f.name === file.name && f.fileSize === file.size && !f.isImporting
     );
     if (existing) {
-      log.info(`Skipping duplicate gaussian splat: ${file.name} (${file.size} bytes) — already exists as ${existing.id}`);
+      log.info(`Skipping duplicate gaussian splat: ${file.name} (${file.size} bytes) - already exists as ${existing.id}`);
       return existing;
     }
 
     const id = generateId();
     log.info(`Starting gaussian splat import: ${file.name} type: ${file.type} size: ${file.size}`);
 
-    // Phase 1: Add placeholder instantly with forced gaussian-splat type
     const placeholder: MediaFile = {
       id,
       name: file.name,
@@ -306,7 +303,6 @@ export const createFileImportSlice: MediaSliceCreator<FileImportActions> = (set,
       files: [...state.files, placeholder],
     }));
 
-    // Phase 2: Full import in background with type override
     try {
       const result = await processImport({ file, id, parentId, typeOverride: 'gaussian-splat' });
       set((state) => finalizePlaceholder(state, id, result.mediaFile));
@@ -314,9 +310,8 @@ export const createFileImportSlice: MediaSliceCreator<FileImportActions> = (set,
       return result.mediaFile;
     } catch (err) {
       log.error(`Gaussian splat import failed: ${file.name}`, err);
-      // Remove placeholder on failure
       set((state) => ({
-        files: state.files.filter(f => f.id !== id),
+        files: state.files.filter((f) => f.id !== id),
       }));
       throw err;
     }

--- a/src/stores/mediaStore/slices/fileManageSlice.ts
+++ b/src/stores/mediaStore/slices/fileManageSlice.ts
@@ -1,7 +1,7 @@
 // File management actions - remove, rename, reload
 // SIMPLIFIED: Uses RAW folder for easy relinking
 
-import type { MediaSliceCreator } from '../types';
+import type { MediaSliceCreator, MediaState } from '../types';
 import { projectFileService } from '../../../services/projectFileService';
 import { fileSystemService } from '../../../services/fileSystemService';
 import { projectDB } from '../../../services/projectDB';
@@ -9,12 +9,17 @@ import { useTimelineStore } from '../../timeline';
 import { Logger } from '../../../services/logger';
 import { engine } from '../../../engine/WebGPUEngine';
 import { thumbnailCacheService } from '../../../services/thumbnailCacheService';
+import { lottieRuntimeManager } from '../../../services/vectorAnimation/LottieRuntimeManager';
+import { readLottieMetadata } from '../../../services/vectorAnimation/lottieMetadata';
+import { createThumbnail } from '../helpers/thumbnailHelpers';
 
 const log = Logger.create('Reload');
+const isBlobUrl = (value?: string): value is string => typeof value === 'string' && value.startsWith('blob:');
 
 export interface FileManageActions {
   removeFile: (id: string) => void;
   renameFile: (id: string, name: string) => void;
+  refreshFileUrls: (id: string, options?: { refreshThumbnail?: boolean }) => Promise<boolean>;
   reloadFile: (id: string) => Promise<boolean>;
   reloadAllFiles: () => Promise<number>;
 }
@@ -35,6 +40,52 @@ export const createFileManageSlice: MediaSliceCreator<FileManageActions> = (set,
     set((state) => ({
       files: state.files.map((f) => (f.id === id ? { ...f, name } : f)),
     }));
+  },
+
+  refreshFileUrls: async (id: string, options) => {
+    const mediaFile = get().files.find((f) => f.id === id);
+    if (!mediaFile) return false;
+
+    if (!mediaFile.file) {
+      return (get() as MediaState & FileManageActions).reloadFile(id);
+    }
+
+    const refreshThumbnail = options?.refreshThumbnail ?? true;
+    const oldUrl = mediaFile.url;
+    const oldThumbnailUrl = mediaFile.thumbnailUrl;
+    const url = URL.createObjectURL(mediaFile.file);
+    let thumbnailUrl = mediaFile.thumbnailUrl;
+
+    if (refreshThumbnail) {
+      if (mediaFile.type === 'image') {
+        thumbnailUrl = URL.createObjectURL(mediaFile.file);
+      } else if (mediaFile.type === 'video') {
+        thumbnailUrl = await createThumbnail(mediaFile.file, 'video');
+      }
+    }
+
+    set((state) => ({
+      files: state.files.map((file) =>
+        file.id === id
+          ? { ...file, url, thumbnailUrl }
+          : file
+      ),
+    }));
+
+    if (isBlobUrl(oldUrl)) {
+      URL.revokeObjectURL(oldUrl);
+    }
+
+    if (refreshThumbnail && isBlobUrl(oldThumbnailUrl) && oldThumbnailUrl !== oldUrl) {
+      URL.revokeObjectURL(oldThumbnailUrl);
+    }
+
+    log.info('Refreshed media blob URLs', {
+      id: mediaFile.id,
+      name: mediaFile.name,
+      refreshThumbnail,
+    });
+    return true;
   },
 
   /**
@@ -301,6 +352,37 @@ export async function updateTimelineClips(mediaFileId: string, file: File): Prom
           isLoading: false,
         });
       }, { once: true });
+    } else if (sourceType === 'lottie') {
+      try {
+        const metadata = await readLottieMetadata(file);
+        const runtime = await lottieRuntimeManager.prepareClipSource({
+          ...clip,
+          file,
+          source: {
+            ...clip.source!,
+            textCanvas: clip.source?.textCanvas,
+          },
+        }, file);
+
+        timelineStore.updateClip(clip.id, {
+          file,
+          needsReload: false,
+          isLoading: false,
+          source: {
+            ...clip.source!,
+            type: 'lottie',
+            textCanvas: runtime.canvas,
+            naturalDuration: metadata.duration ?? clip.duration,
+            mediaFileId,
+          },
+        });
+      } catch (error) {
+        log.warn('Failed to reload lottie for clip', { clipName: clip.name, error });
+        timelineStore.updateClip(clip.id, {
+          needsReload: false,
+          isLoading: false,
+        });
+      }
     } else if (sourceType === 'model') {
       // 3D Model — create blob URL for Three.js loader
       const modelUrl = URL.createObjectURL(file);

--- a/src/stores/mediaStore/types.ts
+++ b/src/stores/mediaStore/types.ts
@@ -2,9 +2,25 @@
 
 import type { CompositionTimelineData, TranscriptWord, TranscriptStatus, AnalysisStatus } from '../../types';
 import type { SplatEffectorSettings } from '../../types/splatEffector';
+import type { VectorAnimationMetadata, VectorAnimationProvider } from '../../types/vectorAnimation';
 
 // Media item types
-export type MediaType = 'video' | 'audio' | 'image' | 'composition' | 'text' | 'solid' | 'model' | 'camera' | 'gaussian-avatar' | 'gaussian-splat' | 'splat-effector';
+export type ImportedMediaType =
+  | 'video'
+  | 'audio'
+  | 'image'
+  | 'model'
+  | 'gaussian-avatar'
+  | 'gaussian-splat'
+  | VectorAnimationProvider;
+
+export type MediaType =
+  | ImportedMediaType
+  | 'composition'
+  | 'text'
+  | 'solid'
+  | 'camera'
+  | 'splat-effector';
 
 // Proxy status for video files
 export type ProxyStatus = 'none' | 'generating' | 'ready' | 'error';
@@ -54,7 +70,7 @@ export interface MediaItem {
 
 // Imported file
 export interface MediaFile extends MediaItem {
-  type: 'video' | 'audio' | 'image' | 'model' | 'gaussian-avatar' | 'gaussian-splat';
+  type: ImportedMediaType;
   file?: File;
   url: string;
   duration?: number;
@@ -91,6 +107,7 @@ export interface MediaFile extends MediaItem {
   projectPath?: string;
   // Import loading state
   isImporting?: boolean;
+  vectorAnimation?: VectorAnimationMetadata;
 }
 
 // Text item (for Media Panel - can be dragged to timeline)

--- a/src/stores/timeline/clip/addCompClip.ts
+++ b/src/stores/timeline/clip/addCompClip.ts
@@ -2,6 +2,7 @@
 // Handles nested composition loading, audio mixdown, and linked audio creation
 
 import type { TimelineClip, TimelineTrack, CompositionTimelineData, SerializableClip, Keyframe } from '../../../types';
+import type { VectorAnimationClipSettings } from '../../../types/vectorAnimation';
 import type { Composition } from '../types';
 import { DEFAULT_TRANSFORM, calculateNativeScale, MAX_NESTING_DEPTH } from '../constants';
 import { useMediaStore } from '../../mediaStore';
@@ -13,6 +14,7 @@ import { blobUrlManager } from '../helpers/blobUrlManager';
 import { updateClipById } from '../helpers/clipStateHelpers';
 import { Logger } from '../../../services/logger';
 import { thumbnailRenderer } from '../../../services/thumbnailRenderer';
+import { lottieRuntimeManager } from '../../../services/vectorAnimation/LottieRuntimeManager';
 // Note: compositionRenderer is used elsewhere for cache invalidation
 
 const log = Logger.create('AddCompClip');
@@ -160,6 +162,24 @@ export async function buildClipSegments(
         }
       } catch (e) {
         log.warn('Failed to generate image segment thumbnail', { clipId: serializedClip.id });
+      }
+    } else if (nestedClip?.source?.textCanvas) {
+      if (nestedClip.source.type === 'lottie') {
+        lottieRuntimeManager.renderClipAtTime(nestedClip, nestedClip.startTime);
+      }
+
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = 160;
+        canvas.height = 90;
+        const ctx = canvas.getContext('2d');
+        if (ctx) {
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
+          ctx.drawImage(nestedClip.source.textCanvas, 0, 0, canvas.width, canvas.height);
+          thumbnails = [canvas.toDataURL('image/jpeg', 0.7)];
+        }
+      } catch (e) {
+        log.warn('Failed to generate canvas segment thumbnail', { clipId: serializedClip.id, error: e });
       }
     }
 
@@ -337,21 +357,31 @@ async function loadSubNestedClips(
       inPoint: sc.inPoint,
       outPoint: sc.outPoint,
       source: null,
+      mediaFileId: sc.mediaFileId,
       thumbnails: sc.thumbnails,
       transform: sc.transform,
       effects: sc.effects || [],
       masks: sc.masks || [],
+      reversed: sc.reversed,
+      speed: sc.speed,
+      preservesPitch: sc.preservesPitch,
       isLoading: true,
     };
     result.push(clip);
 
     // Load media directly on the clip object (no store update needed)
     const type = sc.sourceType;
-    const fileUrl = blobUrlManager.create(clipId, mediaFile.file, (type === 'video' ? 'video' : type === 'audio' ? 'audio' : type === 'model' ? 'model' : 'image') as 'video' | 'audio' | 'image' | 'model');
+    const fileUrl = type === 'lottie'
+      ? null
+      : blobUrlManager.create(
+        clipId,
+        mediaFile.file,
+        (type === 'video' ? 'video' : type === 'audio' ? 'audio' : type === 'model' ? 'model' : 'image') as 'video' | 'audio' | 'image' | 'model'
+      );
 
     if (type === 'video') {
       const video = document.createElement('video');
-      video.src = fileUrl;
+      video.src = fileUrl!;
       video.muted = true;
       video.playsInline = true;
       video.preload = 'auto';
@@ -376,21 +406,44 @@ async function loadSubNestedClips(
       }, { once: true });
     } else if (type === 'image') {
       const img = new Image();
-      img.src = fileUrl;
+      img.src = fileUrl!;
       img.addEventListener('load', () => {
         clip.source = { type: 'image', imageElement: img };
         clip.isLoading = false;
       }, { once: true });
     } else if (type === 'audio') {
       const audio = document.createElement('audio');
-      audio.src = fileUrl;
+      audio.src = fileUrl!;
       audio.preload = 'auto';
       audio.addEventListener('canplaythrough', () => {
         clip.source = { type: 'audio', audioElement: audio, naturalDuration: audio.duration };
         clip.isLoading = false;
       }, { once: true });
+    } else if (type === 'lottie') {
+      clip.source = {
+        type: 'lottie',
+        mediaFileId: sc.mediaFileId,
+        naturalDuration: sc.naturalDuration,
+        vectorAnimationSettings: sc.vectorAnimationSettings,
+      };
+      void lottieRuntimeManager.prepareClipSource(clip, mediaFile.file).then((runtime) => {
+        const naturalDuration = runtime.metadata.duration ?? sc.naturalDuration ?? sc.duration;
+        clip.source = {
+          type: 'lottie',
+          textCanvas: runtime.canvas,
+          mediaFileId: sc.mediaFileId,
+          naturalDuration,
+          vectorAnimationSettings: sc.vectorAnimationSettings,
+        };
+        clip.isLoading = false;
+        lottieRuntimeManager.renderClipAtTime(clip, clip.startTime);
+        log.debug('Sub-nested lottie loaded', { clipId, name: clip.name, depth });
+      }).catch((error) => {
+        clip.isLoading = false;
+        log.warn('Failed to load sub-nested lottie', { clipId, error });
+      });
     } else if (type === 'model') {
-      clip.source = { type: 'model', modelUrl: fileUrl, naturalDuration: 3600 };
+      clip.source = { type: 'model', modelUrl: fileUrl!, naturalDuration: 3600 };
       clip.is3D = true;
       clip.isLoading = false;
     }
@@ -510,6 +563,7 @@ export async function loadNestedClips(params: LoadNestedClipsParams): Promise<Ti
       inPoint: serializedClip.inPoint,
       outPoint: serializedClip.outPoint,
       source: null,
+      mediaFileId: serializedClip.mediaFileId,
       thumbnails: serializedClip.thumbnails,
       linkedClipId: serializedClip.linkedClipId,
       waveform: serializedClip.waveform,
@@ -518,6 +572,9 @@ export async function loadNestedClips(params: LoadNestedClipsParams): Promise<Ti
       masks: serializedClip.masks || [],
       isLoading: true,
       is3D: serializedClip.is3D,
+      reversed: serializedClip.reversed,
+      speed: serializedClip.speed,
+      preservesPitch: serializedClip.preservesPitch,
     };
 
     nestedClips.push(nestedClip);
@@ -540,18 +597,34 @@ export async function loadNestedClips(params: LoadNestedClipsParams): Promise<Ti
     // Load media element async - track URL for cleanup
     const type = serializedClip.sourceType;
     const urlType = type === 'video' ? 'video' : type === 'audio' ? 'audio' : type === 'model' ? 'model' : 'image';
-    const fileUrl = blobUrlManager.create(nestedClip.id, mediaFile.file, urlType as 'video' | 'audio' | 'image' | 'model');
+    const fileUrl = type === 'lottie'
+      ? null
+      : blobUrlManager.create(nestedClip.id, mediaFile.file, urlType as 'video' | 'audio' | 'image' | 'model');
 
     if (type === 'video') {
-      loadVideoNestedClip(compClipId, nestedClip.id, fileUrl, mediaFile.file, get, set);
+      loadVideoNestedClip(compClipId, nestedClip.id, fileUrl!, mediaFile.file, get, set);
     } else if (type === 'audio') {
-      loadAudioNestedClip(compClipId, nestedClip.id, fileUrl, get, set);
+      loadAudioNestedClip(compClipId, nestedClip.id, fileUrl!, get, set);
     } else if (type === 'image') {
-      loadImageNestedClip(compClipId, nestedClip.id, fileUrl, get, set);
+      loadImageNestedClip(compClipId, nestedClip.id, fileUrl!, get, set);
+    } else if (type === 'lottie') {
+      loadLottieNestedClip(
+        compClipId,
+        nestedClip.id,
+        mediaFile.file,
+        {
+          mediaFileId: serializedClip.mediaFileId,
+          naturalDuration: serializedClip.naturalDuration,
+          vectorAnimationSettings: serializedClip.vectorAnimationSettings,
+        },
+        nestedClip,
+        get,
+        set
+      );
     } else if (type === 'model') {
       // 3D model — set directly on clip object (synchronous, no async load needed)
       // Must mutate the local object because the array is returned before store updates apply
-      nestedClip.source = { type: 'model', modelUrl: fileUrl, naturalDuration: 3600 };
+      nestedClip.source = { type: 'model', modelUrl: fileUrl!, naturalDuration: 3600 };
       nestedClip.is3D = true;
       nestedClip.isLoading = false;
     }
@@ -726,6 +799,80 @@ function loadImageNestedClip(
 
     log.debug('Nested image loaded', { compClipId, nestedClipId });
   }, { once: true });
+}
+
+function loadLottieNestedClip(
+  compClipId: string,
+  nestedClipId: string,
+  file: File,
+  sourceInfo: {
+    mediaFileId?: string;
+    naturalDuration?: number;
+    vectorAnimationSettings?: VectorAnimationClipSettings;
+  },
+  targetClip: TimelineClip | undefined,
+  get: CompClipStoreGet,
+  set: CompClipStoreSet
+): void {
+  const baseClip = get().clips
+    .find((clip) => clip.id === compClipId)
+    ?.nestedClips?.find((clip) => clip.id === nestedClipId) ?? targetClip;
+
+  const runtimeClip: TimelineClip = {
+    ...(baseClip ?? {
+      id: nestedClipId,
+      trackId: '',
+      name: file.name,
+      file,
+      startTime: 0,
+      duration: sourceInfo.naturalDuration ?? 0,
+      inPoint: 0,
+      outPoint: sourceInfo.naturalDuration ?? 0,
+      transform: { ...DEFAULT_TRANSFORM },
+      effects: [],
+    }),
+    file,
+    source: {
+      type: 'lottie',
+      mediaFileId: sourceInfo.mediaFileId,
+      naturalDuration: sourceInfo.naturalDuration,
+      vectorAnimationSettings: sourceInfo.vectorAnimationSettings,
+    },
+  };
+
+  void lottieRuntimeManager.prepareClipSource(runtimeClip, file).then((runtime) => {
+    const naturalDuration =
+      runtime.metadata.duration ??
+      sourceInfo.naturalDuration ??
+      runtimeClip.duration;
+    runtimeClip.source = {
+      type: 'lottie',
+      textCanvas: runtime.canvas,
+      mediaFileId: sourceInfo.mediaFileId,
+      naturalDuration,
+      vectorAnimationSettings: sourceInfo.vectorAnimationSettings,
+    };
+    lottieRuntimeManager.renderClipAtTime(runtimeClip, runtimeClip.startTime);
+
+    set({
+      clips: updateNestedClipInCompClip(get().clips, compClipId, nestedClipId, {
+        file,
+        source: runtimeClip.source,
+        isLoading: false,
+      }),
+    });
+
+    const { invalidateCache } = get();
+    invalidateCache?.();
+    log.debug('Nested lottie loaded', { compClipId, nestedClipId });
+  }).catch((error) => {
+    set({
+      clips: updateNestedClipInCompClip(get().clips, compClipId, nestedClipId, {
+        isLoading: false,
+      }),
+    });
+    log.warn('Nested lottie load failed', { compClipId, nestedClipId, error });
+  });
 }
 
 export interface GenerateCompThumbnailsParams {

--- a/src/stores/timeline/clip/addLottieClip.ts
+++ b/src/stores/timeline/clip/addLottieClip.ts
@@ -1,0 +1,87 @@
+import type { TimelineClip } from '../../../types';
+import {
+  DEFAULT_VECTOR_ANIMATION_CLIP_SETTINGS,
+  type VectorAnimationMetadata,
+} from '../../../types/vectorAnimation';
+import { lottieRuntimeManager } from '../../../services/vectorAnimation/LottieRuntimeManager';
+import { DEFAULT_TRANSFORM, calculateNativeScale } from '../constants';
+import { generateClipId } from '../helpers/idGenerator';
+
+export interface AddLottieClipParams {
+  trackId: string;
+  file: File;
+  startTime: number;
+  estimatedDuration: number;
+  mediaFileId?: string;
+  metadata?: VectorAnimationMetadata;
+}
+
+export function createLottieClipPlaceholder(params: AddLottieClipParams): TimelineClip {
+  const { trackId, file, startTime, estimatedDuration, mediaFileId, metadata } = params;
+  const clipId = generateClipId('clip-lottie');
+  const duration = metadata?.duration ?? estimatedDuration;
+  const nativeScale = (metadata?.width && metadata?.height)
+    ? calculateNativeScale(metadata.width, metadata.height)
+    : { x: 1, y: 1 };
+
+  return {
+    id: clipId,
+    trackId,
+    name: file.name,
+    file,
+    startTime,
+    duration,
+    inPoint: 0,
+    outPoint: duration,
+    source: {
+      type: 'lottie',
+      naturalDuration: metadata?.duration ?? duration,
+      mediaFileId,
+      vectorAnimationSettings: { ...DEFAULT_VECTOR_ANIMATION_CLIP_SETTINGS },
+    },
+    mediaFileId,
+    transform: { ...DEFAULT_TRANSFORM, scale: nativeScale },
+    effects: [],
+    isLoading: true,
+  };
+}
+
+export interface LoadLottieMediaParams {
+  clip: TimelineClip;
+  file: File;
+  mediaFileId?: string;
+  metadata?: VectorAnimationMetadata;
+  updateClip: (id: string, updates: Partial<TimelineClip>) => void;
+}
+
+export async function loadLottieMedia(params: LoadLottieMediaParams): Promise<void> {
+  const { clip, file, mediaFileId, metadata, updateClip } = params;
+  const runtime = await lottieRuntimeManager.prepareClipSource(clip, file);
+  const resolvedMetadata = metadata ?? runtime.metadata;
+  const naturalDuration = resolvedMetadata.duration ?? clip.duration;
+  const nativeScale = (resolvedMetadata.width && resolvedMetadata.height)
+    ? calculateNativeScale(resolvedMetadata.width, resolvedMetadata.height)
+    : clip.transform.scale;
+
+  updateClip(clip.id, {
+    file,
+    duration: naturalDuration,
+    outPoint: naturalDuration,
+    source: {
+      ...clip.source!,
+      type: 'lottie',
+      mediaFileId,
+      naturalDuration,
+      textCanvas: runtime.canvas,
+      vectorAnimationSettings: {
+        ...DEFAULT_VECTOR_ANIMATION_CLIP_SETTINGS,
+        ...clip.source?.vectorAnimationSettings,
+      },
+    },
+    transform: {
+      ...clip.transform,
+      scale: nativeScale,
+    },
+    isLoading: false,
+  });
+}

--- a/src/stores/timeline/clipSlice.ts
+++ b/src/stores/timeline/clipSlice.ts
@@ -24,10 +24,11 @@ function deepCloneClipProps(clip: TimelineClip): Partial<TimelineClip> {
 }
 
 // Import extracted modules
-import { detectMediaType } from './helpers/mediaTypeHelpers';
+import { classifyMediaType } from './helpers/mediaTypeHelpers';
 import { loadVideoMedia } from './clip/addVideoClip';
 import { createAudioClipPlaceholder, loadAudioMedia } from './clip/addAudioClip';
 import { createImageClipPlaceholder, loadImageMedia } from './clip/addImageClip';
+import { createLottieClipPlaceholder, loadLottieMedia } from './clip/addLottieClip';
 import { createModelClipPlaceholder, loadModelMedia } from './clip/addModelClip';
 import { createGaussianSplatClipPlaceholder, loadGaussianSplatMedia } from './clip/addGaussianSplatClip';
 import { createVideoElement, createAudioElement } from './helpers/webCodecsHelpers';
@@ -44,10 +45,12 @@ import {
 } from './helpers/idGenerator';
 import { blobUrlManager } from './helpers/blobUrlManager';
 import { updateClipById } from './helpers/clipStateHelpers';
+import { readLottieMetadata } from '../../services/vectorAnimation/lottieMetadata';
+import { lottieRuntimeManager } from '../../services/vectorAnimation/LottieRuntimeManager';
 
 export const createClipSlice: SliceCreator<CoreClipActions> = (set, get) => ({
   addClip: async (trackId, file, startTime, providedDuration, mediaFileId, mediaTypeOverride?) => {
-    const mediaType = (mediaTypeOverride as ReturnType<typeof detectMediaType> | 'gaussian-avatar' | 'gaussian-splat') || detectMediaType(file);
+    const mediaType = (mediaTypeOverride as Awaited<ReturnType<typeof classifyMediaType>> | 'gaussian-avatar' | 'gaussian-splat') || await classifyMediaType(file);
     const estimatedDuration = providedDuration ?? 5;
 
     log.debug('Adding clip', { mediaType, file: file.name });
@@ -60,8 +63,13 @@ export const createClipSlice: SliceCreator<CoreClipActions> = (set, get) => ({
       return;
     }
 
-    if ((mediaType === 'video' || mediaType === 'image' || mediaType === 'model' || mediaType === 'gaussian-avatar' || mediaType === 'gaussian-splat') && targetTrack.type !== 'video') {
-      log.warn('Cannot add video/image/model/gaussian-avatar/gaussian-splat to audio track');
+    if (mediaType === 'unknown') {
+      log.warn('Unsupported clip type', { file: file.name });
+      return;
+    }
+
+    if ((mediaType === 'video' || mediaType === 'image' || mediaType === 'lottie' || mediaType === 'model' || mediaType === 'gaussian-avatar' || mediaType === 'gaussian-splat') && targetTrack.type !== 'video') {
+      log.warn('Cannot add visual clip to audio track');
       return;
     }
     if (mediaType === 'audio' && targetTrack.type !== 'audio') {
@@ -80,12 +88,19 @@ export const createClipSlice: SliceCreator<CoreClipActions> = (set, get) => ({
 
     // Look up transcript from MediaFile for carry-over to new clips
     let sourceTranscript: import('../../types').TranscriptWord[] | undefined;
+    let sourceMediaFile:
+      | {
+        transcript?: import('../../types').TranscriptWord[];
+        transcriptStatus?: string;
+        vectorAnimation?: import('../../types').VectorAnimationMetadata;
+      }
+      | undefined;
     if (mediaFileId) {
       try {
         const { useMediaStore } = await import('../mediaStore');
-        const mf = useMediaStore.getState().files.find((f: { id: string }) => f.id === mediaFileId);
-        if (mf?.transcriptStatus === 'ready' && mf.transcript?.length) {
-          sourceTranscript = mf.transcript;
+        sourceMediaFile = useMediaStore.getState().files.find((f: { id: string }) => f.id === mediaFileId);
+        if (sourceMediaFile?.transcriptStatus === 'ready' && sourceMediaFile.transcript?.length) {
+          sourceTranscript = sourceMediaFile.transcript;
         }
       } catch { /* mediaStore not ready */ }
     }
@@ -208,6 +223,31 @@ export const createClipSlice: SliceCreator<CoreClipActions> = (set, get) => ({
         file,
         mediaFileId,
         waveformsEnabled,
+        updateClip,
+      });
+
+      invalidateCache();
+      return;
+    }
+
+    if (mediaType === 'lottie') {
+      const vectorAnimationMetadata = sourceMediaFile?.vectorAnimation ?? await readLottieMetadata(file);
+      const lottieClip = createLottieClipPlaceholder({
+        trackId,
+        file,
+        startTime,
+        estimatedDuration: providedDuration ?? vectorAnimationMetadata.duration ?? estimatedDuration,
+        mediaFileId,
+        metadata: vectorAnimationMetadata,
+      });
+      set({ clips: [...clips, lottieClip] });
+      updateDuration();
+
+      await loadLottieMedia({
+        clip: lottieClip,
+        file,
+        mediaFileId,
+        metadata: vectorAnimationMetadata,
         updateClip,
       });
 
@@ -361,6 +401,9 @@ export const createClipSlice: SliceCreator<CoreClipActions> = (set, get) => ({
         audio.src = '';
         audio.load();
       }
+      if (clip.source?.type === 'lottie') {
+        lottieRuntimeManager.destroyClipRuntime(clip.id);
+      }
       blobUrlManager.revokeAll(removeId);
     }
 
@@ -398,7 +441,7 @@ export const createClipSlice: SliceCreator<CoreClipActions> = (set, get) => ({
       const targetTrack = tracks.find(t => t.id === newTrackId);
       const sourceType = movingClip.source?.type;
       if (targetTrack && sourceType) {
-        if ((sourceType === 'video' || sourceType === 'image' || sourceType === 'camera') && targetTrack.type !== 'video') return;
+        if ((sourceType === 'video' || sourceType === 'image' || sourceType === 'lottie' || sourceType === 'camera') && targetTrack.type !== 'video') return;
         if (sourceType === 'audio' && targetTrack.type !== 'audio') return;
       }
     }

--- a/src/stores/timeline/clipboardSlice.ts
+++ b/src/stores/timeline/clipboardSlice.ts
@@ -7,6 +7,7 @@ import { Logger } from '../../services/logger';
 import { captureSnapshot } from '../historyStore';
 import { DEFAULT_SCENE_CAMERA_SETTINGS } from '../mediaStore';
 import { DEFAULT_SPLAT_EFFECTOR_SETTINGS } from '../../types/splatEffector';
+import { lottieRuntimeManager } from '../../services/vectorAnimation/LottieRuntimeManager';
 
 const log = Logger.create('Clipboard');
 
@@ -55,6 +56,9 @@ export const createClipboardSlice: SliceCreator<ClipboardActions> = (set, get) =
         outPoint: clip.outPoint,
         sourceType: clip.source?.type || 'video',
         naturalDuration: clip.source?.naturalDuration,
+        vectorAnimationSettings: clip.source?.vectorAnimationSettings
+          ? { ...clip.source.vectorAnimationSettings }
+          : undefined,
         cameraSettings: clip.source?.type === 'camera' && clip.source.cameraSettings
           ? { ...clip.source.cameraSettings }
           : undefined,
@@ -194,6 +198,11 @@ export const createClipboardSlice: SliceCreator<ClipboardActions> = (set, get) =
           type: 'text' as const,
           mediaFileId: clipData.mediaFileId,
           naturalDuration: clipData.naturalDuration ?? clipData.duration,
+        } : clipData.sourceType === 'lottie' && clipData.mediaFileId ? {
+          type: 'lottie' as const,
+          mediaFileId: clipData.mediaFileId,
+          naturalDuration: clipData.naturalDuration ?? clipData.duration,
+          vectorAnimationSettings: clipData.vectorAnimationSettings,
         } : clipData.mediaFileId ? {
           type: clipData.sourceType,
           mediaFileId: clipData.mediaFileId,
@@ -268,7 +277,7 @@ export const createClipboardSlice: SliceCreator<ClipboardActions> = (set, get) =
     log.info('Pasted clips', { count: newClips.length, ids: newClips.map(c => c.id) });
 
     // Reload media for pasted clips asynchronously
-    import('../mediaStore').then(({ useMediaStore }) => {
+    import('../mediaStore').then(async ({ useMediaStore }) => {
       const mediaStore = useMediaStore.getState();
 
       for (const newClip of newClips) {
@@ -370,9 +379,60 @@ export const createClipboardSlice: SliceCreator<ClipboardActions> = (set, get) =
           continue;
         }
 
-        // Load media based on type
-        const fileUrl = URL.createObjectURL(mediaFile.file);
         const sourceType = newClip.source?.type;
+
+        if (sourceType === 'lottie') {
+          try {
+            const runtimeClip: TimelineClip = {
+              ...newClip,
+              file: mediaFile.file,
+              source: {
+                type: 'lottie',
+                mediaFileId,
+                naturalDuration: newClip.source?.naturalDuration ?? newClip.duration,
+                vectorAnimationSettings: newClip.source?.vectorAnimationSettings,
+              },
+            };
+            const runtime = await lottieRuntimeManager.prepareClipSource(runtimeClip, mediaFile.file);
+            const naturalDuration =
+              runtime.metadata.duration ??
+              newClip.source?.naturalDuration ??
+              newClip.duration;
+            lottieRuntimeManager.renderClipAtTime(runtimeClip, runtimeClip.startTime);
+
+            set((state) => ({
+              clips: state.clips.map((c) =>
+                c.id === newClip.id
+                  ? {
+                      ...c,
+                      file: mediaFile.file!,
+                      source: {
+                        type: 'lottie' as const,
+                        textCanvas: runtime.canvas,
+                        mediaFileId,
+                        naturalDuration,
+                        vectorAnimationSettings: runtimeClip.source?.vectorAnimationSettings,
+                      },
+                      isLoading: false,
+                      needsReload: false,
+                    }
+                  : c
+              ),
+            }));
+          } catch (error) {
+            log.warn('Failed to restore pasted lottie clip', { clipId: newClip.id, error });
+            set((state) => ({
+              clips: state.clips.map((c) =>
+                c.id === newClip.id
+                  ? { ...c, isLoading: false }
+                  : c
+              ),
+            }));
+          }
+          continue;
+        }
+
+        const fileUrl = URL.createObjectURL(mediaFile.file);
 
         if (sourceType === 'video') {
           const video = document.createElement('video');

--- a/src/stores/timeline/helpers/mediaTypeHelpers.ts
+++ b/src/stores/timeline/helpers/mediaTypeHelpers.ts
@@ -1,12 +1,15 @@
 // Media type detection helpers - shared across clipSlice and other components
 // Eliminates duplication of file type detection logic
 
+import { readLottieJsonFile } from '../../../services/vectorAnimation/lottieJsonSniffer';
+
 export const AUDIO_EXTENSIONS = ['wav', 'mp3', 'ogg', 'flac', 'aac', 'm4a', 'wma', 'aiff', 'opus'] as const;
 export const VIDEO_EXTENSIONS = ['mp4', 'webm', 'mov', 'avi', 'mkv', 'wmv', 'm4v', 'flv'] as const;
 export const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg'] as const;
 export const MODEL_EXTENSIONS = ['obj', 'gltf', 'glb', 'fbx'] as const;
+export const VECTOR_ANIMATION_EXTENSIONS = ['lottie', 'riv'] as const;
 
-export type MediaType = 'video' | 'audio' | 'image' | 'model' | 'gaussian-splat' | 'unknown';
+export type MediaType = 'video' | 'audio' | 'image' | 'model' | 'gaussian-splat' | 'lottie' | 'rive' | 'unknown';
 
 /**
  * Detect the media type of a file using MIME type with fallback to extension.
@@ -29,7 +32,26 @@ export function detectMediaType(file: File): MediaType {
   if (GAUSSIAN_SPLAT_EXTENSIONS.includes(ext as typeof GAUSSIAN_SPLAT_EXTENSIONS[number])) {
     return 'gaussian-splat';
   }
+  if (ext === 'lottie') {
+    return 'lottie';
+  }
+  if (ext === 'riv') {
+    return 'rive';
+  }
   return 'unknown';
+}
+
+/**
+ * Async media type classification for formats that require content sniffing.
+ */
+export async function classifyMediaType(file: File): Promise<MediaType> {
+  const syncType = detectMediaType(file);
+  if (syncType !== 'unknown') {
+    return syncType;
+  }
+
+  const lottieJson = await readLottieJsonFile(file);
+  return lottieJson ? 'lottie' : 'unknown';
 }
 
 /**
@@ -94,4 +116,10 @@ export function isGaussianSplatFile(file: File | string): boolean {
   const name = typeof file === 'string' ? file : file.name;
   const ext = name.split('.').pop()?.toLowerCase() || '';
   return GAUSSIAN_SPLAT_EXTENSIONS.includes(ext as typeof GAUSSIAN_SPLAT_EXTENSIONS[number]);
+}
+
+export function isVectorAnimationFile(file: File | string): boolean {
+  const name = typeof file === 'string' ? file : file.name;
+  const ext = name.split('.').pop()?.toLowerCase() || '';
+  return VECTOR_ANIMATION_EXTENSIONS.includes(ext as typeof VECTOR_ANIMATION_EXTENSIONS[number]);
 }

--- a/src/stores/timeline/serializationUtils.ts
+++ b/src/stores/timeline/serializationUtils.ts
@@ -14,6 +14,8 @@ import { sanitizePlayheadPosition } from '../../services/layerBuilder/PlayheadSt
 import { thumbnailCacheService } from '../../services/thumbnailCacheService';
 import type { WebCodecsPlayer } from '../../engine/WebCodecsPlayer';
 import { DEFAULT_GAUSSIAN_SPLAT_SETTINGS } from '../../engine/gaussian/types';
+import { lottieRuntimeManager } from '../../services/vectorAnimation/LottieRuntimeManager';
+import { readLottieMetadata } from '../../services/vectorAnimation/lottieMetadata';
 
 const log = Logger.create('Timeline');
 
@@ -126,6 +128,7 @@ export const createSerializationUtils: SliceCreator<SerializationUtils> = (set, 
         text3DProperties: clip.text3DProperties ?? clip.source?.text3DProperties,
         // Solid clip support
         solidColor: clip.source?.type === 'solid' ? (clip.solidColor || clip.name.replace('Solid ', '')) : undefined,
+        vectorAnimationSettings: clip.source?.vectorAnimationSettings,
         // Clip label color
         // 3D layer support
         is3D: clip.is3D || undefined,
@@ -1184,6 +1187,7 @@ export const createSerializationUtils: SliceCreator<SerializationUtils> = (set, 
           type: serializedClip.sourceType,
           mediaFileId: serializedClip.mediaFileId, // Preserve mediaFileId for cache lookups
           naturalDuration: serializedClip.naturalDuration,
+          vectorAnimationSettings: serializedClip.vectorAnimationSettings,
         },
         mediaFileId: serializedClip.mediaFileId, // Restore top-level mediaFileId for audio/proxy lookup
         needsReload: needsReload, // Flag for UI to show reload indicator
@@ -1405,6 +1409,52 @@ export const createSerializationUtils: SliceCreator<SerializationUtils> = (set, 
           }));
           wakePreviewAfterRestore();
         }, { once: true });
+      } else if (type === 'lottie') {
+        void (async () => {
+          try {
+            const runtimeClip: TimelineClip = {
+              ...clip,
+              file: mediaFile.file!,
+              source: {
+                type: 'lottie',
+                mediaFileId: serializedClip.mediaFileId,
+                naturalDuration: serializedClip.naturalDuration,
+                vectorAnimationSettings: serializedClip.vectorAnimationSettings,
+              },
+            };
+            const metadata = await readLottieMetadata(mediaFile.file!);
+            const runtime = await lottieRuntimeManager.prepareClipSource(runtimeClip, mediaFile.file!);
+            set((state) => ({
+              clips: state.clips.map((currentClip) =>
+                currentClip.id === clip.id
+                  ? {
+                      ...currentClip,
+                      file: mediaFile.file!,
+                      source: {
+                        type: 'lottie',
+                        textCanvas: runtime.canvas,
+                        mediaFileId: serializedClip.mediaFileId,
+                        naturalDuration: metadata.duration ?? serializedClip.naturalDuration ?? serializedClip.duration,
+                        vectorAnimationSettings: serializedClip.vectorAnimationSettings,
+                      },
+                      isLoading: false,
+                      needsReload: false,
+                    }
+                  : currentClip
+              ),
+            }));
+            wakePreviewAfterRestore();
+          } catch (error) {
+            log.warn('Failed to restore lottie clip', { clip: clip.name, error });
+            set((state) => ({
+              clips: state.clips.map((currentClip) =>
+                currentClip.id === clip.id
+                  ? { ...currentClip, isLoading: false }
+                  : currentClip
+              ),
+            }));
+          }
+        })();
       } else if (type === 'model') {
         // 3D Model clips — just need a blob URL, Three.js handles loading
         set(state => ({
@@ -1520,6 +1570,9 @@ export const createSerializationUtils: SliceCreator<SerializationUtils> = (set, 
         try { if (audio.src) URL.revokeObjectURL(audio.src); } catch {}
         audio.removeAttribute('src');
         audio.load();
+      }
+      if (clip.source?.type === 'lottie') {
+        lottieRuntimeManager.destroyClipRuntime(clip.id);
       }
       // WebCodecsPlayers stay in globalWcpCache — don't destroy them.
       // Pause them so the decoder isn't running while detached.

--- a/src/stores/timeline/types.ts
+++ b/src/stores/timeline/types.ts
@@ -15,8 +15,10 @@ import type {
   TextClipProperties,
   Text3DProperties,
   Layer,
+  SerializableClip,
 } from '../../types';
 import type { Composition } from '../mediaStore';
+import type { VectorAnimationClipSettings } from '../../types/vectorAnimation';
 
 // Re-export imported types for convenience
 export type {
@@ -35,6 +37,7 @@ export type {
   TextClipProperties,
   Text3DProperties,
   Layer,
+  SerializableClip,
 };
 
 // Mask edit mode types
@@ -399,7 +402,7 @@ export interface ClipboardClipData {
   duration: number;
   inPoint: number;
   outPoint: number;
-  sourceType: 'video' | 'audio' | 'image' | 'text' | 'solid' | 'model' | 'camera' | 'gaussian-avatar' | 'gaussian-splat' | 'splat-effector';
+  sourceType: SerializableClip['sourceType'];
   naturalDuration?: number;
   transform: ClipTransform;
   effects: Effect[];
@@ -412,6 +415,7 @@ export interface ClipboardClipData {
   textProperties?: import('../../types').TextClipProperties;
   text3DProperties?: import('../../types').Text3DProperties;
   solidColor?: string;
+  vectorAnimationSettings?: VectorAnimationClipSettings;
   cameraSettings?: import('../mediaStore/types').SceneCameraSettings;
   meshType?: import('../mediaStore/types').MeshPrimitiveType;
   splatEffectorSettings?: import('../../types/splatEffector').SplatEffectorSettings;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,23 @@
 // Core types for WebVJ Mixer
 
+import type {
+  VectorAnimationClipSettings,
+  VectorAnimationProvider,
+} from './vectorAnimation';
+
+export type TimelineSourceType =
+  | 'video'
+  | 'audio'
+  | 'image'
+  | 'text'
+  | 'solid'
+  | 'model'
+  | 'camera'
+  | 'gaussian-avatar'
+  | 'gaussian-splat'
+  | 'splat-effector'
+  | VectorAnimationProvider;
+
 export interface Layer {
   id: string;
   name: string;
@@ -420,7 +438,7 @@ export interface TimelineClip {
   inPoint: number;        // Trim in point within source (seconds)
   outPoint: number;       // Trim out point within source (seconds)
   source: {
-    type: 'video' | 'audio' | 'image' | 'text' | 'solid' | 'model' | 'camera' | 'gaussian-avatar' | 'gaussian-splat' | 'splat-effector';
+    type: TimelineSourceType;
     modelUrl?: string;  // Blob URL to 3D model file
     meshType?: import('../stores/mediaStore/types').MeshPrimitiveType;  // Primitive mesh type
     text3DProperties?: Text3DProperties;
@@ -440,6 +458,7 @@ export interface TimelineClip {
     naturalDuration?: number;
     mediaFileId?: string;  // Reference to MediaFile for proxy lookup
     textCanvas?: HTMLCanvasElement;  // Pre-rendered text/solid canvas for text and solid clips
+    vectorAnimationSettings?: VectorAnimationClipSettings;
     filePath?: string;  // Path to original file (for native helper to access directly)
     runtimeSourceId?: string;
     runtimeSessionKey?: string;
@@ -542,7 +561,7 @@ export interface SerializableClip {
   duration: number;
   inPoint: number;
   outPoint: number;
-  sourceType: 'video' | 'audio' | 'image' | 'text' | 'solid' | 'model' | 'camera' | 'gaussian-avatar' | 'gaussian-splat' | 'splat-effector';
+  sourceType: TimelineSourceType;
   naturalDuration?: number;
   thumbnails?: string[];
   linkedClipId?: string;
@@ -574,6 +593,7 @@ export interface SerializableClip {
   text3DProperties?: Text3DProperties;
   // Solid clip support
   solidColor?: string;
+  vectorAnimationSettings?: VectorAnimationClipSettings;
   // Transition support
   transitionIn?: TimelineTransition;
   transitionOut?: TimelineTransition;
@@ -703,3 +723,9 @@ export type {
   RenderDestinationType,
   RenderTarget,
 } from './renderTarget';
+
+export type {
+  VectorAnimationClipSettings,
+  VectorAnimationMetadata,
+  VectorAnimationProvider,
+} from './vectorAnimation';

--- a/src/types/vectorAnimation.ts
+++ b/src/types/vectorAnimation.ts
@@ -1,0 +1,46 @@
+export type VectorAnimationProvider = 'lottie' | 'rive';
+
+export interface VectorAnimationMetadata {
+  provider: VectorAnimationProvider;
+  width?: number;
+  height?: number;
+  fps?: number;
+  duration?: number;
+  totalFrames?: number;
+  animationNames?: string[];
+  defaultAnimationName?: string;
+  artboardNames?: string[];
+  stateMachineNames?: string[];
+}
+
+export interface VectorAnimationClipSettings {
+  loop: boolean;
+  endBehavior: 'hold' | 'clear' | 'loop';
+  fit: 'contain' | 'cover' | 'fill';
+  backgroundColor?: string;
+  animationName?: string;
+  artboard?: string;
+  stateMachineName?: string;
+}
+
+export const DEFAULT_VECTOR_ANIMATION_CLIP_SETTINGS: VectorAnimationClipSettings = {
+  loop: false,
+  endBehavior: 'hold',
+  fit: 'contain',
+};
+
+export function mergeVectorAnimationSettings(
+  sourceSettings?: VectorAnimationClipSettings,
+): VectorAnimationClipSettings {
+  return {
+    ...DEFAULT_VECTOR_ANIMATION_CLIP_SETTINGS,
+    ...sourceSettings,
+  };
+}
+
+export function shouldLoopVectorAnimation(
+  sourceSettings?: VectorAnimationClipSettings,
+): boolean {
+  const settings = mergeVectorAnimationSettings(sourceSettings);
+  return settings.loop || settings.endBehavior === 'loop';
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,6 +1,6 @@
 // App version
 // Format: MAJOR.MINOR.PATCH
-export const APP_VERSION = '1.5.3';
+export const APP_VERSION = '1.5.4';
 
 export interface ChangelogNotice {
   type: 'info' | 'warning' | 'success' | 'danger';

--- a/tests/stores/mediaStore/fileManageSlice.test.ts
+++ b/tests/stores/mediaStore/fileManageSlice.test.ts
@@ -868,6 +868,37 @@ describe('MediaStore - File Management', () => {
     });
   });
 
+  describe('refreshFileUrls', () => {
+    it('should recreate image blob urls from the current file object', async () => {
+      const createObjectURL = vi.spyOn(URL, 'createObjectURL')
+        .mockReturnValueOnce('blob:http://localhost/refreshed-file')
+        .mockReturnValueOnce('blob:http://localhost/refreshed-thumb');
+      const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+      const file = makeMediaFile({
+        id: 'img-1',
+        type: 'image',
+        name: 'still.png',
+        file: new File(['image'], 'still.png', { type: 'image/png' }),
+        url: 'blob:http://localhost/original-file',
+        thumbnailUrl: 'blob:http://localhost/original-thumb',
+      });
+
+      store.setState({ files: [file] });
+
+      const result = await store.getState().refreshFileUrls('img-1');
+      const updated = store.getState().files[0];
+
+      expect(result).toBe(true);
+      expect(updated.url).toBe('blob:http://localhost/refreshed-file');
+      expect(updated.thumbnailUrl).toBe('blob:http://localhost/refreshed-thumb');
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:http://localhost/original-file');
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:http://localhost/original-thumb');
+
+      createObjectURL.mockRestore();
+      revokeObjectURL.mockRestore();
+    });
+  });
+
   // --- moveToFolder advanced ---
 
   describe('moveToFolder advanced', () => {

--- a/tests/stores/timeline/clipSlice.test.ts
+++ b/tests/stores/timeline/clipSlice.test.ts
@@ -1317,6 +1317,22 @@ describe('clipSlice', () => {
 
       expect(moved.trackId).toBe('video-1'); // should not change
     });
+
+    it('prevents moving lottie clip to audio track', () => {
+      const clip = createMockClip({
+        id: 'clip-1',
+        trackId: 'video-1',
+        startTime: 0,
+        duration: 5,
+        source: { type: 'lottie', naturalDuration: 5 } as any,
+      });
+      store = createTestTimelineStore({ clips: [clip], snappingEnabled: false } as any);
+
+      store.getState().moveClip('clip-1', 0, 'audio-1');
+      const moved = store.getState().clips.find(c => c.id === 'clip-1')!;
+
+      expect(moved.trackId).toBe('video-1');
+    });
   });
 
   // ========== Additional updateClipTransform edge cases ==========

--- a/tests/unit/exportLayerBuilder.test.ts
+++ b/tests/unit/exportLayerBuilder.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildLayersAtTime,
   cleanupLayerBuilder,
@@ -7,6 +7,7 @@ import {
 import type { ExportClipState, FrameContext } from '../../src/engine/export/types';
 import { useMediaStore } from '../../src/stores/mediaStore';
 import { useTimelineStore } from '../../src/stores/timeline';
+import { lottieRuntimeManager } from '../../src/services/vectorAnimation/LottieRuntimeManager';
 
 describe('ExportLayerBuilder', () => {
   beforeEach(() => {
@@ -444,5 +445,64 @@ describe('ExportLayerBuilder', () => {
     expect(nestedLayers[1]?.source?.gaussianSplatFileHash).toBe('nested-hash');
     expect(nestedLayers[1]?.source?.gaussianSplatSettings?.render.maxSplats).toBe(0);
     expect(nestedLayers[1]?.source?.gaussianSplatSettings?.render.sortFrequency).toBe(1);
+  });
+
+  it('exports lottie clips via the shared text canvas path', () => {
+    const track = {
+      id: 'track-1',
+      type: 'video',
+      visible: true,
+      solo: false,
+    } as any;
+    const canvas = document.createElement('canvas');
+    const renderSpy = vi.spyOn(lottieRuntimeManager, 'renderClipAtTime').mockReturnValue(canvas);
+
+    const clip = {
+      id: 'clip-lottie',
+      name: 'Lottie Clip',
+      trackId: 'track-1',
+      startTime: 0,
+      duration: 4,
+      inPoint: 0,
+      outPoint: 4,
+      source: {
+        type: 'lottie',
+        textCanvas: canvas,
+        naturalDuration: 4,
+      },
+      transform: {},
+      effects: [],
+      file: new File(['lottie'], 'anim.lottie', { type: 'application/zip' }),
+    } as any;
+
+    const ctx: FrameContext = {
+      time: 1,
+      fps: 30,
+      frameTolerance: 50_000,
+      clipsAtTime: [clip],
+      trackMap: new Map([[track.id, track]]),
+      clipsByTrack: new Map([[track.id, clip]]),
+      getInterpolatedTransform: () => ({
+        position: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1 },
+        rotation: { x: 0, y: 0, z: 0 },
+        opacity: 1,
+        blendMode: 'normal',
+      }),
+      getInterpolatedEffects: () => [],
+      getSourceTimeForClip: () => 1,
+      getInterpolatedSpeed: () => 1,
+    };
+
+    initializeLayerBuilder([track]);
+
+    const layers = buildLayersAtTime(ctx, new Map(), null, false);
+
+    expect(renderSpy).toHaveBeenCalledWith(clip, 1);
+    expect(layers).toHaveLength(1);
+    expect(layers[0]?.source?.type).toBe('text');
+    expect(layers[0]?.source?.textCanvas).toBe(canvas);
+
+    renderSpy.mockRestore();
   });
 });

--- a/tests/unit/importPipeline.test.ts
+++ b/tests/unit/importPipeline.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  detectMediaType: vi.fn(() => 'video'),
+  classifyMediaType: vi.fn(async () => 'video'),
   calculateFileHash: vi.fn(async () => 'hash-123'),
   getMediaInfo: vi.fn(async () => ({ duration: 12.5, width: 1920, height: 1080 })),
   createThumbnail: vi.fn(async () => undefined),
@@ -11,10 +11,20 @@ const mocks = vi.hoisted(() => ({
   copyToRawFolder: vi.fn(),
   getProxyFrameCount: vi.fn(async () => 0),
   isProjectOpen: vi.fn(() => true),
+  prepareLottieAsset: vi.fn(async () => ({
+    metadata: {
+      provider: 'lottie',
+      width: 640,
+      height: 360,
+      fps: 30,
+      duration: 4,
+      totalFrames: 120,
+    },
+  })),
 }));
 
 vi.mock('../../src/stores/timeline/helpers/mediaTypeHelpers', () => ({
-  detectMediaType: mocks.detectMediaType,
+  classifyMediaType: mocks.classifyMediaType,
 }));
 
 vi.mock('../../src/stores/mediaStore/helpers/fileHashHelpers', () => ({
@@ -50,6 +60,10 @@ vi.mock('../../src/services/projectFileService', () => ({
   },
 }));
 
+vi.mock('../../src/services/vectorAnimation/lottieMetadata', () => ({
+  prepareLottieAsset: mocks.prepareLottieAsset,
+}));
+
 vi.mock('../../src/stores/settingsStore', () => ({
   useSettingsStore: {
     getState: () => ({ copyMediaToProject: true }),
@@ -61,7 +75,7 @@ import { processImport } from '../../src/stores/mediaStore/helpers/importPipelin
 describe('processImport', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.detectMediaType.mockReturnValue('video');
+    mocks.classifyMediaType.mockResolvedValue('video');
     mocks.isProjectOpen.mockReturnValue(true);
   });
 
@@ -102,5 +116,32 @@ describe('processImport', () => {
     expect(mocks.storeHandle).toHaveBeenCalledWith('media_media-1', rawHandle);
     expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:original');
     expect(createObjectURLSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('stores Lottie metadata without using HTML media probing', async () => {
+    mocks.classifyMediaType.mockResolvedValue('lottie');
+    const lottieFile = new File(['{"v":"5.8.1"}'], 'anim.lottie', {
+      type: 'application/zip',
+      lastModified: 2,
+    });
+
+    const result = await processImport({
+      file: lottieFile,
+      id: 'media-lottie-1',
+    });
+
+    expect(mocks.prepareLottieAsset).toHaveBeenCalledWith(lottieFile);
+    expect(mocks.getMediaInfo).not.toHaveBeenCalled();
+    expect(result.mediaFile.type).toBe('lottie');
+    expect(result.mediaFile.vectorAnimation).toEqual(expect.objectContaining({
+      provider: 'lottie',
+      width: 640,
+      height: 360,
+      duration: 4,
+    }));
+    expect(result.mediaFile.width).toBe(640);
+    expect(result.mediaFile.height).toBe(360);
+    expect(result.mediaFile.fps).toBe(30);
+    expect(result.mediaFile.duration).toBe(4);
   });
 });

--- a/tests/unit/layerBuilderService.test.ts
+++ b/tests/unit/layerBuilderService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { LayerBuilderService } from '../../src/services/layerBuilder/LayerBuilderService';
 import { flags } from '../../src/engine/featureFlags';
 import { useTimelineStore } from '../../src/stores/timeline';
@@ -12,6 +12,7 @@ import {
 } from '../../src/services/mediaRuntime/runtimePlayback';
 import { mediaRuntimeRegistry } from '../../src/services/mediaRuntime/registry';
 import { scrubSettleState } from '../../src/services/scrubSettleState';
+import { lottieRuntimeManager } from '../../src/services/vectorAnimation/LottieRuntimeManager';
 
 const initialTimelineState = useTimelineStore.getState();
 const initialMediaState = useMediaStore.getState();
@@ -189,6 +190,67 @@ describe('LayerBuilderService paused visual provider selection', () => {
 
     expect(layers).toHaveLength(1);
     expect(layers[0]?.source?.webCodecsPlayer).toBe(clipPlayer);
+  });
+
+  it('routes lottie clips through the existing canvas layer path', () => {
+    const service = new LayerBuilderService();
+    const canvas = document.createElement('canvas');
+    const renderSpy = vi.spyOn(lottieRuntimeManager, 'renderClipAtTime').mockReturnValue(canvas);
+
+    useMediaStore.setState({
+      activeCompositionId: null,
+      activeLayerSlots: {},
+      layerOpacities: {},
+      files: [],
+      compositions: [],
+      proxyEnabled: false,
+    } as any);
+
+    useTimelineStore.setState({
+      tracks: [
+        {
+          id: 'track-v1',
+          name: 'Video 1',
+          type: 'video',
+          visible: true,
+          muted: false,
+          solo: false,
+        },
+      ],
+      clips: [
+        {
+          id: 'clip-lottie-1',
+          trackId: 'track-v1',
+          name: 'anim.lottie',
+          file: new File(['lottie'], 'anim.lottie', { type: 'application/zip' }),
+          startTime: 0,
+          duration: 4,
+          inPoint: 0,
+          outPoint: 4,
+          effects: [],
+          transform: { ...DEFAULT_TRANSFORM },
+          source: {
+            type: 'lottie',
+            textCanvas: canvas,
+            naturalDuration: 4,
+          },
+          isLoading: false,
+        },
+      ],
+      playheadPosition: 1,
+      isPlaying: false,
+      isDraggingPlayhead: false,
+      playbackSpeed: 1,
+    } as any);
+
+    const layers = service.buildLayersFromStore();
+
+    expect(renderSpy).toHaveBeenCalledWith(expect.objectContaining({ id: 'clip-lottie-1' }), 1);
+    expect(layers).toHaveLength(1);
+    expect(layers[0]?.source?.type).toBe('text');
+    expect(layers[0]?.source?.textCanvas).toBe(canvas);
+
+    renderSpy.mockRestore();
   });
 
   it('keeps full WebCodecs preview bound to the scrub runtime while actively dragging the playhead', () => {

--- a/tests/unit/projectMediaPersistence.test.ts
+++ b/tests/unit/projectMediaPersistence.test.ts
@@ -218,6 +218,113 @@ describe('project media persistence', () => {
     ]);
   });
 
+  it('persists vector animation metadata and clip settings for lottie assets', async () => {
+    mocks.mediaState.activeCompositionId = 'comp-1';
+    mocks.mediaState.files = [{
+      id: 'media-lottie-1',
+      name: 'anim.lottie',
+      type: 'lottie',
+      filePath: 'C:/capture/anim.lottie',
+      projectPath: 'Raw/anim.lottie',
+      duration: 4,
+      width: 640,
+      height: 360,
+      fps: 30,
+      fileSize: 4096,
+      proxyStatus: 'none',
+      parentId: null,
+      createdAt: 1,
+      vectorAnimation: {
+        provider: 'lottie',
+        width: 640,
+        height: 360,
+        fps: 30,
+        duration: 4,
+        totalFrames: 120,
+        animationNames: ['intro', 'loop'],
+        defaultAnimationName: 'intro',
+      },
+    }];
+    mocks.mediaState.compositions = [{
+      id: 'comp-1',
+      name: 'Comp 1',
+      type: 'composition',
+      parentId: null,
+      createdAt: 1,
+      width: 1920,
+      height: 1080,
+      frameRate: 30,
+      duration: 60,
+      backgroundColor: '#000000',
+      timelineData: { tracks: [], clips: [] },
+    }];
+    mocks.timelineState.getSerializableState.mockReturnValue({
+      tracks: [{ id: 'track-v1', name: 'Video 1', type: 'video', height: 60, muted: false, visible: true, solo: false }],
+      clips: [{
+        id: 'clip-lottie-1',
+        trackId: 'track-v1',
+        name: 'anim.lottie',
+        mediaFileId: 'media-lottie-1',
+        startTime: 0,
+        duration: 4,
+        inPoint: 0,
+        outPoint: 4,
+        sourceType: 'lottie',
+        naturalDuration: 4,
+        transform: {
+          opacity: 1,
+          blendMode: 'normal',
+          position: { x: 0, y: 0, z: 0 },
+          scale: { x: 1, y: 1 },
+          rotation: { x: 0, y: 0, z: 0 },
+        },
+        effects: [],
+        vectorAnimationSettings: {
+          loop: true,
+          endBehavior: 'loop',
+          fit: 'cover',
+          animationName: 'loop',
+          backgroundColor: '#112233',
+        },
+      }],
+      playheadPosition: 0,
+      duration: 60,
+      zoom: 1,
+      scrollX: 0,
+      inPoint: null,
+      outPoint: null,
+      loopPlayback: false,
+    });
+
+    const { syncStoresToProject } = await import('../../src/services/project/projectSave');
+    await syncStoresToProject();
+
+    expect(mocks.updateMedia).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'media-lottie-1',
+        type: 'lottie',
+        vectorAnimation: expect.objectContaining({
+          provider: 'lottie',
+          animationNames: ['intro', 'loop'],
+        }),
+      }),
+    ]);
+    expect(mocks.updateCompositions).toHaveBeenCalledWith([
+      expect.objectContaining({
+        clips: [
+          expect.objectContaining({
+            id: 'clip-lottie-1',
+            sourceType: 'lottie',
+            vectorAnimationSettings: expect.objectContaining({
+              animationName: 'loop',
+              backgroundColor: '#112233',
+            }),
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it('persists gaussian splat transform scale and splat settings into project compositions', async () => {
     mocks.mediaState.activeCompositionId = 'comp-1';
     mocks.mediaState.compositions = [{

--- a/tests/unit/serialization.test.ts
+++ b/tests/unit/serialization.test.ts
@@ -128,6 +128,13 @@ describe('SerializableClip structure', () => {
       reversed: true,
       isComposition: true,
       compositionId: 'comp-1',
+      vectorAnimationSettings: {
+        loop: true,
+        endBehavior: 'loop',
+        fit: 'cover',
+        animationName: 'intro',
+        backgroundColor: '#123456',
+      },
     });
 
     const json = JSON.stringify(clip);
@@ -141,6 +148,13 @@ describe('SerializableClip structure', () => {
     expect(restored.reversed).toBe(true);
     expect(restored.isComposition).toBe(true);
     expect(restored.compositionId).toBe('comp-1');
+    expect(restored.vectorAnimationSettings).toEqual({
+      loop: true,
+      endBehavior: 'loop',
+      fit: 'cover',
+      animationName: 'intro',
+      backgroundColor: '#123456',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add Lottie timeline support with properties, persistence, clipboard handling, and media URL recovery after reload
- rebuild the export panel around containers, sticky summary badges, bitrate wiring, and project-persistent presets with undo/redo support
- refresh README and feature docs and bump the app version to 1.5.4 with changelog entries for the release

## Validation
- npm run build
- npm run lint
- npm run test