### PR TITLE
fix: fall back to base splat runtime during export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,28 @@ Die alten Claude-Commands unter `C:\Users\admin\.claude\commands\` sollen in Cod
 
 Wenn ein Skill nicht verfuegbar ist, direkt ueber lokale Skripte, MCP-Tools, HTTP-Bridge oder API arbeiten. Nicht an Claude-Command-Dateien haengen bleiben.
 
-## 0.2 MasterSelects Debug Bridge
+## 0.2 gstack Integration
+
+`gstack` ist fuer strukturierte Planung, Reviews, Browser-QA und Security-Checks verfuegbar. Global installieren, nicht ins Repo vendorisieren.
+
+Installationspfade:
+
+- Codex: `git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack && cd ~/gstack && ./setup --host codex`
+- Claude Code: `git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup --team`
+- Windows: Git Bash oder WSL verwenden; `bun` und `node` muessen installiert sein
+- Nach der Codex-Installation Codex neu starten, damit neue Skills geladen werden
+
+Einsatzregeln:
+
+- `masterselects` bleibt erste Wahl fuer Timeline-, Preview-, Clip- und Debug-Bridge-Automation in der lokalen App
+- `gstack-office-hours`, `gstack-autoplan`, `gstack-plan-eng-review`, `gstack-plan-design-review` und `gstack-plan-devex-review` fuer Discovery, Scope und Plan-Qualitaet
+- `gstack-review` fuer unabhaengige Code-Reviews
+- `gstack-investigate` fuer Root-Cause-Debugging statt Trial-and-Error-Fixes
+- `gstack-cso` fuer Security-Reviews
+- `gstack-qa`, `gstack-qa-only`, `gstack-browse`, `gstack-open-gstack-browser` und `gstack-setup-browser-cookies` fuer Browser-QA, Repros und auth-geschuetzte Flows
+- `gstack-upgrade` verwenden, statt eine Repo-lokale gstack-Kopie zu pflegen
+
+## 0.3 MasterSelects Debug Bridge
 
 Fuer App-Debugging existieren lokale AI-Tools hinter `POST http://localhost:5173/api/ai-tools`. Voraussetzung: Dev-Server laeuft und die App ist im Browser geoeffnet.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,30 @@ Die `/masterselects` Skill stellt 4 Debug-Tools bereit, die über den HTTP Bridg
 
 ---
 
+## 0.2 gstack Integration
+
+`gstack` ist fuer strukturierte Planung, Reviews, Browser-QA und Security-Checks verfuegbar. Global installieren, nicht ins Repo vendorisieren.
+
+Installationspfade:
+
+- Codex: `git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack && cd ~/gstack && ./setup --host codex`
+- Claude Code: `git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup --team`
+- Windows: Git Bash oder WSL verwenden; `bun` und `node` muessen installiert sein
+- Nach der Codex-Installation Codex neu starten, damit neue Skills geladen werden
+
+Einsatzregeln:
+
+- `/masterselects` bleibt erste Wahl fuer Timeline-, Preview-, Clip- und Debug-Bridge-Automation in der lokalen App
+- `gstack-office-hours`, `gstack-autoplan`, `gstack-plan-eng-review`, `gstack-plan-design-review` und `gstack-plan-devex-review` fuer Discovery, Scope und Plan-Qualitaet in Codex
+- `/office-hours`, `/autoplan`, `/plan-eng-review`, `/plan-design-review` und `/plan-devex-review` fuer denselben Workflow in Claude Code
+- `gstack-review` oder `/review` fuer unabhaengige Code-Reviews
+- `gstack-investigate` oder `/investigate` fuer Root-Cause-Debugging statt Trial-and-Error-Fixes
+- `gstack-cso` oder `/cso` fuer Security-Reviews
+- `gstack-qa`, `gstack-qa-only`, `gstack-browse`, `gstack-open-gstack-browser`, `gstack-setup-browser-cookies` oder die entsprechenden Slash-Commands fuer Browser-QA, Repros und auth-geschuetzte Flows
+- `gstack-upgrade` oder `/gstack-upgrade` verwenden, statt eine Repo-lokale gstack-Kopie zu pflegen
+
+---
+
 ## 1. Workflow (WICHTIG!)
 
 ### Branch-Regeln

--- a/docs/Features/3D-Layers.md
+++ b/docs/Features/3D-Layers.md
@@ -13,10 +13,12 @@ Legacy gaussian-avatar support still exists in code for migration and old projec
 |---|---|---|
 | Per-layer 3D toggle | Stable | Any normal video/image layer can be switched between 2D and 3D. |
 | OBJ / glTF / GLB / FBX model import | Stable | Model clips are always 3D and render through Three.js. |
+| Numbered GLB sequences | Stable | Numbered `.glb` frames import as a single 30fps model-sequence clip. |
 | Primitive mesh clips | Stable | Cube, sphere, plane, cylinder, torus, cone, and 3D text are created from the Media Panel. |
 | Scene camera clips | Stable | Timeline camera clips control the shared Three.js scene. |
 | Gaussian splat clips | Stable but specialized | Default route is shared-scene Three.js; native WebGPU rendering is optional. |
-| Splat effector clips | Stable but specialized | They deform Three.js splats live at playback time. |
+| Numbered PLY / SPLAT sequences | Stable | Numbered `.ply` / `.splat` frames import as one shared-scene gaussian-splat sequence clip. |
+| 3D effector clips | Stable but specialized | They influence shared-scene 3D layers live at playback time. |
 | Gaussian avatar import | Legacy only | Import is blocked; existing projects may still expose blendshape editing. |
 | Temporal / particle splat settings | Experimental | Wired in the engine/export path, but not yet exposed as a dedicated properties tab. |
 
@@ -34,7 +36,7 @@ Legacy gaussian-avatar support still exists in code for migration and old projec
 
 Three.js is used as the shared 3D scene for classic 3D layers and for the default gaussian-splat route. The native gaussian-splat renderer is a separate WebGPU path, enabled by the clip-level `useNativeRenderer` setting.
 
-Camera clips and splat effectors only affect the shared Three.js scene. They do not drive the native gaussian-splat renderer.
+Camera clips and 3D effectors only affect the shared Three.js scene. They do not drive the native gaussian-splat renderer.
 
 ## Stable 3D Features
 
@@ -51,6 +53,8 @@ Camera clips and splat effectors only affect the shared Three.js scene. They do 
 - Models are auto-centered and normalized to fit the viewport.
 - Default lighting is Ambient plus Directional lighting.
 - The Transform panel exposes a wireframe debug toggle for model clips.
+- Numbered `.glb` files like `frame000000.glb`, `frame000001.glb`, `frame000002.glb` are grouped into one model-sequence asset during import.
+- GLB sequences currently default to 30fps and use frame-based playback through the existing model clip path.
 
 ### Primitive Meshes and 3D Text
 
@@ -90,11 +94,14 @@ The Transform tab also turns into camera-orbit controls for the active scene cam
 Gaussian splat clips are imported from `.ply` and `.splat` files.
 
 - Clips are created as `is3D: true`.
-- The clip-level render tab exposes `useNativeRenderer`, `maxSplats`, `sortFrequency`, `splatScale`, `nearPlane`, and `farPlane`.
+- The clip-level render tab exposes `useNativeRenderer`, `maxSplats`, `sortFrequency`, `splatScale`, `orientationPreset`, `nearPlane`, and `farPlane`.
 - The default renderer is the shared Three.js scene path.
 - Native WebGPU rendering is optional and off by default.
-- The shared-scene route participates in scene cameras and splat effectors.
+- Numbered `.ply` or `.splat` files like `scan000000.ply`, `scan000001.ply`, `scan000002.ply` are grouped into one gaussian-splat sequence asset during batch import.
+- Gaussian-splat sequences currently stay on the shared Three.js scene path even if a clip was previously set to native render.
+- The shared-scene route participates in scene cameras and 3D effectors.
 - The native route uses its own camera-style navigation controls in the Transform tab.
+- A per-clip `3D Effector` toggle in the Transform tab lets you opt shared-scene splat/model layers in or out.
 
 Some gaussian-splat settings exist in the data model and export pipeline but are not yet surfaced as a full dedicated UI:
 
@@ -104,16 +111,20 @@ Some gaussian-splat settings exist in the data model and export pipeline but are
 
 Those are wired through the renderer and export code, but they should still be treated as in-progress surface area.
 
-## Splat Effectors
+## 3D Effectors
 
-Splat effector clips are timeline clips that only affect Three.js splats.
+3D effector clips are non-rendering timeline clips that influence shared-scene 3D layers.
 
 - Modes: `repel`, `attract`, `swirl`, and `noise`
 - Controls: strength, falloff, speed, and seed
 - Transform scale acts as the effector radius
 - They do not render visible content on their own
+- Shared-scene gaussian splats use the direct splat deformation path
+- Shared-scene gaussian-splat sequences also use that direct splat deformation path frame by frame
+- Models, primitive meshes, and 3D text receive object-level motion
+- Native gaussian splats ignore 3D effectors because they do not run in the shared Three.js scene
 
-This is a good example of a specialized 3D feature that is stable in the UI, but limited to the shared-scene splat path.
+This is a shared-scene 3D feature that is stable in the UI, but it does not extend into the native gaussian-splat renderer.
 
 ## Legacy Gaussian Avatars
 
@@ -133,7 +144,7 @@ If you see avatar-specific code paths in the renderer or AI tooling, treat them 
 | Regular 2D clip | Transform, Effects, Masks, Transcript, Analysis |
 | Camera clip | Transform, Camera |
 | Gaussian splat clip | Transform, Gaussian, Effects, Masks, Transcript, Analysis |
-| Splat effector clip | Transform, Effector, Effects, Masks, Transcript, Analysis |
+| 3D effector clip | Transform, Effector, Effects, Masks, Transcript, Analysis |
 | 3D text clip | 3D Text, Transform, Effects, Masks |
 | Legacy gaussian avatar clip | Transform, Blendshapes |
 
@@ -164,11 +175,11 @@ The Transform tab is context-sensitive:
 | `src/stores/timeline/meshClipSlice.ts` | Primitive mesh and 3D text clip creation |
 | `src/stores/timeline/cameraClipSlice.ts` | Timeline camera clip creation |
 | `src/stores/timeline/clip/addGaussianSplatClip.ts` | Gaussian splat clip creation |
-| `src/stores/timeline/splatEffectorClipSlice.ts` | Splat effector clip creation |
+| `src/stores/timeline/splatEffectorClipSlice.ts` | 3D effector clip creation |
 | `src/components/panels/properties/TransformTab.tsx` | Context-sensitive 3D transform and camera controls |
 | `src/components/panels/properties/GaussianSplatTab.tsx` | Gaussian splat render settings tab |
 | `src/components/panels/properties/CameraTab.tsx` | Scene camera settings tab |
-| `src/components/panels/properties/SplatEffectorTab.tsx` | Splat effector settings tab |
+| `src/components/panels/properties/SplatEffectorTab.tsx` | 3D effector settings tab |
 | `src/components/panels/properties/BlendshapesTab.tsx` | Legacy gaussian-avatar blendshapes tab |
 | `src/engine/featureFlags.ts` | 3D feature flags |
 
@@ -178,10 +189,10 @@ The Transform tab is context-sensitive:
 |---|---|---|
 | `.obj` | Supported | Imported as a Three.js model clip. |
 | `.gltf` | Supported | Imported as a Three.js model clip. |
-| `.glb` | Supported | Imported as a Three.js model clip. |
+| `.glb` | Supported | Imported as a Three.js model clip. Numbered `.glb` frames are grouped into a model-sequence clip. |
 | `.fbx` | Supported | Imported as a Three.js model clip. |
-| `.ply` | Supported | Gaussian splat import. |
-| `.splat` | Supported | Gaussian splat import. |
+| `.ply` | Supported | Gaussian splat import. Numbered `.ply` frames are grouped into a shared-scene sequence clip. |
+| `.splat` | Supported | Gaussian splat import. Numbered `.splat` frames are grouped into a shared-scene sequence clip. |
 | `.ksplat` | Not yet supported | Parser stubs exist, but the file is rejected today. |
 | `.gsplat-zip` | Not yet supported | Parser stubs exist, but the file is rejected today. |
 | Gaussian avatar `.zip` | Legacy only | Import is blocked in the current product surface. |

--- a/docs/Features/AI-Integration.md
+++ b/docs/Features/AI-Integration.md
@@ -29,29 +29,40 @@ GPT-powered editing with 79 exported tools across 15 exported definition groups,
 
 ### Features
 - Interactive chat interface
-- Model selection dropdown
+- Model selection badge with popover
+- Shared hosted-credit pricing per model
 - Conversation history
 - Clear chat button
 - Auto-scrolling
 - Tool execution indicators
+- Styled approval cards for mutating/sensitive tool calls
+- Compact control pills below the prompt box
+- Optional per-panel approval bypass toggle below the send button
+- Thinking-effort selector for supported OpenAI chat models
 
 ### Available Models
 ```
-GPT-5.2, GPT-5.2 Pro
-GPT-5.1, GPT-5.1 Codex, GPT-5.1 Codex Mini
+GPT-5.4, GPT-5.4 Mini, GPT-5.4 Nano
+GPT-5.3 Chat, GPT-5.3 Codex
+GPT-5.2, GPT-5.2 Codex
+GPT-5.1, GPT-5.1 Codex Mini
 GPT-5, GPT-5 Mini, GPT-5 Nano
 GPT-4.1, GPT-4.1 Mini, GPT-4.1 Nano
 GPT-4o, GPT-4o Mini
-o3, o4-mini, o3-pro (reasoning)
+o3, o4-mini, o3-mini
 ```
 
 Default model: `gpt-5.1`
 
+The dropdown is sourced from `src/shared/openAiModelCatalog.ts`. That same catalog also drives hosted chat billing in `functions/lib/modelPricing.ts`, so the UI label and the charged credits stay in sync.
+The same catalog also marks which models support OpenAI reasoning effort controls, so the chat panel only shows the Thinking control when the selected model can use it.
+
 ### Editor Mode
-When enabled:
+The AI chat panel always runs with editor tools enabled:
 - Includes timeline context in prompts
 - Uses the exported AI tool catalog from `src/services/aiTools/definitions`
 - The chat UI applies its own approval gate before calling mutating or sensitive tools
+- Users can temporarily bypass those confirmations from the panel
 - AI can manipulate timeline directly
 
 The current tool surface is 79 exported tool definitions across 15 exported definition groups. Two dispatch gaps remain in the shared registry:
@@ -92,6 +103,7 @@ That console surface is dev-only. The Vite dev bridge and the Native Helper HTTP
 - Active IN / OUT / REF assignments appear as removable color badges around the prompt box
 - Hovering a prompt-box badge strongly emphasizes the linked board node for as long as the badge is hovered
 - Nano Banana 2 accepts up to 14 ordered reference images; the composer labels them as `REF 1`, `REF 2`, ... so prompts can refer to them explicitly
+- FlashBoard's Kie.ai catalog includes Kling 3.0, Seedance 2.0, and Nano Banana 2; Seedance 2.0 currently ships as a Board-only Kie option with text-to-video and image-to-video support
 - IN / OUT / REF outlines scale with zoom and use a stronger glow so references stay readable while navigating the board
 
 ### Current Backends
@@ -100,7 +112,7 @@ The current AI Video stack is no longer best described as "PiAPI as one unified 
 
 | Backend | Where it is used | Notes |
 |---------|------------------|-------|
-| `Kie.ai` | Classic generator and FlashBoard | Current provider list comes from `getKieAiProviders()`; user-supplied key in Settings |
+| `Kie.ai` | Classic generator and FlashBoard | Classic provider list comes from `getKieAiProviders()`; FlashBoard extends the Kie catalog with Seedance 2.0; user-supplied key in Settings |
 | `MasterSelects Cloud` | Classic generator and FlashBoard when hosted access is available | Hosted credits/account flow; board mode resolves to hosted Kling when no local Kie key is present |
 | `PiAPI` | Legacy compatibility and some catalog/pricing metadata | Still present in older history/key migration paths and FlashBoard pricing/catalog helpers, but not the primary runtime path the current panel describes |
 

--- a/docs/Features/FlashBoard.md
+++ b/docs/Features/FlashBoard.md
@@ -13,7 +13,7 @@ FlashBoard is the AI canvas workspace behind the AI Video panel's Board mode. It
 FlashBoard is not a separate model backend. It is a workspace layer on top of the existing AI services:
 
 - `piapi` for the PiAPI catalog
-- `kieai` for Kie.ai Kling 3.0 and Nano Banana 2
+- `kieai` for Kie.ai Kling 3.0, Seedance 2.0, and Nano Banana 2
 - `cloud` for hosted Kling 3.0 and hosted Nano Banana 2
 
 The AI Video panel switches into FlashBoard when the user selects Board mode. If the user has no Kie.ai key and is signed in to MasterSelects Cloud, the board uses the hosted cloud service scope. Otherwise it stays on Kie.ai.
@@ -68,9 +68,12 @@ The board uses the shared catalog from `FlashBoardModelCatalog`:
 
 - PiAPI video providers from the shared PiAPI catalog
 - Kie.ai Kling 3.0 video
+- Kie.ai Seedance 2.0 video
 - Kie.ai Nano Banana 2 image generation
 - Cloud Kling 3.0 video
 - Cloud Nano Banana 2 image generation
+
+Seedance 2.0 is currently exposed only in FlashBoard on the Kie.ai path. The existing Classic AI Video flow remains narrower and continues to focus on the classic Kie provider list.
 
 The classic AI Video flow is narrower: it currently exposes only the Kie.ai Kling 3.0 provider list, while FlashBoard exposes the richer catalog.
 

--- a/docs/Features/Media-Panel.md
+++ b/docs/Features/Media-Panel.md
@@ -39,6 +39,9 @@ The panel also accepts a few specialized asset types that flow into the timeline
 - `model` files: OBJ, glTF/GLB, FBX
 - `gaussian-splat` files: PLY, SPLAT
 
+Numbered `.glb` files with a shared prefix are detected as a sequence during batch import. A folder containing `frame000000.glb`, `frame000001.glb`, `frame000002.glb` and so on will appear as one model asset instead of many separate files.
+Numbered `.ply` or `.splat` files with a shared prefix are also detected as a sequence during batch import. A folder containing `scan000000.ply`, `scan000001.ply`, `scan000002.ply` and so on will appear as one gaussian-splat asset instead of many separate files.
+
 Lottie imports are treated as first-class media items. `.json` files are only accepted when their contents actually match Lottie structure, so arbitrary JSON data is not misclassified as animation.
 
 ### Import Methods
@@ -54,7 +57,7 @@ Click the **+ Add** button for creating new items:
 - **3D Text** - New 3D text mesh item
 - **Solid** - New solid color item (placed in auto-created "Solids" folder)
 - **Camera** - New camera item
-- **Splat Effector** - New splat-effector item
+- **3D Effector** - New shared-scene 3D effector item
 - **Mesh** ▶ - Submenu with 3D primitive meshes (placed in auto-created "Meshes" folder):
   - Cube, Sphere, Plane, Cylinder, Torus, Cone
   - Creates a `MeshItem` which can be dragged to the timeline as a 3D clip
@@ -75,11 +78,13 @@ Imports use a two-phase approach:
 
 1. **Phase 1 (instant):** A placeholder entry appears immediately in the panel with `isImporting: true`, showing file name and size
 2. **Phase 2 (background):** Full processing runs in the background:
-   - Media info extraction (dimensions, duration, FPS, codec, bitrate, audio detection)
-   - Thumbnail generation (for video and image files)
-   - File hash calculation (for deduplication and proxy matching)
-   - Copy to project RAW folder when `copyMediaToProject` is enabled, or when the import is forced
-   - Existing proxy detection (by file hash)
+    - Media info extraction (dimensions, duration, FPS, codec, bitrate, audio detection)
+    - Thumbnail generation (for video and image files)
+    - File hash calculation (for deduplication and proxy matching)
+    - Copy to project RAW folder when `copyMediaToProject` is enabled, or when the import is forced
+    - Numbered GLB sequence grouping into a single 30fps model-sequence asset
+    - Numbered PLY/SPLAT sequence grouping into a single 30fps gaussian-splat sequence asset
+    - Existing proxy detection (by file hash)
 
 **Deduplication:** Files with matching name + size are automatically skipped.
 
@@ -448,6 +453,7 @@ interface MediaFile {
 - Uses actual media duration
 - Audio-only files restricted to audio tracks
 - Files still importing or missing cannot be dragged to timeline
+- Numbered gaussian-splat sequences always stay on the shared Three.js 3D renderer path after drop
 - Compositions cannot be dragged into themselves (active comp check)
 - Mesh items create 3D clips with `is3D: true` and `meshType` (rendered via Three.js)
 

--- a/docs/Features/Timeline.md
+++ b/docs/Features/Timeline.md
@@ -2,14 +2,14 @@
 
 [<- Back to Index](./README.md)
 
-The Timeline is the core editing interface for multi-track editing. It now covers video, audio, image, Lottie, text, solid, mesh, composition, camera, and splat-effector clips, with keyframe lanes, transitions, multicam grouping, pick-whip parenting, and slot-grid playback.
+The Timeline is the core editing interface for multi-track editing. It now covers video, audio, image, Lottie, text, solid, mesh, composition, camera, and 3D-effector clips, with keyframe lanes, transitions, multicam grouping, pick-whip parenting, and slot-grid playback.
 
 ---
 
 ## Track Types
 
 ### Video Tracks
-- Hold video, image, Lottie, text, solid, mesh, composition, camera, and splat-effector clips.
+- Hold video, image, Lottie, text, solid, mesh, composition, camera, and 3D-effector clips.
 - Higher tracks render on top of lower tracks.
 - Expanded tracks can show keyframe property rows and curve editors.
 - Default layout starts with `Video 2` above `Video 1`.
@@ -69,8 +69,8 @@ getTrackChildren()  // Query child tracks
 - Nested compositions can be dropped from the media panel.
 - Double-click enters the nested comp for editing.
 
-### Camera and Splat Effector
-- Camera clips and splat-effector clips are first-class clip types in the store and copy/paste flow.
+### Camera and 3D Effector
+- Camera clips and 3D-effector clips are first-class clip types in the store and copy/paste flow.
 - Camera/native-gaussian clips expose camera-oriented property labels in the keyframe UI.
 
 ### YouTube Download

--- a/functions/api/ai/chat.ts
+++ b/functions/api/ai/chat.ts
@@ -22,6 +22,7 @@ interface HostedChatRouteBody {
   idempotencyKey?: string;
   messages?: unknown;
   model?: string;
+  reasoning_effort?: string;
   stream?: boolean;
 }
 
@@ -249,6 +250,7 @@ export const onRequest: AppRouteHandler = async (context: AppContext): Promise<R
     max_tokens: request.max_tokens,
     messages: request.messages,
     model: request.model,
+    reasoning_effort: request.reasoning_effort,
     response_format: request.response_format,
     stream: false,
     tool_choice: request.tool_choice,

--- a/functions/lib/modelPricing.ts
+++ b/functions/lib/modelPricing.ts
@@ -1,77 +1,44 @@
-/**
- * Model-weighted credit costs (Option B).
- *
- * Each model has a fixed credit cost per request. The base unit is 1 credit
- * for the cheapest models (nano/mini). Expensive models cost proportionally
- * more credits so that break-even is maintained across all plans.
- *
- * Pricing reference (USD per 1M tokens, March 2026):
- *   gpt-4.1-nano:   $0.10 in / $0.40 out   → ~$0.0003/req → 1 credit
- *   gpt-4.1-mini:   $0.40 in / $1.60 out   → ~$0.0012/req → 1 credit
- *   gpt-4o-mini:    $0.15 in / $0.60 out   → ~$0.0005/req → 1 credit
- *   gpt-5-nano:     $0.05 in / $0.40 out   → ~$0.0003/req → 1 credit
- *   gpt-5-mini:     $0.25 in / $2.00 out   → ~$0.0013/req → 1 credit
- *   gpt-4o:         $2.50 in / $10.00 out  → ~$0.0075/req → 5 credits
- *   gpt-4.1:        $2.00 in / $8.00 out   → ~$0.006/req  → 5 credits
- *   gpt-5:          $1.25 in / $10.00 out  → ~$0.006/req  → 5 credits
- *   gpt-5.1:        ~$2 in / ~$8 out       → ~$0.006/req  → 5 credits
- *   o4-mini:        $1.10 in / $4.40 out   → ~$0.003/req  → 3 credits
- *   o3-mini:        $1.10 in / $4.40 out   → ~$0.003/req  → 3 credits
- *   o3:             $2.00 in / $8.00 out   → ~$0.006/req  → 5 credits (+ reasoning tokens)
- *   gpt-5.1-codex:  ~$2 in / ~$8 out      → ~$0.006/req  → 5 credits
- *   gpt-5.2:        ~$3 in / ~$12 out     → ~$0.008/req  → 8 credits
- *   gpt-5.2-pro:    ~$5 in / ~$20 out     → ~$0.013/req  → 10 credits
- *   o3-pro:         $20 in / $80 out       → ~$0.06/req   → 50 credits
- */
+import {
+  DEFAULT_OPENAI_MODEL_PRICING,
+  getOpenAiModelPricing,
+  OPENAI_MODEL_CATALOG,
+  type OpenAiModelTier,
+} from '../../src/shared/openAiModelCatalog';
 
+/**
+ * Shared hosted-chat pricing.
+ *
+ * The source of truth lives in src/shared/openAiModelCatalog.ts so the chat
+ * dropdown and the Cloudflare billing route stay aligned.
+ */
 export interface ModelPricingEntry {
   /** Credits consumed per request */
   creditCost: number;
   /** Tier label for UI display */
-  tier: 'low' | 'mid' | 'high' | 'premium';
+  tier: OpenAiModelTier;
 }
 
-const MODEL_PRICING: Record<string, ModelPricingEntry> = {
-  // --- Tier: low (1 credit) ---
-  'gpt-4.1-nano':       { creditCost: 1,  tier: 'low' },
-  'gpt-4.1-mini':       { creditCost: 1,  tier: 'low' },
-  'gpt-4o-mini':        { creditCost: 1,  tier: 'low' },
-  'gpt-5-nano':         { creditCost: 1,  tier: 'low' },
-  'gpt-5-mini':         { creditCost: 1,  tier: 'low' },
-  'gpt-5.1-codex-mini': { creditCost: 1,  tier: 'low' },
-
-  // --- Tier: mid (3 credits) ---
-  'o4-mini':            { creditCost: 3,  tier: 'mid' },
-  'o3-mini':            { creditCost: 3,  tier: 'mid' },
-
-  // --- Tier: high (5 credits) ---
-  'gpt-4o':             { creditCost: 5,  tier: 'high' },
-  'gpt-4.1':            { creditCost: 5,  tier: 'high' },
-  'gpt-5':              { creditCost: 5,  tier: 'high' },
-  'gpt-5.1':            { creditCost: 5,  tier: 'high' },
-  'gpt-5.1-codex':      { creditCost: 5,  tier: 'high' },
-  'o3':                 { creditCost: 5,  tier: 'high' },
-
-  // --- Tier: premium (8-50 credits) ---
-  'gpt-5.2':            { creditCost: 8,  tier: 'premium' },
-  'gpt-5.2-pro':        { creditCost: 10, tier: 'premium' },
-  'o3-pro':             { creditCost: 50, tier: 'premium' },
-};
-
-/** Default cost for unknown models */
-const DEFAULT_CREDIT_COST: ModelPricingEntry = { creditCost: 5, tier: 'high' };
-
-/** Look up credit cost for a model. Unknown models default to 5 (high tier). */
+/** Look up credit cost for a model. Unknown models use the shared default. */
 export function getModelCreditCost(model: string): number {
-  return (MODEL_PRICING[model] ?? DEFAULT_CREDIT_COST).creditCost;
+  return getOpenAiModelPricing(model).creditCost;
 }
 
 /** Look up full pricing entry for a model. */
 export function getModelPricing(model: string): ModelPricingEntry {
-  return MODEL_PRICING[model] ?? DEFAULT_CREDIT_COST;
+  return getOpenAiModelPricing(model);
 }
 
 /** Get all known model pricing entries (for capabilities/UI). */
 export function getAllModelPricing(): Record<string, ModelPricingEntry> {
-  return { ...MODEL_PRICING };
+  return Object.fromEntries(
+    OPENAI_MODEL_CATALOG.map((entry) => [
+      entry.id,
+      {
+        creditCost: entry.creditCost,
+        tier: entry.tier,
+      },
+    ]),
+  );
 }
+
+export { DEFAULT_OPENAI_MODEL_PRICING };

--- a/functions/lib/providers/openai.ts
+++ b/functions/lib/providers/openai.ts
@@ -23,6 +23,7 @@ export interface HostedChatRequest {
   max_tokens?: number;
   messages: HostedChatMessage[];
   model: string;
+  reasoning_effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
   response_format?: Record<string, unknown>;
   stream?: boolean;
   tool_choice?: unknown;
@@ -37,6 +38,15 @@ export interface HostedChatCapabilities {
   provider: 'openai';
   streamingSupported: false;
 }
+
+const SUPPORTED_REASONING_EFFORTS = new Set<NonNullable<HostedChatRequest['reasoning_effort']>>([
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -132,12 +142,19 @@ export function normalizeHostedChatRequest(body: unknown): HostedChatRequest | n
   }
 
   const model = typeof body.model === 'string' && body.model.trim() ? body.model.trim() : 'gpt-4.1-mini';
+  const reasoningEffortCandidate =
+    typeof body.reasoning_effort === 'string'
+      ? body.reasoning_effort.trim() as NonNullable<HostedChatRequest['reasoning_effort']>
+      : undefined;
 
   return {
     max_completion_tokens: normalizeNumericValue(body.max_completion_tokens),
     max_tokens: normalizeNumericValue(body.max_tokens),
     messages,
     model,
+    reasoning_effort: reasoningEffortCandidate && SUPPORTED_REASONING_EFFORTS.has(reasoningEffortCandidate)
+      ? reasoningEffortCandidate
+      : undefined,
     response_format: isRecord(body.response_format) ? body.response_format : undefined,
     stream: body.stream === true,
     tool_choice: body.tool_choice,
@@ -153,6 +170,7 @@ export async function runHostedChatCompletion(env: Env, request: HostedChatReque
     max_tokens: request.max_tokens,
     messages: request.messages,
     model: request.model,
+    reasoning_effort: request.reasoning_effort,
     response_format: request.response_format,
     stream: false,
     tool_choice: request.tool_choice,

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,359 @@
+# Issue 77 - Lottie / Rive Implementation Plan
+
+Date: 2026-04-15
+Status: Draft
+Branch: `77-lottie-rive-animation-files-on-timeline`
+
+## Mission
+
+Add first-class timeline support for Lottie and prepare the repo for Rive without building a second render pipeline.
+
+The first shippable milestone is:
+
+- Lottie `.lottie` and Lottie JSON import
+- Lottie clips on video tracks
+- deterministic preview scrubbing
+- deterministic nested composition preview
+- deterministic export
+- project save/load and relink
+- media panel and timeline UX
+
+Rive is phase 2 on the same canvas-backed architecture. Do not let Rive block Lottie MVP.
+
+## Current Codebase Reality
+
+### Type gates
+
+- `src/stores/mediaStore/types.ts` does not know `lottie` or `rive`.
+- `src/types/index.ts` does not know `lottie` or `rive` as clip source types.
+- `src/services/project/types/media.types.ts` still restricts project media to `video | audio | image`.
+- `src/services/project/types/composition.types.ts` and `src/types/index.ts` serialize explicit `sourceType` unions and must be updated.
+
+### Import and clip creation gates
+
+- `src/stores/timeline/helpers/mediaTypeHelpers.ts` only detects `video | audio | image | model | gaussian-splat | unknown`.
+- `src/components/timeline/utils/fileTypeHelpers.ts` and `src/components/panels/media/dropImport.ts` only allow the currently known media types.
+- `src/stores/mediaStore/helpers/importPipeline.ts` only extracts metadata and thumbnails for `video | audio | image`.
+- `src/stores/mediaStore/slices/fileImportSlice.ts` only has placeholder/import flows for current media types plus gaussian splat.
+- `src/stores/timeline/clipSlice.ts` only routes `video`, `audio`, `image`, `model`, and `gaussian-splat`.
+
+### Why this is feasible
+
+- Text and solid clips already prove that canvas-backed sources fit the render stack.
+- `src/services/layerBuilder/LayerBuilderService.ts` already builds layers from `source.textCanvas`.
+- `src/engine/render/LayerCollector.ts` already uploads `textCanvas` into GPU textures.
+- `src/engine/export/ExportLayerBuilder.ts` already exports `textCanvas` layers.
+- `src/services/thumbnailRenderer.ts` already renders thumbnails from `textCanvas`.
+- `src/services/compositionRenderer.ts` already carries `textCanvas` through composition evaluation.
+
+### Real gaps that must be closed
+
+- Nested preview is incomplete. `LayerBuilderService.buildNestedClipLayer()` does not forward generic canvas-backed clips today.
+- The paused-sync path in `src/components/timeline/hooks/useLayerSync.ts` only handles nested video/image clips.
+- Save/load, relink, background slot playback, and clipboard restore all branch explicitly on known source types.
+- UI files hardcode type badges and icons in `MediaPanel.tsx`, `FileTypeIcon.tsx`, `TimelineClip.tsx`, `useExternalDrop.ts`, and `properties/index.tsx`.
+
+## Frozen Decisions
+
+These decisions are not open for agent debate unless the user explicitly reopens them.
+
+1. Phase 1 is Lottie. Phase 2 is Rive.
+2. Lottie runtime for MVP is `@lottiefiles/dotlottie-web`.
+3. Do not use Lottie worker mode in MVP. Deterministic scrubbing and export matter more than max concurrency.
+4. Rive must use the low-level web runtime, not the React wrapper.
+5. Do not add a new compositor or WebGPU source path for Lottie/Rive in phase 1.
+6. `TimelineClip.source.type` must become `lottie` or `rive`, but render `Layer.source` should continue to reuse the existing canvas path with `type: 'text'` plus `textCanvas`.
+7. Do not rename `textCanvas` in this issue. The name is imperfect, but a generic rename would create unnecessary churn across the render stack.
+8. `.json` files must be content-sniffed before they are treated as Lottie. Do not classify every JSON file as Lottie by extension alone.
+9. Runtime cursors are clip-local. The same source reused at multiple times must not fight over one playback cursor.
+10. Rive audio, data binding, and rich interactive state-machine inputs are out of scope for the first implementation.
+11. Do not add new synthetic media-panel item types for Lottie or Rive. They are imported file types, not generated items like text/solid/camera.
+
+## Shared Contract To Land First
+
+This wave is serialized. One agent owns it. Nobody else edits these files until this wave lands.
+
+### Files
+
+- `src/types/index.ts`
+- `src/stores/mediaStore/types.ts`
+- `src/stores/timeline/types.ts`
+- `src/services/project/types/media.types.ts`
+- `src/services/project/types/composition.types.ts`
+- new `src/types/vectorAnimation.ts`
+
+### Minimum contract
+
+Use one dedicated metadata object and one dedicated per-clip settings object. Do not spray new top-level optional fields everywhere.
+
+```ts
+export interface VectorAnimationMetadata {
+  provider: 'lottie' | 'rive';
+  width?: number;
+  height?: number;
+  fps?: number;
+  duration?: number;
+  totalFrames?: number;
+  animationNames?: string[];
+  defaultAnimationName?: string;
+  artboardNames?: string[];
+  stateMachineNames?: string[];
+}
+
+export interface VectorAnimationClipSettings {
+  loop: boolean;
+  endBehavior: 'hold' | 'clear' | 'loop';
+  fit: 'contain' | 'cover' | 'fill';
+  backgroundColor?: string;
+  animationName?: string;
+  artboard?: string;
+  stateMachineName?: string;
+}
+```
+
+### Required contract updates
+
+- `MediaFile.type` includes `lottie` and `rive`.
+- `TimelineClip.source.type` includes `lottie` and `rive`.
+- `SerializableClip.sourceType` includes `lottie` and `rive`.
+- `ProjectMediaFile.type` includes `lottie` and `rive`.
+- `ProjectClip.sourceType` includes `lottie` and `rive`.
+- `MediaFile` gets `vectorAnimation?: VectorAnimationMetadata`.
+- `TimelineClip.source` gets `vectorAnimationSettings?: VectorAnimationClipSettings`.
+- `SerializableClip` and `ProjectClip` get `vectorAnimationSettings?: VectorAnimationClipSettings`.
+
+### Acceptance
+
+- `npm run build` passes after the contract wave.
+- No render behavior is changed yet.
+- No agent edits shared union files in parallel after ownership is assigned.
+
+## Execution Order
+
+1. Land the shared contract wave.
+2. Implement the Lottie runtime service and metadata extraction.
+3. In parallel, implement import/clip creation, render/export wiring, persistence/reload, and UI.
+4. Finish with tests and docs.
+5. Start Rive only after Lottie is green.
+
+## Workstream 1 - Import And Clip Ingestion
+
+### Ownership
+
+- `src/stores/timeline/helpers/mediaTypeHelpers.ts`
+- `src/components/timeline/utils/fileTypeHelpers.ts`
+- `src/components/panels/media/dropImport.ts`
+- `src/stores/mediaStore/helpers/importPipeline.ts`
+- `src/stores/mediaStore/slices/fileImportSlice.ts`
+- `src/stores/timeline/clipSlice.ts`
+- new `src/stores/timeline/clip/addLottieClip.ts`
+- optional stub `src/stores/timeline/clip/addRiveClip.ts`
+- `src/components/timeline/hooks/useExternalDrop.ts`
+
+### Build
+
+- Add `.lottie` and `.riv` extension detection.
+- Add async JSON sniffing for Lottie JSON in the import pipeline.
+- Route imported Lottie files into a real `MediaFile.type === 'lottie'`.
+- Create a Lottie clip placeholder with `source.type = 'lottie'`, `mediaFileId`, `naturalDuration`, `textCanvas`, and default `vectorAnimationSettings`.
+- Keep Lottie on video tracks only.
+- For `.json` desktop drop, allow a small async classification step before `addClip`. Do not force the old fully-sync fast path for these files.
+- Do not attempt Rive runtime here. A stub clip factory is enough if it helps phase 2.
+
+### Acceptance
+
+- Importing a `.lottie` file creates a usable media panel item with dimensions and duration.
+- Importing a Lottie JSON file works only when the JSON actually matches Lottie structure.
+- Dragging a media panel Lottie item onto a video track creates a `lottie` clip.
+- Dragging a Lottie file directly from desktop does not misclassify arbitrary JSON files.
+
+## Workstream 2 - Lottie Runtime And Canvas Lifecycle
+
+### Ownership
+
+- `package.json`
+- `package-lock.json`
+- new `src/services/vectorAnimation/LottieRuntimeManager.ts`
+- new `src/services/vectorAnimation/lottieMetadata.ts`
+- new `src/services/vectorAnimation/lottieJsonSniffer.ts`
+- new `src/services/vectorAnimation/types.ts`
+- `src/stores/mediaStore/slices/fileManageSlice.ts`
+
+### Build
+
+- Add `@lottiefiles/dotlottie-web`.
+- Create a clip-keyed runtime manager that owns one hidden `HTMLCanvasElement` plus one Lottie runtime instance per active clip.
+- Expose APIs to:
+  - load metadata from `File`
+  - ensure runtime for a clip
+  - render a clip at an exact timeline time
+  - update clip settings
+  - prune stale clip runtimes
+  - destroy all runtimes
+- Rehydrate Lottie canvases on `reloadFile()` and `updateTimelineClips()`.
+- Derive exact animation time from clip-local time plus `vectorAnimationSettings.loop` and `endBehavior`.
+- Populate `clip.source.textCanvas` with the managed canvas so the rest of the stack can reuse it.
+
+### Acceptance
+
+- The same Lottie source can exist in two clips at different times without cursor fights.
+- Scrubbing to the same frame twice produces the same canvas output.
+- Reloading a missing file restores the Lottie canvas and clears `needsReload`.
+- No free-running autoplay loop exists outside timeline time.
+
+## Workstream 3 - Render, Nested Preview, Export, And Thumbnails
+
+### Ownership
+
+- `src/services/layerBuilder/LayerBuilderService.ts`
+- `src/components/timeline/hooks/useLayerSync.ts`
+- `src/engine/export/ExportLayerBuilder.ts`
+- `src/services/thumbnailRenderer.ts`
+- `src/services/compositionRenderer.ts`
+- touch `src/engine/render/LayerCollector.ts` only if strictly necessary
+
+### Build
+
+- Teach the main layer builder to recognize `clip.source.type === 'lottie'` and reuse `buildTextLayer()` or an equivalent canvas layer path.
+- Before building layers, ask `LottieRuntimeManager` to render active Lottie clips at the current playhead time and prune stale runtimes.
+- Extend nested preview in both `LayerBuilderService.buildNestedClipLayer()` and `useLayerSync` so nested clips with `textCanvas` are treated like renderable canvas clips, not ignored.
+- Extend `ExportLayerBuilder` so Lottie clips and nested Lottie clips export through the existing canvas source path.
+- Extend `thumbnailRenderer` and `compositionRenderer` conditions so canvas-backed `lottie` clips are not excluded just because their semantic source type is not `text`.
+
+### Acceptance
+
+- Lottie preview works while paused, while scrubbing, and during playback.
+- A Lottie clip inside a nested composition is visible in preview.
+- Export uses the same deterministic frame mapping as preview.
+- Thumbnails can be generated from Lottie clips without a special export-only renderer.
+
+## Workstream 4 - Persistence, Restore, Background Playback, Clipboard
+
+### Ownership
+
+- `src/stores/timeline/serializationUtils.ts`
+- `src/services/project/projectSave.ts`
+- `src/services/project/projectLoad.ts`
+- `src/services/layerPlaybackManager.ts`
+- `src/services/slotDeckManager.ts`
+- `src/stores/timeline/clipboardSlice.ts`
+- `src/stores/timeline/clip/addCompClip.ts`
+
+### Build
+
+- Save `MediaFile.type === 'lottie'` plus `vectorAnimation` metadata into project files.
+- Save `vectorAnimationSettings` on timeline clips and nested clips.
+- Restore Lottie clips from project data with placeholder files when necessary, then hand them back to the runtime manager once the real file exists.
+- Ensure nested composition hydration and clipboard paste preserve `sourceType === 'lottie'`.
+- Extend background slot playback and composition preparation so canvas-backed Lottie clips are kept alive outside the active editor composition.
+
+### Acceptance
+
+- Save, close, reload, and relink preserve Lottie media and clip settings.
+- Background composition playback does not silently drop Lottie clips.
+- Copy/paste and nested comp duplication preserve Lottie type and settings.
+
+## Workstream 5 - UI, Icons, Properties
+
+### Ownership
+
+- `src/components/panels/MediaPanel.tsx`
+- `src/components/panels/media/FileTypeIcon.tsx`
+- `src/components/timeline/TimelineClip.tsx`
+- `src/components/panels/properties/index.tsx`
+- new `src/components/panels/properties/LottieTab.tsx`
+- optional `src/components/panels/properties/RiveTab.tsx`
+- `src/App.css` if styling is needed
+
+### Build
+
+- Add media and timeline icons for `lottie` and `rive`.
+- Show semantic clip badges based on `source.type`.
+- Add a Lottie properties tab with at least:
+  - loop toggle
+  - end behavior
+  - fit
+  - animation selection for multi-animation `.lottie`
+  - background color if the runtime exposes it cleanly
+- Keep Lottie clips finite by default. Do not mark them as "infinite" like text/solid/camera.
+- Do not add Media Panel "create new Lottie" menu items. Imported file UX is enough.
+
+### Acceptance
+
+- Imported Lottie items are visually distinct in the media panel and timeline.
+- Properties edits update preview without re-importing the file.
+- Multi-animation `.lottie` packages can switch the active animation from the properties panel.
+
+## Workstream 6 - Tests And Docs
+
+### Ownership
+
+- `tests/unit/importPipeline.test.ts`
+- `tests/stores/timeline/clipSlice.test.ts`
+- `tests/stores/mediaStore/fileManageSlice.test.ts`
+- `tests/unit/layerBuilderService.test.ts`
+- `tests/unit/exportLayerBuilder.test.ts`
+- `tests/unit/serialization.test.ts`
+- `tests/unit/projectMediaPersistence.test.ts`
+- `tests/unit/mediaPanelDropImport.test.ts`
+- `docs/Features/Media-Panel.md`
+- `docs/Features/Timeline.md`
+- add a focused feature doc if the existing docs become too noisy
+
+### Build
+
+- Add detection tests for `.lottie` and Lottie JSON sniffing.
+- Add clip creation tests for `source.type === 'lottie'`.
+- Add reload tests for Lottie relink.
+- Add layer builder and export tests proving Lottie is routed through the canvas path.
+- Add serialization and project persistence round-trip tests.
+- Update feature docs with supported file types, limitations, and property behavior.
+
+### Acceptance
+
+- `npm run build`
+- `npx vitest run tests/unit/importPipeline.test.ts tests/stores/timeline/clipSlice.test.ts tests/stores/mediaStore/fileManageSlice.test.ts tests/unit/layerBuilderService.test.ts tests/unit/exportLayerBuilder.test.ts tests/unit/serialization.test.ts tests/unit/projectMediaPersistence.test.ts tests/unit/mediaPanelDropImport.test.ts`
+
+## Rive Phase 2
+
+Do not start this until Lottie is green.
+
+### Scope
+
+- Imported `.riv` files
+- artboard selection
+- one deterministic linear animation path first
+- optional single state machine selection after the linear path works
+
+### Rules
+
+- Use the same canvas-backed render strategy as Lottie.
+- Do not use `rive-react` as the core runtime.
+- Cache parsed file data if helpful, but keep render cursors clip-local.
+- Leave Rive audio and rich data binding out of the first pass.
+
+## Shared Hot Spots That Must Not Be Edited Casually In Parallel
+
+- `src/types/index.ts`
+- `src/stores/mediaStore/types.ts`
+- `src/services/project/types/media.types.ts`
+- `src/services/project/types/composition.types.ts`
+- `src/stores/timeline/serializationUtils.ts`
+- `src/services/project/projectSave.ts`
+- `src/services/project/projectLoad.ts`
+- `src/services/layerBuilder/LayerBuilderService.ts`
+- `src/components/timeline/hooks/useExternalDrop.ts`
+- `package.json`
+- `package-lock.json`
+
+## Definition Of Done
+
+Treat this issue as done only when all of the following are true:
+
+- A user can import `.lottie` and Lottie JSON files into the media panel.
+- A user can drag a Lottie media item to a video track and get a real Lottie clip.
+- Scrubbing, paused preview, playback, nested comps, thumbnails, and export all render deterministically.
+- Save/load and relink preserve Lottie media and clip settings.
+- The same Lottie source can be reused multiple times on the timeline at different times.
+- Build passes and the targeted tests pass.
+- Rive has a follow-up implementation path that reuses the same architecture instead of reopening the design from scratch.

--- a/src/App.css
+++ b/src/App.css
@@ -8443,6 +8443,11 @@ input[type="checkbox"] {
   background: rgba(45, 140, 235, 0.15);
 }
 
+.media-grid-item.importing {
+  opacity: 0.55;
+  cursor: progress;
+}
+
 .media-grid-thumb {
   position: relative;
   aspect-ratio: 16 / 9;
@@ -8489,6 +8494,20 @@ input[type="checkbox"] {
   border-radius: 8px;
   font-variant-numeric: tabular-nums;
   min-width: 16px;
+  text-align: center;
+}
+
+.media-grid-import-badge {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  background: rgba(45, 140, 235, 0.18);
+  color: var(--accent);
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 8px;
+  font-variant-numeric: tabular-nums;
+  min-width: 28px;
   text-align: center;
 }
 
@@ -8555,6 +8574,7 @@ input[type="checkbox"] {
 
 .media-item.importing {
   opacity: 0.5;
+  cursor: progress;
 }
 
 .media-item.importing .media-col-name::after {
@@ -8567,6 +8587,20 @@ input[type="checkbox"] {
 @keyframes importPulse {
   0%, 100% { opacity: 0.5; }
   50% { opacity: 1; }
+}
+
+.media-item-import-progress {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 38px;
+  padding: 1px 5px;
+  margin-left: 6px;
+  border-radius: 999px;
+  background: rgba(45, 140, 235, 0.18);
+  color: var(--accent);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
 }
 
 .media-folder-arrow {

--- a/src/changelog-data.json
+++ b/src/changelog-data.json
@@ -1,5 +1,35 @@
 [
   {
+    "date": "2026-04-20",
+    "type": "new",
+    "title": "FlashBoard Adds Seedance 2.0 via Kie.ai",
+    "description": "FlashBoard now exposes Seedance 2.0 in the model catalog and pricing flow, with the Kie.ai service path updated so text-to-video and sequence-oriented generation can be routed through the board UI.",
+    "section": "FlashBoard / AI Video",
+    "commits": [
+      "324a5e81"
+    ]
+  },
+  {
+    "date": "2026-04-20",
+    "type": "improve",
+    "title": "AI Chat Model Catalog and Landing Experience Were Refreshed",
+    "description": "The OpenAI model catalog, AI chat pricing/model wiring, and the dedicated landing page were updated together so the public entry flow and in-app AI surfaces stay aligned with the current product lineup.",
+    "section": "AI Chat / Landing",
+    "commits": [
+      "324a5e81"
+    ]
+  },
+  {
+    "date": "2026-04-20",
+    "type": "fix",
+    "title": "Overlaid PLY and Splat Sequences Stay in Sync During Playback",
+    "description": "Gaussian splat sequence playback now prewarms the upcoming per-frame Three.js runtimes instead of waiting for on-demand cache misses, which removes the small playback offset that could appear when `.ply` and `.splat` layers were stacked together.",
+    "section": "3D / Gaussian Splats",
+    "commits": [
+      "196389f6"
+    ]
+  },
+  {
     "date": "2026-04-18",
     "type": "new",
     "title": "MasterSelects Now Opens Through a Dedicated Landing Page",

--- a/src/components/panels/AIChatPanel.css
+++ b/src/components/panels/AIChatPanel.css
@@ -81,87 +81,25 @@
   background: var(--accent-hover);
 }
 
-.ai-chat-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--sp-3) var(--sp-4);
-  background: var(--bg-tertiary);
-  border-bottom: 1px solid var(--border-color);
-  flex-shrink: 0;
-}
-
-.ai-chat-header h2 {
-  margin: 0;
-  font-size: var(--font-xl);
-  font-weight: var(--font-semibold);
-}
-
-.ai-chat-title-group {
-  display: flex;
-  align-items: center;
-  gap: var(--sp-2);
-}
-
-.ai-access-chip {
-  display: inline-flex;
-  align-items: center;
-  padding: 2px 8px;
-  border-radius: var(--radius-full);
-  font-size: var(--font-xs);
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-wide);
-  border: 1px solid var(--border-color);
-  color: var(--text-secondary);
-}
-
-.ai-access-chip.hosted {
-  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
-  color: var(--accent);
-}
-
-.ai-access-chip.byo {
-  border-color: var(--border-color);
-}
-
-.ai-access-chip.none {
-  color: var(--danger-light);
-  border-color: var(--danger-border);
-}
-
-.ai-chat-controls {
-  display: flex;
-  gap: var(--sp-2);
-  align-items: center;
-}
-
-.model-select {
+.btn-clear {
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
-  padding: var(--sp-1) var(--sp-2);
-  font-size: var(--font-md);
-  cursor: pointer;
-}
-
-.model-select:hover {
-  border-color: var(--accent);
-}
-
-.btn-clear {
-  background: transparent;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   color: var(--text-secondary);
-  padding: var(--sp-1) var(--sp-2);
-  font-size: var(--font-sm);
+  padding: var(--sp-2) var(--sp-4);
+  font-size: var(--font-md);
+  font-weight: var(--font-medium);
   cursor: pointer;
-  transition: all var(--transition-normal);
+  transition:
+    background var(--transition-normal),
+    border-color var(--transition-normal),
+    color var(--transition-normal),
+    opacity var(--transition-normal);
 }
 
 .btn-clear:hover:not(:disabled) {
-  border-color: var(--accent);
+  background: color-mix(in srgb, var(--bg-secondary) 78%, white 8%);
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--border-color));
   color: var(--text-primary);
 }
 
@@ -341,12 +279,23 @@
 
 /* Input Area */
 .ai-chat-input-area {
-  display: flex;
-  gap: var(--sp-2);
   padding: var(--sp-3) var(--sp-4);
   background: var(--bg-tertiary);
   border-top: 1px solid var(--border-color);
   flex-shrink: 0;
+}
+
+.ai-chat-composer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  width: 100%;
+}
+
+.ai-chat-input-row {
+  display: flex;
+  gap: var(--sp-2);
+  width: 100%;
 }
 
 .ai-chat-input {
@@ -358,7 +307,10 @@
   padding: var(--sp-2) var(--sp-3);
   font-size: var(--font-lg);
   font-family: inherit;
-  resize: none;
+  min-height: 64px;
+  max-height: 240px;
+  resize: vertical;
+  overflow-y: auto;
   line-height: 1.4;
 }
 
@@ -393,26 +345,163 @@
   cursor: not-allowed;
 }
 
-/* Editor Mode Toggle */
-.editor-mode-toggle {
+.ai-chat-control-bar {
   display: flex;
   align-items: center;
-  gap: var(--sp-1);
-  cursor: pointer;
-  font-size: var(--font-sm);
+  justify-content: space-between;
+  gap: var(--sp-2);
+}
+
+.ai-chat-pill-group {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  position: relative;
+  flex-wrap: wrap;
+}
+
+.ai-chat-pill {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.06);
   color: var(--text-secondary);
-}
-
-.editor-mode-toggle input {
+  font-size: 11px;
   cursor: pointer;
+  transition:
+    border-color var(--transition-normal),
+    background var(--transition-normal),
+    color var(--transition-normal),
+    opacity var(--transition-normal);
+  white-space: nowrap;
 }
 
-.editor-mode-toggle .toggle-label {
+.ai-chat-pill:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+}
+
+.ai-chat-pill.active {
+  background: var(--accent);
+  color: var(--text-on-accent);
+  border-color: var(--accent);
+}
+
+.ai-chat-toggle-pill {
   user-select: none;
 }
 
-.editor-mode-toggle input:checked + .toggle-label {
-  color: var(--accent);
+.ai-chat-toggle-pill input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ai-chat-pill:disabled,
+.ai-chat-toggle-pill:has(input:disabled) {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.ai-chat-toggle-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+
+.ai-chat-toggle-pill.active .ai-chat-toggle-dot {
+  opacity: 1;
+}
+
+.ai-chat-popover {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  min-width: 220px;
+  max-width: 320px;
+  padding: 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: var(--bg-elevated, #2a2a3e);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  z-index: 5;
+}
+
+.ai-chat-popover-model {
+  min-width: 260px;
+}
+
+.ai-chat-popover-title {
+  margin-bottom: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.ai-chat-popover-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.ai-chat-popover-pill {
+  appearance: none;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 5px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-secondary);
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--transition-normal),
+    background var(--transition-normal),
+    color var(--transition-normal);
+}
+
+.ai-chat-popover-pill:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+}
+
+.ai-chat-popover-pill.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--text-on-accent);
+}
+
+.ai-chat-popover-pill-label {
+  color: inherit;
+}
+
+.ai-chat-popover-pill-meta {
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.3;
+}
+
+.ai-chat-popover-pill.active .ai-chat-popover-pill-meta {
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.ai-chat-clear-bottom {
+  margin-left: auto;
+  align-self: center;
+  justify-content: center;
+  min-width: 0;
+  text-align: center;
 }
 
 /* Tool Calls Display */
@@ -500,6 +589,124 @@
   color: var(--accent);
   font-style: italic;
   animation: pulse 1.5s infinite;
+}
+
+.ai-chat-message.tool-approval {
+  align-self: flex-start;
+  max-width: min(560px, 100%);
+  padding: 0;
+  background: transparent;
+}
+
+.tool-approval-banner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  padding: var(--sp-3);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--warning-subtle, var(--bg-tertiary)) 55%, var(--bg-tertiary)), var(--bg-tertiary));
+  border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border-color));
+  border-radius: var(--radius-xl);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
+}
+
+.tool-approval-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  flex-wrap: wrap;
+}
+
+.tool-approval-label {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  color: var(--accent);
+  font-size: var(--font-xs);
+  font-weight: var(--font-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+}
+
+.tool-approval-name {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--font-sm);
+  font-weight: var(--font-semibold);
+}
+
+.tool-approval-copy {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-sm);
+  line-height: 1.45;
+}
+
+.tool-approval-args {
+  margin: 0;
+  padding: var(--sp-2);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--bg-secondary) 92%, black 8%);
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-size: var(--font-xs);
+  font-family: var(--font-mono);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 220px;
+  overflow: auto;
+}
+
+.tool-approval-buttons {
+  display: flex;
+  gap: var(--sp-2);
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.btn-approve,
+.btn-deny {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-lg);
+  padding: var(--sp-2) var(--sp-3);
+  font-size: var(--font-sm);
+  font-weight: var(--font-semibold);
+  cursor: pointer;
+  transition:
+    background var(--transition-normal),
+    border-color var(--transition-normal),
+    color var(--transition-normal),
+    transform var(--transition-fast);
+}
+
+.btn-approve:hover,
+.btn-deny:hover {
+  transform: translateY(-1px);
+}
+
+.btn-approve {
+  background: var(--accent);
+  color: var(--text-on-accent);
+}
+
+.btn-approve:hover {
+  background: var(--accent-hover);
+}
+
+.btn-deny {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border-color);
+}
+
+.btn-deny:hover {
+  border-color: color-mix(in srgb, var(--danger-light) 45%, var(--border-color));
+  color: var(--danger-light);
 }
 
 @keyframes pulse {
@@ -634,4 +841,24 @@
 
 .ai-chat-onboarding-dismiss:hover {
   background: var(--accent-hover);
+}
+
+@media (max-width: 640px) {
+  .ai-chat-input-row {
+    flex-direction: column;
+  }
+
+  .btn-send {
+    width: 100%;
+    align-self: stretch;
+  }
+
+  .tool-approval-buttons {
+    flex-direction: column;
+  }
+
+  .btn-approve,
+  .btn-deny {
+    width: 100%;
+  }
 }

--- a/src/components/panels/AIChatPanel.tsx
+++ b/src/components/panels/AIChatPanel.tsx
@@ -5,34 +5,13 @@ import { useSettingsStore } from '../../stores/settingsStore';
 import { useAccountStore } from '../../stores/accountStore';
 import { AI_TOOLS, executeAITool, getQuickTimelineSummary, getToolPolicy } from '../../services/aiTools';
 import { cloudAiService } from '../../services/cloudAiService';
+import {
+  DEFAULT_OPENAI_MODEL_ID,
+  OPENAI_CHAT_DROPDOWN_MODELS,
+  type OpenAiReasoningEffort,
+} from '../../shared/openAiModelCatalog';
 import type { ToolPolicyEntry } from '../../services/aiTools';
 import './AIChatPanel.css';
-
-// Available OpenAI models with credit cost per request
-const OPENAI_MODELS = [
-  // GPT-5.2 series (newest - Dec 2025)
-  { id: 'gpt-5.2', name: 'GPT-5.2 (Thinking)', credits: 8 },
-  { id: 'gpt-5.2-pro', name: 'GPT-5.2 Pro', credits: 10 },
-  // GPT-5.1 series
-  { id: 'gpt-5.1', name: 'GPT-5.1', credits: 5 },
-  { id: 'gpt-5.1-codex', name: 'GPT-5.1 Codex', credits: 5 },
-  { id: 'gpt-5.1-codex-mini', name: 'GPT-5.1 Codex Mini', credits: 1 },
-  // GPT-5 series
-  { id: 'gpt-5', name: 'GPT-5', credits: 5 },
-  { id: 'gpt-5-mini', name: 'GPT-5 Mini', credits: 1 },
-  { id: 'gpt-5-nano', name: 'GPT-5 Nano', credits: 1 },
-  // Reasoning models
-  { id: 'o3', name: 'o3 (Reasoning)', credits: 5 },
-  { id: 'o4-mini', name: 'o4-mini (Reasoning)', credits: 3 },
-  { id: 'o3-pro', name: 'o3-pro (Deep Reasoning)', credits: 50 },
-  // GPT-4.1 series
-  { id: 'gpt-4.1', name: 'GPT-4.1', credits: 5 },
-  { id: 'gpt-4.1-mini', name: 'GPT-4.1 Mini', credits: 1 },
-  { id: 'gpt-4.1-nano', name: 'GPT-4.1 Nano', credits: 1 },
-  // GPT-4o series (legacy)
-  { id: 'gpt-4o', name: 'GPT-4o', credits: 5 },
-  { id: 'gpt-4o-mini', name: 'GPT-4o Mini', credits: 1 },
-];
 
 // System prompt for editor mode
 const EDITOR_SYSTEM_PROMPT = `You are an AI video editing assistant with direct access to the timeline AND media panel. You can:
@@ -115,10 +94,45 @@ interface PendingApproval {
   resolve: (approved: boolean) => void;
 }
 
+type AiApprovalMode = 'auto' | 'confirm-destructive' | 'confirm-all-mutating';
+type ChatControlPopover = 'model' | 'reasoning' | null;
+
 const MAX_TOOL_RESULT_MESSAGE_CHARS = 12000;
 const MAX_TOOL_RESULT_ARRAY_ITEMS = 20;
 const MAX_TOOL_RESULT_OBJECT_KEYS = 30;
 const MAX_TOOL_RESULT_STRING_CHARS = 1200;
+const REASONING_OPTION_COPY: Record<OpenAiReasoningEffort, { compactLabel: string; description: string; label: string }> = {
+  none: {
+    compactLabel: 'none',
+    description: 'No extra reasoning step. Fastest and cheapest.',
+    label: 'None',
+  },
+  minimal: {
+    compactLabel: 'min',
+    description: 'Very light reasoning for quick replies.',
+    label: 'Minimal',
+  },
+  low: {
+    compactLabel: 'low',
+    description: 'Low reasoning effort with lower latency.',
+    label: 'Low',
+  },
+  medium: {
+    compactLabel: 'med',
+    description: 'Balanced reasoning depth and speed.',
+    label: 'Medium',
+  },
+  high: {
+    compactLabel: 'high',
+    description: 'Deeper reasoning for harder edits or planning.',
+    label: 'High',
+  },
+  xhigh: {
+    compactLabel: 'xhigh',
+    description: 'Maximum available reasoning for supported models.',
+    label: 'XHigh',
+  },
+};
 
 function truncateText(value: string, maxLength: number): string {
   if (value.length <= maxLength) {
@@ -258,7 +272,7 @@ function sanitizeConversationHistory(messages: Message[]): Message[] {
 
 function shouldRequireConfirmation(
   policy: ToolPolicyEntry | undefined,
-  approvalMode: 'auto' | 'confirm-destructive' | 'confirm-all-mutating',
+  approvalMode: AiApprovalMode,
 ): boolean {
   if (!policy) return true; // unknown tools require confirmation
   if (approvalMode === 'auto') return false;
@@ -310,14 +324,17 @@ export function AIChatPanel() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const [model, setModel] = useState('gpt-5.1');
+  const [model, setModel] = useState(DEFAULT_OPENAI_MODEL_ID);
+  const [reasoningEffort, setReasoningEffort] = useState<OpenAiReasoningEffort | null>('none');
   const [error, setError] = useState<string | null>(null);
-  const [editorMode, setEditorMode] = useState(true); // Enable tools by default
+  const [bypassToolApprovals, setBypassToolApprovals] = useState(false);
+  const [controlPopover, setControlPopover] = useState<ChatControlPopover>(null);
   const [currentToolAction, setCurrentToolAction] = useState<string | null>(null);
   const [pendingApproval, setPendingApproval] = useState<PendingApproval | null>(null);
   const [onboardingClosing, setOnboardingClosing] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const controlPopoverRef = useRef<HTMLDivElement>(null);
 
   // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
@@ -328,19 +345,57 @@ export function AIChatPanel() {
   const hasApiKey = !!apiKeys.openai;
   const accessMode: 'hosted' | 'byo' | 'none' = hasHostedAccess ? 'hosted' : hasApiKey ? 'byo' : 'none';
   const hasAccess = accessMode !== 'none';
+  const effectiveApprovalMode: AiApprovalMode = bypassToolApprovals ? 'auto' : aiApprovalMode;
+  const selectedModel = OPENAI_CHAT_DROPDOWN_MODELS.find((entry) => entry.id === model);
+  const supportedReasoningEfforts = selectedModel?.supportedReasoningEfforts;
+  const reasoningChipLabel = reasoningEffort ? REASONING_OPTION_COPY[reasoningEffort].compactLabel : null;
+  const modelChipLabel = selectedModel
+    ? `${selectedModel.label} · ${selectedModel.creditCost === 1 ? '1 cr' : `${selectedModel.creditCost} cr`}`
+    : model;
+  const bypassToggleHint = bypassToolApprovals
+    ? 'Tools run immediately in this panel'
+    : 'Keep confirmation prompts for tool actions';
+
+  useEffect(() => {
+    const availableReasoningEfforts = selectedModel?.supportedReasoningEfforts ?? [];
+
+    if (!selectedModel || availableReasoningEfforts.length === 0) {
+      setReasoningEffort(null);
+      setControlPopover(null);
+      return;
+    }
+
+    if (reasoningEffort && availableReasoningEfforts.includes(reasoningEffort)) {
+      return;
+    }
+
+    setReasoningEffort(selectedModel.defaultReasoningEffort ?? availableReasoningEfforts[0] ?? null);
+  }, [reasoningEffort, selectedModel]);
+
+  useEffect(() => {
+    if (!controlPopover) {
+      return;
+    }
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (controlPopoverRef.current && !controlPopoverRef.current.contains(event.target as Node)) {
+        setControlPopover(null);
+      }
+    };
+
+    window.addEventListener('mousedown', handleOutsideClick);
+    return () => window.removeEventListener('mousedown', handleOutsideClick);
+  }, [controlPopover]);
 
   // Build API messages from chat history
   const buildAPIMessages = useCallback((userContent: string): APIMessage[] => {
     const apiMessages: APIMessage[] = [];
     const safeMessages = sanitizeConversationHistory(messages);
 
-    // Add system prompt in editor mode
-    if (editorMode) {
-      apiMessages.push({
-        role: 'system',
-        content: EDITOR_SYSTEM_PROMPT + getQuickTimelineSummary(),
-      });
-    }
+    apiMessages.push({
+      role: 'system',
+      content: EDITOR_SYSTEM_PROMPT + getQuickTimelineSummary(),
+    });
 
     // Add conversation history
     for (const msg of safeMessages) {
@@ -373,7 +428,7 @@ export function AIChatPanel() {
     apiMessages.push({ role: 'user', content: userContent });
 
     return apiMessages;
-  }, [messages, editorMode]);
+  }, [messages]);
 
   // Call OpenAI API
   const callOpenAI = useCallback(async (
@@ -394,11 +449,12 @@ export function AIChatPanel() {
         : { max_tokens: 4096 }),
     };
 
-    // Add tools in editor mode
-    if (editorMode) {
-      requestBody.tools = AI_TOOLS;
-      requestBody.tool_choice = 'auto';
+    if (reasoningEffort) {
+      requestBody.reasoning_effort = reasoningEffort;
     }
+
+    requestBody.tools = AI_TOOLS;
+    requestBody.tool_choice = 'auto';
 
     if (accessMode === 'hosted') {
       if (idempotencyKey) {
@@ -423,7 +479,7 @@ export function AIChatPanel() {
     }
 
     return parseChatCompletionPayload(await response.json());
-  }, [accessMode, model, editorMode, apiKeys.openai]);
+  }, [accessMode, model, reasoningEffort, apiKeys.openai]);
 
   // Send message to OpenAI (with tool calling loop)
   const sendMessage = useCallback(async () => {
@@ -508,7 +564,7 @@ export function AIChatPanel() {
 
           // Check if this tool requires user confirmation
           const policy = getToolPolicy(toolCall.name);
-          const needsConfirmation = shouldRequireConfirmation(policy, aiApprovalMode);
+          const needsConfirmation = shouldRequireConfirmation(policy, effectiveApprovalMode);
 
           let result: { success: boolean; data?: unknown; error?: string };
 
@@ -573,7 +629,7 @@ export function AIChatPanel() {
       setIsLoading(false);
       setCurrentToolAction(null);
     }
-  }, [input, hasAccess, isLoading, buildAPIMessages, callOpenAI, aiApprovalMode, accessMode, loadAccountState]);
+  }, [input, hasAccess, isLoading, buildAPIMessages, callOpenAI, effectiveApprovalMode, accessMode, loadAccountState]);
 
   // Handle key press
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -631,45 +687,6 @@ export function AIChatPanel() {
           </div>
         </div>
       )}
-      {/* Header */}
-      <div className="ai-chat-header">
-        <div className="ai-chat-title-group">
-          <h2>AI Editor</h2>
-          <span className={`ai-access-chip ${accessMode}`}>
-            {accessMode === 'hosted' ? 'Cloud' : accessMode === 'byo' ? 'OpenAI key' : 'Locked'}
-          </span>
-        </div>
-        <div className="ai-chat-controls">
-          <label className="editor-mode-toggle" title="Enable timeline editing tools">
-            <input
-              type="checkbox"
-              checked={editorMode}
-              onChange={(e) => setEditorMode(e.target.checked)}
-              disabled={isLoading}
-            />
-            <span className="toggle-label">Tools</span>
-          </label>
-          <select
-            className="model-select"
-            value={model}
-            onChange={(e) => setModel(e.target.value)}
-            disabled={isLoading}
-          >
-            {OPENAI_MODELS.map(m => (
-              <option key={m.id} value={m.id}>{m.name} ({m.credits === 1 ? '1 credit' : `${m.credits} credits`})</option>
-            ))}
-          </select>
-          <button
-            className="btn-clear"
-            onClick={clearChat}
-            disabled={isLoading || messages.length === 0}
-            title="Clear chat"
-          >
-            Clear
-          </button>
-        </div>
-      </div>
-
       {/* Messages */}
       <div className="ai-chat-messages">
         {messages.length === 0 ? (
@@ -694,8 +711,8 @@ export function AIChatPanel() {
                       <li><strong>Downloads:</strong> "Search YouTube for nature footage and download it"</li>
                     </ul>
                     <p className="ai-chat-onboarding-note">
-                      The <strong>Tools</strong> toggle enables timeline editing. Turn it off for a normal chat.
-                      Use the approval mode in Settings to control which actions need your confirmation.
+                      AI chat runs directly against the editor tool surface.
+                      Use the approval mode in Settings or the Auto tools switch below to control confirmations.
                     </p>
                   </div>
                   <button className="ai-chat-onboarding-dismiss" onClick={dismissOnboarding}>
@@ -705,11 +722,9 @@ export function AIChatPanel() {
               </div>
             )}
             <div className="ai-chat-welcome">
-              <p>{editorMode ? 'AI Editor Ready' : 'Start a conversation'}</p>
+              <p>AI Editor Ready</p>
               <span className="welcome-hint">
-                {editorMode
-                  ? 'Ask me to edit your timeline - cut clips, remove silence, etc.'
-                  : `Using ${OPENAI_MODELS.find(m => m.id === model)?.name}`}
+                Ask me to edit your timeline - cut clips, remove silence, etc.
               </span>
             </div>
           </>
@@ -786,8 +801,13 @@ export function AIChatPanel() {
         {pendingApproval && (
           <div className="ai-chat-message tool-approval">
             <div className="tool-approval-banner">
-              <span className="tool-approval-label">Confirm action:</span>
-              <span className="tool-approval-name">{pendingApproval.toolName}</span>
+              <div className="tool-approval-header">
+                <span className="tool-approval-label">Approval required</span>
+                <span className="tool-approval-name">{pendingApproval.toolName}</span>
+              </div>
+              <p className="tool-approval-copy">
+                The AI wants to run this editor action.
+              </p>
               <pre className="tool-approval-args">
                 {JSON.stringify(pendingApproval.args, null, 2).substring(0, 200)}
               </pre>
@@ -796,7 +816,7 @@ export function AIChatPanel() {
                   className="btn-approve"
                   onClick={() => pendingApproval.resolve(true)}
                 >
-                  Allow
+                  Allow action
                 </button>
                 <button
                   className="btn-deny"
@@ -835,25 +855,125 @@ export function AIChatPanel() {
 
       {/* Input */}
       <div className="ai-chat-input-area">
-        <textarea
-          ref={inputRef}
-          className="ai-chat-input"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder={editorMode
-            ? "e.g., 'Remove all silent parts' or 'Split clip at 5 seconds'"
-            : "Type a message... (Enter to send)"}
-          disabled={isLoading || !hasAccess}
-          rows={2}
-        />
-        <button
-          className="btn-send"
-          onClick={sendMessage}
-          disabled={!input.trim() || isLoading || !hasAccess}
-        >
-          {isLoading ? '...' : 'Send'}
-        </button>
+        <div className="ai-chat-composer">
+          <div className="ai-chat-input-row">
+            <textarea
+              ref={inputRef}
+              className="ai-chat-input"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="e.g., 'Remove all silent parts' or 'Split clip at 5 seconds'"
+              disabled={isLoading || !hasAccess}
+              rows={2}
+            />
+            <button
+              className="btn-send"
+              onClick={sendMessage}
+              disabled={!input.trim() || isLoading || !hasAccess}
+            >
+              {isLoading ? '...' : 'Send'}
+            </button>
+          </div>
+          <div className="ai-chat-control-bar">
+            <div className="ai-chat-pill-group" ref={controlPopoverRef}>
+              <button
+                className={`ai-chat-pill ${controlPopover === 'model' ? 'active' : ''}`}
+                type="button"
+                onClick={() => setControlPopover((current) => current === 'model' ? null : 'model')}
+                title="Model selection"
+                disabled={isLoading}
+              >
+                {modelChipLabel}
+              </button>
+
+              {controlPopover === 'model' && (
+                <div className="ai-chat-popover ai-chat-popover-model">
+                  <div className="ai-chat-popover-title">Model</div>
+                  <div className="ai-chat-popover-pills">
+                    {OPENAI_CHAT_DROPDOWN_MODELS.map((entry) => (
+                      <button
+                        key={entry.id}
+                        className={`ai-chat-popover-pill ${model === entry.id ? 'active' : ''}`}
+                        type="button"
+                        onClick={() => {
+                          setModel(entry.id);
+                          setControlPopover(null);
+                        }}
+                      >
+                        <span className="ai-chat-popover-pill-label">{entry.label}</span>
+                        <span className="ai-chat-popover-pill-meta">
+                          {entry.creditCost === 1 ? '1 credit' : `${entry.creditCost} credits`} · {entry.tier}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <label
+                className={`ai-chat-pill ai-chat-toggle-pill ${bypassToolApprovals ? 'active' : ''}`}
+                title={bypassToggleHint}
+              >
+                <input
+                  type="checkbox"
+                  checked={bypassToolApprovals}
+                  onChange={(e) => setBypassToolApprovals(e.target.checked)}
+                  disabled={isLoading || !!pendingApproval || !hasAccess}
+                />
+                <span className="ai-chat-toggle-dot" />
+                <span>Auto tools</span>
+              </label>
+
+              {(supportedReasoningEfforts?.length ?? 0) > 0 && reasoningChipLabel && (
+                <>
+                  <button
+                    className={`ai-chat-pill ${controlPopover === 'reasoning' ? 'active' : ''}`}
+                    type="button"
+                    onClick={() => setControlPopover((current) => current === 'reasoning' ? null : 'reasoning')}
+                    title="Thinking effort"
+                  >
+                    Thinking {reasoningChipLabel}
+                  </button>
+
+                  {controlPopover === 'reasoning' && (
+                    <div className="ai-chat-popover">
+                      <div className="ai-chat-popover-title">Thinking</div>
+                      <div className="ai-chat-popover-pills">
+                        {supportedReasoningEfforts?.map((effort) => (
+                          <button
+                            key={effort}
+                            className={`ai-chat-popover-pill ${reasoningEffort === effort ? 'active' : ''}`}
+                            type="button"
+                            onClick={() => {
+                              setReasoningEffort(effort);
+                              setControlPopover(null);
+                            }}
+                          >
+                            <span className="ai-chat-popover-pill-label">
+                              {REASONING_OPTION_COPY[effort].label}
+                            </span>
+                            <span className="ai-chat-popover-pill-meta">
+                              {REASONING_OPTION_COPY[effort].description}
+                            </span>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+            <button
+              className="ai-chat-pill ai-chat-clear-bottom"
+              onClick={clearChat}
+              disabled={isLoading || messages.length === 0}
+              title="Clear chat"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/panels/flashboard/FlashBoardComposer.tsx
+++ b/src/components/panels/flashboard/FlashBoardComposer.tsx
@@ -289,10 +289,21 @@ export function FlashBoardComposer({
         duration,
         imageSize,
         generateAudio: effectiveGenerateAudio,
+        hasStartFrame: Boolean(composer.startMediaFileId),
         multiShots,
       })
       : null
-  ), [selectedEntry, service, providerId, mode, duration, imageSize, effectiveGenerateAudio, multiShots]);
+  ), [
+    selectedEntry,
+    service,
+    providerId,
+    mode,
+    duration,
+    imageSize,
+    effectiveGenerateAudio,
+    composer.startMediaFileId,
+    multiShots,
+  ]);
   const maxReferenceImages = selectedEntry?.supportsTextToImage ? selectedEntry.maxReferenceImages : undefined;
   const effectiveReferenceMediaFileIds = useMemo(
     () => clampReferenceMediaFileIds(composer.referenceMediaFileIds ?? [], maxReferenceImages),
@@ -521,7 +532,7 @@ export function FlashBoardComposer({
       providerId,
       version,
       outputType: selectedEntry.outputType ?? 'video',
-      mode,
+      mode: selectedEntry.modes.length > 0 ? mode : undefined,
       prompt: effectivePrompt,
       duration,
       aspectRatio,
@@ -805,6 +816,7 @@ export function FlashBoardComposer({
                           imageSize,
                           mode,
                           generateAudio: p.supportsGenerateAudio ? effectiveGenerateAudio : false,
+                          hasStartFrame: Boolean(composer.startMediaFileId),
                           multiShots: p.supportsMultiShot ? multiShots : false,
                         });
 
@@ -856,6 +868,7 @@ export function FlashBoardComposer({
                     duration: d,
                     imageSize,
                     generateAudio: effectiveGenerateAudio,
+                    hasStartFrame: Boolean(composer.startMediaFileId),
                     multiShots,
                   });
 
@@ -887,6 +900,7 @@ export function FlashBoardComposer({
                     duration,
                     imageSize: size,
                     generateAudio: effectiveGenerateAudio,
+                    hasStartFrame: Boolean(composer.startMediaFileId),
                     multiShots,
                   });
 
@@ -918,6 +932,7 @@ export function FlashBoardComposer({
                     duration,
                     imageSize,
                     generateAudio: effectiveGenerateAudio,
+                    hasStartFrame: Boolean(composer.startMediaFileId),
                     multiShots,
                   });
 

--- a/src/components/panels/flashboard/FlashBoardInspector.tsx
+++ b/src/components/panels/flashboard/FlashBoardInspector.tsx
@@ -27,6 +27,7 @@ export function FlashBoardInspector() {
       duration: request.duration,
       imageSize: request.imageSize,
       generateAudio: request.generateAudio,
+      hasStartFrame: Boolean(request.startMediaFileId),
       multiShots: request.multiShots,
     })
     : null;

--- a/src/components/panels/flashboard/FlashBoardNode.tsx
+++ b/src/components/panels/flashboard/FlashBoardNode.tsx
@@ -230,6 +230,7 @@ function FlashBoardNodeComponent({
       duration: node.request.duration,
       imageSize: node.request.imageSize,
       generateAudio: node.request.generateAudio,
+      hasStartFrame: Boolean(node.request.startMediaFileId),
       multiShots: node.request.multiShots,
     })?.compactLabel ?? null
     : null;

--- a/src/engine/render/RenderDispatcher.ts
+++ b/src/engine/render/RenderDispatcher.ts
@@ -34,7 +34,11 @@ import { buildSplatCamera, resolveOrbitCameraPose } from '../gaussian/core/Splat
 import { loadGaussianSplatAssetCached } from '../gaussian/loaders';
 import { DEFAULT_GAUSSIAN_SPLAT_SETTINGS } from '../gaussian/types';
 import { DEFAULT_SPLAT_EFFECTOR_SETTINGS } from '../../types/splatEffector';
-import { waitForBasePreparedSplatRuntime, waitForTargetPreparedSplatRuntime } from '../three/splatRuntimeCache';
+import {
+  getPreparedSplatRuntimeSync,
+  waitForBasePreparedSplatRuntime,
+  waitForTargetPreparedSplatRuntime,
+} from '../three/splatRuntimeCache';
 
 const log = Logger.create('RenderDispatcher');
 const GAUSSIAN_PLAYBACK_SORT_FREQUENCY = 6;
@@ -375,6 +379,101 @@ export class RenderDispatcher {
     this.exportReadyModelUrls.clear();
   }
 
+  private describeExportReadinessError(error: unknown): string {
+    return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  }
+
+  private isRecoverableThreeSplatExportError(error: unknown): boolean {
+    const message = this.describeExportReadinessError(error).toLowerCase();
+    return message.includes('array buffer allocation failed') || message.includes('out of memory');
+  }
+
+  private async ensureThreeSplatRuntimeReadyForExport(options: {
+    cacheKey: string;
+    fileHash?: string;
+    file?: File;
+    url?: string;
+    fileName: string;
+    gaussianSplatSequence?: NonNullable<Layer['source']>['gaussianSplatSequence'];
+    preferBaseRuntime: boolean;
+    requestedMaxSplats: number;
+  }): Promise<void> {
+    const {
+      cacheKey,
+      fileHash,
+      file,
+      url,
+      fileName,
+      gaussianSplatSequence,
+      preferBaseRuntime,
+      requestedMaxSplats,
+    } = options;
+    const variant = preferBaseRuntime ? 'base' : 'target';
+    const threeSplatKey = `${cacheKey}|${variant}|${requestedMaxSplats}`;
+    if (this.exportReadyThreeSplatKeys.has(threeSplatKey)) {
+      return;
+    }
+
+    const sourceOptions = {
+      cacheKey,
+      fileHash,
+      file,
+      url,
+      fileName,
+      gaussianSplatSequence,
+      requestedMaxSplats,
+    };
+
+    if (preferBaseRuntime) {
+      await waitForBasePreparedSplatRuntime(sourceOptions);
+      this.exportReadyThreeSplatKeys.add(threeSplatKey);
+      return;
+    }
+
+    try {
+      await waitForTargetPreparedSplatRuntime(sourceOptions);
+      this.exportReadyThreeSplatKeys.add(threeSplatKey);
+      return;
+    } catch (targetError) {
+      const cachedBaseRuntime = getPreparedSplatRuntimeSync({
+        ...sourceOptions,
+        variant: 'base',
+      });
+      if (cachedBaseRuntime) {
+        log.warn('Precise export falling back to cached base Three.js splat runtime', {
+          cacheKey,
+          fileName,
+          requestedMaxSplats,
+          error: targetError,
+        });
+        this.exportReadyThreeSplatKeys.add(threeSplatKey);
+        return;
+      }
+
+      if (!this.isRecoverableThreeSplatExportError(targetError)) {
+        throw targetError;
+      }
+
+      try {
+        await waitForBasePreparedSplatRuntime(sourceOptions);
+      } catch (fallbackError) {
+        throw new Error(
+          `Three.js gaussian splat export fallback failed after target runtime error ` +
+          `(${this.describeExportReadinessError(targetError)}). ` +
+          `Fallback error: ${this.describeExportReadinessError(fallbackError)}`,
+        );
+      }
+
+      log.warn('Precise export falling back to rebuilt base Three.js splat runtime', {
+        cacheKey,
+        fileName,
+        requestedMaxSplats,
+        error: targetError,
+      });
+      this.exportReadyThreeSplatKeys.add(threeSplatKey);
+    }
+  }
+
   async ensureExportLayersReady(layers: Layer[]): Promise<void> {
     const visibleLayers = this.collectVisibleExportLayers(layers);
     if (visibleLayers.length === 0) {
@@ -520,21 +619,16 @@ export class RenderDispatcher {
         preferBaseRuntime,
         requestedMaxSplats,
       }) => {
-        const variant = preferBaseRuntime ? 'base' : 'target';
-        const threeSplatKey = `${cacheKey}|${variant}|${requestedMaxSplats}`;
-        if (this.exportReadyThreeSplatKeys.has(threeSplatKey)) {
-          return;
-        }
-        await (preferBaseRuntime ? waitForBasePreparedSplatRuntime : waitForTargetPreparedSplatRuntime)({
+        await this.ensureThreeSplatRuntimeReadyForExport({
           cacheKey,
           fileHash,
           file,
           url,
           fileName,
           gaussianSplatSequence,
+          preferBaseRuntime,
           requestedMaxSplats,
         });
-        this.exportReadyThreeSplatKeys.add(threeSplatKey);
       }),
     ];
 

--- a/src/engine/three/splatRuntimeCache.ts
+++ b/src/engine/three/splatRuntimeCache.ts
@@ -647,6 +647,10 @@ export function prewarmGaussianSplatRuntime(options: RuntimeSourceOptions): void
     });
   });
 
+  if (options.gaussianSplatSequence) {
+    return;
+  }
+
   const targetTaskKey = buildRuntimeKey(
     options.cacheKey,
     'target',

--- a/src/marketing/LandingPage.tsx
+++ b/src/marketing/LandingPage.tsx
@@ -1,30 +1,251 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { OPENAI_CHAT_DROPDOWN_MODELS } from '../shared/openAiModelCatalog';
+import { getCatalogEntry } from '../services/flashboard/FlashBoardModelCatalog';
+import { getCatalogEntryPriceEstimate } from '../services/flashboard/FlashBoardPricing';
 import { APP_VERSION } from '../version';
 import { buildEditorHref } from '../routing/entryExperience';
 import './landing.css';
 
-const capabilityColumns = [
+const galleryCards = [
   {
-    title: 'Media first',
-    items: ['Video and audio timelines', 'Image sequences and stills', 'Fast jump into the editor'],
+    eyebrow: 'Editor',
+    title: 'Timeline, preview, scopes, and media browser in one real workspace.',
+    copy: 'Use the actual product surface as the hero. It already communicates that MasterSelects is not a toy tool.',
+    imageSrc: '/preview.png',
+    imageAlt: 'MasterSelects editor showing preview, histogram, waveform, vectorscope, media browser, and timeline.',
   },
   {
-    title: 'Beyond media',
-    items: ['PDF, SVG, JSON, CSV', '3D formats like OBJ, FBX, glTF', 'Everything can become a visual signal'],
-  },
-  {
-    title: 'Operator flow',
-    items: ['Landing for explanation and onboarding', 'Editor kept direct and uncluttered', 'Separate URL for power users'],
+    eyebrow: 'Multi Preview + Export',
+    title: 'A second real shot can sell compositions, export, and panel density better than any mock.',
+    copy: 'The export panel, dual previews, and timeline explain capability immediately when they are shown as they really are.',
+    imageSrc: '/og-image.png',
+    imageAlt: 'MasterSelects editor showing dual preview panels, export settings, media list, and timeline.',
   },
 ];
 
-const signalTags = ['Video', 'Audio', 'PDF', 'SVG', 'OBJ', 'JSON', 'CSV', 'glTF'];
+const signalPills = ['Real Screenshots', 'Editor First', 'Timeline', 'Preview', 'WebCodecs Fast'];
+type PricingDetailTab = 'chat' | 'image' | 'video';
+
+const planCards = [
+  {
+    badge: 'Entry',
+    credits: 25,
+    featured: false,
+    fit: 'Try chat and small image runs.',
+    id: 'free',
+    priceAmount: '0',
+    priceSuffix: 'EUR',
+    title: 'Free',
+  },
+  {
+    badge: 'Creator',
+    credits: 4500,
+    featured: false,
+    fit: 'Built for image runs and short hosted video work.',
+    id: 'starter',
+    priceAmount: '4,90',
+    priceSuffix: 'EUR / mo',
+    title: 'Starter',
+  },
+  {
+    badge: 'Popular',
+    credits: 13500,
+    featured: true,
+    fit: 'Best fit for regular AI-assisted editing sessions.',
+    id: 'pro',
+    priceAmount: '14,90',
+    priceSuffix: 'EUR / mo',
+    title: 'Pro',
+  },
+  {
+    badge: 'Production',
+    credits: 27000,
+    featured: false,
+    fit: 'Largest pool for repeated generation and team use.',
+    id: 'studio',
+    priceAmount: '29,90',
+    priceSuffix: 'EUR / mo',
+    title: 'Studio',
+  },
+] as const;
+
+function formatCredits(value: number): string {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function formatCreditLabel(value: number): string {
+  return `${formatCredits(value)} ${value === 1 ? 'credit' : 'credits'}`;
+}
+
+function extractCreditCount(label: string | null | undefined): number | null {
+  if (!label) {
+    return null;
+  }
+
+  const match = label.match(/(\d[\d,]*)/);
+
+  if (!match) {
+    return null;
+  }
+
+  const value = Number.parseInt(match[1].replace(/,/g, ''), 10);
+  return Number.isFinite(value) ? value : null;
+}
+
+function formatCapacityCount(planCredits: number, unitCost: number | null): string {
+  if (unitCost == null || unitCost <= 0) {
+    return '--';
+  }
+
+  const count = Math.floor(planCredits / unitCost);
+  return count < 1 ? '<1' : formatCredits(count);
+}
+
+const cheapestChatModel = OPENAI_CHAT_DROPDOWN_MODELS.reduce((lowest, current) => (
+  current.creditCost < lowest.creditCost ? current : lowest
+));
+const balancedChatModel = OPENAI_CHAT_DROPDOWN_MODELS.find((model) => model.id === 'gpt-5.1') ?? cheapestChatModel;
+const premiumChatModel = OPENAI_CHAT_DROPDOWN_MODELS.find((model) => model.id === 'gpt-5.4') ?? balancedChatModel;
+
+const hostedImageEntry = getCatalogEntry('cloud', 'nano-banana-2');
+const hostedVideoEntry = getCatalogEntry('cloud', 'cloud-kling');
+
+const hostedImage1k = hostedImageEntry
+  ? getCatalogEntryPriceEstimate(hostedImageEntry, { imageSize: '1K', outputType: 'image' })
+  : null;
+const hostedImage4k = hostedImageEntry
+  ? getCatalogEntryPriceEstimate(hostedImageEntry, { imageSize: '4K', outputType: 'image' })
+  : null;
+const hostedVideoStd = hostedVideoEntry
+  ? getCatalogEntryPriceEstimate(hostedVideoEntry, {
+      duration: 5,
+      generateAudio: false,
+      mode: 'std',
+      outputType: 'video',
+    })
+  : null;
+const hostedVideoPro = hostedVideoEntry
+  ? getCatalogEntryPriceEstimate(hostedVideoEntry, {
+      duration: 10,
+      generateAudio: true,
+      mode: 'pro',
+      outputType: 'video',
+    })
+  : null;
+const hostedImage1kCredits = extractCreditCount(hostedImage1k?.fullLabel);
+const hostedVideoStdCredits = extractCreditCount(hostedVideoStd?.fullLabel);
+
+const planOutputExamples = [
+  {
+    basis: `${cheapestChatModel.label} request`,
+    category: 'Approx chats',
+    unitCost: cheapestChatModel.creditCost,
+  },
+  {
+    basis: 'Nano Banana 2 Cloud, 1K',
+    category: 'Approx images',
+    unitCost: hostedImage1kCredits,
+  },
+  {
+    basis: 'Kling Cloud, 5s standard',
+    category: 'Approx videos',
+    unitCost: hostedVideoStdCredits,
+  },
+] as const;
+
+const aiCreditExamples = [
+  {
+    category: 'Chat',
+    label: `${cheapestChatModel.label} request`,
+    value: formatCreditLabel(cheapestChatModel.creditCost),
+    note: 'Lowest current hosted chat cost in the dropdown.',
+    tab: 'chat',
+  },
+  {
+    category: 'Chat',
+    label: `${balancedChatModel.label} request`,
+    value: formatCreditLabel(balancedChatModel.creditCost),
+    note: 'Balanced default for stronger editing and assistant work.',
+    tab: 'chat',
+  },
+  {
+    category: 'Chat',
+    label: `${premiumChatModel.label} request`,
+    value: formatCreditLabel(premiumChatModel.creditCost),
+    note: 'Higher-end chat tier for heavier requests.',
+    tab: 'chat',
+  },
+  {
+    category: 'Image',
+    label: 'Nano Banana 2 Cloud, 1K',
+    value: hostedImage1k?.fullLabel ?? '--',
+    note: 'Hosted image generation at the smallest listed cloud resolution.',
+    tab: 'image',
+  },
+  {
+    category: 'Image',
+    label: 'Nano Banana 2 Cloud, 4K',
+    value: hostedImage4k?.fullLabel ?? '--',
+    note: 'High-resolution cloud image generation.',
+    tab: 'image',
+  },
+  {
+    category: 'Video',
+    label: 'Kling Cloud, 5s standard',
+    value: hostedVideoStd?.fullLabel ?? '--',
+    note: 'Shortest standard hosted video example on the landing page.',
+    tab: 'video',
+  },
+  {
+    category: 'Video',
+    label: 'Kling Cloud, 10s pro + sound',
+    value: hostedVideoPro?.fullLabel ?? '--',
+    note: 'Heaviest example shown here for hosted video generation.',
+    tab: 'video',
+  },
+] as const;
+
+const pricingReferenceCards: Array<{ id: PricingDetailTab; eyebrow: string; note: string; value: string }> = [
+  {
+    eyebrow: 'Cheapest chat',
+    id: 'chat',
+    note: cheapestChatModel.label,
+    value: formatCreditLabel(cheapestChatModel.creditCost),
+  },
+  {
+    eyebrow: 'Cheapest image',
+    id: 'image',
+    note: 'Nano Banana 2 Cloud',
+    value: hostedImage1k?.fullLabel ?? '--',
+  },
+  {
+    eyebrow: 'Cheapest video',
+    id: 'video',
+    note: 'Kling Cloud standard',
+    value: hostedVideoStd?.fullLabel ?? '--',
+  },
+];
+
+const pricingDetailTabs: Array<{ id: PricingDetailTab; label: string }> = [
+  { id: 'chat', label: 'Chat' },
+  { id: 'image', label: 'Images' },
+  { id: 'video', label: 'Video' },
+];
 
 export function LandingPage() {
   const editorHref = buildEditorHref(window.location);
   const portSuffix = window.location.port ? `:${window.location.port}` : '';
   const subdomainHref = `${window.location.protocol}//landing.localhost${portSuffix}/`;
   const fallbackLandingHref = `${window.location.protocol}//localhost${portSuffix}/landing`;
+  const [isPricingExpanded, setIsPricingExpanded] = useState(false);
+  const [activePricingTab, setActivePricingTab] = useState<PricingDetailTab>('chat');
+
+  const activeUsageExamples = aiCreditExamples.filter((entry) => entry.tab === activePricingTab);
+
+  const openPricingTab = (tab: PricingDetailTab) => {
+    setActivePricingTab(tab);
+    setIsPricingExpanded(true);
+  };
 
   useEffect(() => {
     const previousTitle = document.title;
@@ -36,126 +257,276 @@ export function LandingPage() {
 
   return (
     <div className="landing-page">
-      <div className="landing-noise" aria-hidden="true" />
+      <div className="landing-grid" aria-hidden="true" />
 
       <header className="landing-header">
         <div className="landing-brand">
-          <span className="landing-brand-mark">MS</span>
-          <div>
+          <div className="landing-brand-stack">
             <strong>MasterSelects</strong>
             <span>Landing Preview</span>
           </div>
+          <span className="landing-build">v{APP_VERSION}</span>
         </div>
-        <a className="landing-header-link" href={editorHref}>Open Editor</a>
+
+        <nav className="landing-nav" aria-label="Landing actions">
+          <a className="landing-nav-link" href="#gallery">Screens</a>
+          <a className="landing-nav-link" href="#pricing">AI Credits</a>
+          <a className="landing-nav-link" href="#routes">Dev URLs</a>
+          <a className="landing-button landing-button-secondary" href={editorHref}>Open Editor</a>
+        </nav>
       </header>
 
       <main className="landing-main">
         <section className="landing-hero">
           <div className="landing-copy">
-            <span className="landing-kicker">Front Website Concept</span>
-            <h1>Give MasterSelects a front door, without slowing down the editor.</h1>
+            <span className="landing-kicker">One-Line Positioning</span>
+            <h1>The media editor wherever you want it.</h1>
             <p className="landing-lead">
-              This is a separate landing page preview. The editor stays directly reachable, while the website can explain
-              the product, show the vision, and funnel new users into the app with one strong action.
+              MasterSelects puts timeline editing, AI video, preview, scopes, and export into one workspace that you
+              can open directly or enter through a clean front page.
             </p>
+
+            <div className="landing-pill-row" aria-label="Landing design principles">
+              {signalPills.map((pill, index) => (
+                <span key={pill} className={`landing-pill ${index === 0 ? 'landing-pill-active' : ''}`}>
+                  {pill}
+                </span>
+              ))}
+            </div>
 
             <div className="landing-actions">
               <a className="landing-button landing-button-primary" href={editorHref}>Start Editing</a>
-              <a className="landing-button landing-button-secondary" href="#routes">See Dev Routes</a>
+              <a className="landing-button landing-button-secondary" href="#gallery">View Screens</a>
             </div>
 
-            <div className="landing-signal-row" aria-label="Supported signal examples">
-              {signalTags.map((tag) => (
-                <span key={tag} className="landing-signal-chip">{tag}</span>
-              ))}
-            </div>
-          </div>
-
-          <div className="landing-stage" aria-hidden="true">
-            <div className="landing-stage-card landing-stage-card-inputs">
-              <span className="landing-stage-label">Incoming Files</span>
-              <div className="landing-stage-list">
-                <span>PDF becomes texture</span>
-                <span>OBJ becomes geometry</span>
-                <span>CSV becomes motion data</span>
+            <div className="landing-route-strip">
+              <div className="landing-route-chip">
+                <span>Editor</span>
+                <code>http://localhost{portSuffix}/</code>
+              </div>
+              <div className="landing-route-chip landing-route-chip-active">
+                <span>Landing</span>
+                <code>{subdomainHref}</code>
               </div>
             </div>
+          </div>
 
-            <div className="landing-stage-card landing-stage-card-core">
-              <span className="landing-stage-label">MasterSelects</span>
-              <strong>Timeline, composite, export</strong>
-              <p>Keep the editor sharp. Let the landing page do the explaining.</p>
-            </div>
+          <div className="landing-hero-media">
+            <figure className="landing-shot landing-shot-primary">
+              <img
+                src="/preview.png"
+                alt="MasterSelects workspace with preview, scopes, media browser, and timeline."
+              />
+              <figcaption>Real workspace shot: preview, scopes, media browser, timeline.</figcaption>
+            </figure>
 
-            <div className="landing-stage-card landing-stage-card-output">
-              <span className="landing-stage-label">Action</span>
-              <div className="landing-stage-cta">Start Editing</div>
-              <small>One click back into the app</small>
-            </div>
+            <figure className="landing-shot landing-shot-secondary">
+              <img
+                src="/og-image.png"
+                alt="MasterSelects workspace with dual preview, export panel, and timeline."
+              />
+              <figcaption>Real workspace shot: dual preview and export.</figcaption>
+            </figure>
           </div>
         </section>
 
-        <section className="landing-metrics">
-          <article>
-            <span className="landing-metric-label">Entry split</span>
-            <strong>Landing + editor</strong>
-            <p>New visitors get context. Returning users still jump straight into work.</p>
-          </article>
-          <article>
-            <span className="landing-metric-label">Dev mode</span>
-            <strong>Separate URL</strong>
-            <p>You can inspect the page live without changing the current root editor flow.</p>
-          </article>
-          <article>
-            <span className="landing-metric-label">Current build</span>
-            <strong>v{APP_VERSION}</strong>
-            <p>This preview is wired into the existing Vite app entry and hot reload cycle.</p>
-          </article>
+        <section className="landing-gallery" id="gallery">
+          {galleryCards.map((card) => (
+            <article key={card.title} className="landing-gallery-card">
+              <div className="landing-gallery-image-wrap">
+                <img className="landing-gallery-image" src={card.imageSrc} alt={card.imageAlt} />
+              </div>
+              <div className="landing-gallery-copy">
+                <span className="landing-card-kicker">{card.eyebrow}</span>
+                <h2>{card.title}</h2>
+                <p>{card.copy}</p>
+              </div>
+            </article>
+          ))}
         </section>
 
-        <section className="landing-section">
-          <div className="landing-section-heading">
-            <span className="landing-section-kicker">Why this split works</span>
-            <h2>The website sells the idea. The editor stays focused.</h2>
+        <section className="landing-pricing-section" id="pricing">
+          <div className="landing-pricing-header">
+            <div className="landing-pricing-copy">
+              <span className="landing-card-kicker">AI Credits</span>
+              <h3>Monthly plans first. Real AI credit math right underneath.</h3>
+              <p>
+                Compare the monthly credit pools directly, then open the per-request breakdown for chat, image, and
+                video generation with the current hosted rates.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="landing-button landing-button-secondary landing-pricing-toggle"
+              onClick={() => setIsPricingExpanded((current) => !current)}
+            >
+              {isPricingExpanded ? 'Hide Cost Breakdown' : 'Open Cost Breakdown'}
+            </button>
           </div>
 
-          <div className="landing-columns">
-            {capabilityColumns.map((column) => (
-              <article key={column.title} className="landing-column-card">
-                <h3>{column.title}</h3>
-                <ul>
-                  {column.items.map((item) => (
-                    <li key={item}>{item}</li>
-                  ))}
-                </ul>
-              </article>
+          <div className="landing-pricing-reference-bar">
+            {pricingReferenceCards.map((summary) => (
+              <button
+                key={summary.id}
+                type="button"
+                className={`landing-pricing-reference-card ${isPricingExpanded && activePricingTab === summary.id ? 'landing-pricing-reference-card-active' : ''}`}
+                onClick={() => openPricingTab(summary.id)}
+              >
+                <span className="landing-pricing-reference-eyebrow">{summary.eyebrow}</span>
+                <strong className="landing-pricing-reference-value">{summary.value}</strong>
+                <span className="landing-pricing-reference-note">{summary.note}</span>
+              </button>
             ))}
           </div>
+
+          <div className="landing-plan-table-wrap">
+            <table className="landing-plan-table">
+              <thead>
+                <tr>
+                  <th className="landing-plan-table-corner" scope="col">
+                    <span className="landing-card-kicker">Monthly Plans</span>
+                    <p>Output counts use the cheapest current hosted option in each category.</p>
+                  </th>
+                  {planCards.map((plan) => (
+                    <th
+                      key={plan.id}
+                      scope="col"
+                      className={`landing-plan-column ${plan.featured ? 'landing-plan-column-featured' : ''}`}
+                    >
+                      <span className="landing-plan-column-badge">{plan.badge}</span>
+                      <strong className="landing-plan-column-name">{plan.title}</strong>
+                      <div className="landing-plan-column-price-block">
+                        <span className="landing-plan-column-price">{plan.priceAmount}</span>
+                        <span className="landing-plan-column-price-note">{plan.priceSuffix}</span>
+                      </div>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row">
+                    <div className="landing-plan-row-copy">
+                      <span className="landing-plan-row-label">Credits / month</span>
+                      <span className="landing-plan-row-note">Monthly hosted credit pool</span>
+                    </div>
+                  </th>
+                  {planCards.map((plan) => (
+                    <td key={`${plan.id}-credits`} className={plan.featured ? 'landing-plan-table-cell-featured' : ''}>
+                      <strong className="landing-plan-table-value">{formatCredits(plan.credits)}</strong>
+                    </td>
+                  ))}
+                </tr>
+
+                {planOutputExamples.map((example) => (
+                  <tr key={example.category}>
+                    <th scope="row">
+                      <div className="landing-plan-row-copy">
+                        <span className="landing-plan-row-label">{example.category}</span>
+                        <span className="landing-plan-row-note">{example.basis}</span>
+                      </div>
+                    </th>
+                    {planCards.map((plan) => (
+                      <td
+                        key={`${plan.id}-${example.category}`}
+                        className={plan.featured ? 'landing-plan-table-cell-featured' : ''}
+                      >
+                        <strong className="landing-plan-table-value">
+                          {formatCapacityCount(plan.credits, example.unitCost)}
+                        </strong>
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+
+                <tr>
+                  <th scope="row">
+                    <div className="landing-plan-row-copy">
+                      <span className="landing-plan-row-label">Built for</span>
+                      <span className="landing-plan-row-note">How each plan reads on the landing page</span>
+                    </div>
+                  </th>
+                  {planCards.map((plan) => (
+                    <td key={`${plan.id}-fit`} className={plan.featured ? 'landing-plan-table-cell-featured' : ''}>
+                      <span className="landing-plan-fit-copy">{plan.fit}</span>
+                    </td>
+                  ))}
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          {isPricingExpanded && (
+            <div className="landing-pricing-detail">
+              <div className="landing-pricing-detail-topbar">
+                <div className="landing-pricing-tab-row" role="tablist" aria-label="Detailed pricing tabs">
+                  {pricingDetailTabs.map((tab) => (
+                    <button
+                      key={tab.id}
+                      type="button"
+                      role="tab"
+                      aria-selected={activePricingTab === tab.id}
+                      className={`landing-pricing-tab ${activePricingTab === tab.id ? 'landing-pricing-tab-active' : ''}`}
+                      onClick={() => setActivePricingTab(tab.id)}
+                    >
+                      {tab.label}
+                    </button>
+                  ))}
+                </div>
+                <p className="landing-pricing-detail-note">
+                  Detailed costs are pulled from the same in-app chat, image, and video credit rules.
+                </p>
+              </div>
+
+              <div className="landing-usage-list">
+                {activeUsageExamples.map((entry) => (
+                  <div key={`${entry.category}-${entry.label}`} className="landing-usage-row">
+                    <div className="landing-usage-copy">
+                      <span className="landing-usage-category">{entry.category}</span>
+                      <strong>{entry.label}</strong>
+                      <p>{entry.note}</p>
+                    </div>
+                    <span className="landing-usage-value">{entry.value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </section>
 
-        <section className="landing-section landing-routes" id="routes">
-          <div className="landing-section-heading">
-            <span className="landing-section-kicker">Dev routes</span>
-            <h2>Use these URLs right now.</h2>
-          </div>
+        <section className="landing-info-grid">
+          <article className="landing-info-card">
+            <span className="landing-card-kicker">Direction</span>
+            <h3>No fake interface blocks anymore.</h3>
+            <p>
+              The next step is not more illustrated UI. It is selecting the right real screenshots, cropping them well,
+              and building the page around those shots.
+            </p>
+            <ul>
+              <li>Hero uses the strongest editor screenshot.</li>
+              <li>Secondary shots show export, AI video, pricing, or settings.</li>
+              <li>Text should stay short and let the product surface do the work.</li>
+            </ul>
+          </article>
 
-          <div className="landing-route-grid">
-            <article className="landing-route-card">
-              <span className="landing-route-label">Editor stays here</span>
-              <code>http://localhost{portSuffix}/</code>
-              <p>Unchanged root entry for the working app.</p>
-            </article>
-            <article className="landing-route-card landing-route-card-accent">
-              <span className="landing-route-label">Landing preview</span>
-              <code>{subdomainHref}</code>
-              <p>The separate dev subdomain for the front website concept.</p>
-            </article>
-            <article className="landing-route-card">
-              <span className="landing-route-label">Fallback landing path</span>
-              <code>{fallbackLandingHref}</code>
-              <p>Use this if your browser does not resolve <code>landing.localhost</code>.</p>
-            </article>
-          </div>
+          <article className="landing-info-card landing-info-card-routes" id="routes">
+            <span className="landing-card-kicker">Dev routes</span>
+            <h3>Root stays the editor. Landing stays separate.</h3>
+            <div className="landing-route-list">
+              <div className="landing-route-card">
+                <span>Editor</span>
+                <code>http://localhost{portSuffix}/</code>
+              </div>
+              <div className="landing-route-card landing-route-card-active">
+                <span>Landing subdomain</span>
+                <code>{subdomainHref}</code>
+              </div>
+              <div className="landing-route-card">
+                <span>Landing fallback</span>
+                <code>{fallbackLandingHref}</code>
+              </div>
+            </div>
+          </article>
         </section>
       </main>
     </div>

--- a/src/marketing/landing.css
+++ b/src/marketing/landing.css
@@ -1,65 +1,39 @@
 .landing-page {
-  --landing-paper: #f4ecdc;
-  --landing-paper-strong: #efe1c1;
-  --landing-ink: #161616;
-  --landing-muted: rgba(22, 22, 22, 0.68);
-  --landing-border: rgba(22, 22, 22, 0.14);
-  --landing-accent: #ef562f;
-  --landing-accent-strong: #d63b14;
-  --landing-teal: #0e7c86;
-  --landing-shadow: 0 32px 80px rgba(84, 46, 19, 0.16);
+  --landing-border: rgba(255, 255, 255, 0.08);
+  --landing-border-strong: rgba(255, 255, 255, 0.14);
+  --landing-text: #f3f4f6;
+  --landing-text-muted: rgba(243, 244, 246, 0.58);
+  --landing-text-soft: rgba(243, 244, 246, 0.78);
+  --landing-blue: #2d8ceb;
+  --landing-blue-dim: rgba(45, 140, 235, 0.16);
+  --landing-shadow: 0 32px 80px rgba(0, 0, 0, 0.42);
   background:
-    radial-gradient(circle at top left, rgba(239, 86, 47, 0.22), transparent 28%),
-    radial-gradient(circle at 85% 18%, rgba(14, 124, 134, 0.18), transparent 24%),
-    linear-gradient(180deg, #f9f4ea 0%, var(--landing-paper) 48%, #f1e4c8 100%);
-  color: var(--landing-ink);
-  font-family: "Aptos", "Segoe UI Variable Display", "Trebuchet MS", sans-serif;
+    radial-gradient(circle at top left, rgba(45, 140, 235, 0.14), transparent 26%),
+    radial-gradient(circle at 90% 10%, rgba(243, 156, 18, 0.08), transparent 18%),
+    linear-gradient(180deg, #090a0d 0%, #0d0f13 100%);
+  color: var(--landing-text);
+  font-family: "Segoe UI Variable Display", "Segoe UI", "Bahnschrift", sans-serif;
   min-height: 100vh;
   overflow-x: hidden;
   position: relative;
 }
 
-.landing-page::before,
-.landing-page::after {
-  border-radius: 999px;
-  content: '';
-  filter: blur(6px);
-  position: absolute;
-  z-index: 0;
-}
-
-.landing-page::before {
-  background: rgba(239, 86, 47, 0.18);
-  height: 19rem;
-  left: -4rem;
-  top: 10rem;
-  transform: rotate(-16deg);
-  width: 19rem;
-}
-
-.landing-page::after {
-  background: rgba(14, 124, 134, 0.14);
-  height: 16rem;
-  right: -3rem;
-  top: 22rem;
-  width: 16rem;
-}
-
-.landing-noise {
+.landing-grid {
   background-image:
-    linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(22, 22, 22, 0.04) 1px, transparent 1px);
-  background-position: center;
-  background-size: 28px 28px;
+    linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+  background-size: 44px 44px;
   inset: 0;
-  opacity: 0.28;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.72), transparent 85%);
+  opacity: 0.5;
   pointer-events: none;
   position: absolute;
-  z-index: 0;
 }
 
 .landing-header,
 .landing-main {
+  margin: 0 auto;
+  max-width: 1460px;
   position: relative;
   z-index: 1;
 }
@@ -67,66 +41,72 @@
 .landing-header {
   align-items: center;
   display: flex;
+  gap: 1rem;
   justify-content: space-between;
-  padding: 1.5rem clamp(1.2rem, 3vw, 3rem) 0;
+  padding: 1.4rem clamp(1.2rem, 3vw, 2.5rem) 0;
 }
 
 .landing-brand {
   align-items: center;
   display: flex;
-  gap: 0.9rem;
+  gap: 1rem;
 }
 
-.landing-brand strong,
-.landing-brand span {
-  display: block;
+.landing-brand-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
 }
 
 .landing-brand strong {
-  font-size: 1rem;
-  letter-spacing: 0.03em;
+  font-size: clamp(1.7rem, 2vw, 2rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1;
 }
 
-.landing-brand span:last-child {
-  color: var(--landing-muted);
-  font-size: 0.82rem;
-  letter-spacing: 0.1em;
+.landing-brand span {
+  color: var(--landing-text-muted);
+  font-size: 0.76rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 
-.landing-brand-mark {
-  align-items: center;
-  background: linear-gradient(135deg, var(--landing-accent), #ff9d5a);
-  border-radius: 1.2rem;
-  box-shadow: 0 14px 32px rgba(214, 59, 20, 0.26);
-  color: white;
-  display: inline-flex;
-  font-family: "Bahnschrift", "Aptos", sans-serif;
-  font-size: 0.92rem;
-  font-weight: 700;
-  height: 2.8rem;
-  justify-content: center;
-  width: 2.8rem;
+.landing-build {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--landing-border);
+  border-radius: 999px;
+  color: var(--landing-text-soft);
+  font-family: "Cascadia Code", "Consolas", monospace;
+  font-size: 0.8rem;
+  padding: 0.45rem 0.75rem;
 }
 
-.landing-header-link,
+.landing-nav {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.landing-nav-link,
 .landing-button {
   border-radius: 999px;
   text-decoration: none;
   transition:
-    transform 180ms ease,
-    box-shadow 180ms ease,
-    border-color 180ms ease,
-    background-color 180ms ease;
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
-.landing-header-link {
-  border: 1px solid rgba(22, 22, 22, 0.14);
-  color: var(--landing-ink);
-  padding: 0.78rem 1.15rem;
+.landing-nav-link {
+  color: var(--landing-text-muted);
+  font-size: 0.92rem;
+  padding: 0.75rem 0.2rem;
 }
 
-.landing-header-link:hover,
+.landing-nav-link:hover,
 .landing-button:hover {
   transform: translateY(-1px);
 }
@@ -134,316 +114,666 @@
 .landing-main {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  padding: 2rem clamp(1.2rem, 3vw, 3rem) 3rem;
+  gap: 1.3rem;
+  padding: 1.8rem clamp(1.2rem, 3vw, 2.5rem) 3rem;
 }
 
 .landing-hero {
-  align-items: center;
+  align-items: stretch;
   display: grid;
-  gap: 2rem;
-  grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.92fr);
+  gap: 1.25rem;
+  grid-template-columns: minmax(0, 0.78fr) minmax(0, 1.22fr);
+}
+
+.landing-copy,
+.landing-gallery-card,
+.landing-info-card {
+  background: linear-gradient(180deg, rgba(22, 24, 29, 0.96), rgba(14, 16, 20, 0.98));
+  border: 1px solid var(--landing-border);
+  border-radius: 24px;
+  box-shadow: var(--landing-shadow);
 }
 
 .landing-copy {
   display: flex;
   flex-direction: column;
-  gap: 1.2rem;
+  gap: 1.15rem;
+  padding: clamp(1.5rem, 2.2vw, 2.5rem);
 }
 
 .landing-kicker,
-.landing-section-kicker,
-.landing-metric-label,
-.landing-route-label,
-.landing-stage-label {
-  color: var(--landing-muted);
-  font-size: 0.8rem;
-  font-weight: 700;
+.landing-card-kicker {
+  color: var(--landing-text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
   letter-spacing: 0.16em;
   text-transform: uppercase;
 }
 
 .landing-copy h1,
-.landing-section-heading h2 {
-  font-family: "Aptos Display", "Bahnschrift", "Trebuchet MS", sans-serif;
-  font-weight: 700;
+.landing-gallery-copy h2,
+.landing-info-card h3 {
+  font-family: "Bahnschrift", "Segoe UI Variable Display", sans-serif;
   letter-spacing: -0.04em;
   line-height: 0.98;
+  margin: 0;
 }
 
 .landing-copy h1 {
-  font-size: clamp(3rem, 8vw, 5.9rem);
-  max-width: 12ch;
+  font-size: clamp(3rem, 5vw, 5.2rem);
+  max-width: 10.5ch;
+}
+
+.landing-lead,
+.landing-gallery-copy p,
+.landing-info-card p,
+.landing-info-card li {
+  color: var(--landing-text-soft);
+  line-height: 1.72;
 }
 
 .landing-lead {
-  color: var(--landing-muted);
-  font-size: clamp(1rem, 1.8vw, 1.2rem);
-  line-height: 1.75;
-  max-width: 56ch;
+  font-size: clamp(1rem, 1.3vw, 1.12rem);
+  margin: 0;
+  max-width: 57ch;
 }
 
-.landing-actions {
+.landing-pill-row,
+.landing-actions,
+.landing-route-strip {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.9rem;
+  gap: 0.75rem;
+}
+
+.landing-pill {
+  background: rgba(0, 0, 0, 0.28);
+  border: 1px solid var(--landing-border);
+  border-radius: 999px;
+  color: var(--landing-text-soft);
+  display: inline-flex;
+  font-size: 0.88rem;
+  line-height: 1;
+  padding: 0.72rem 0.92rem;
+}
+
+.landing-pill-active {
+  background: var(--landing-blue-dim);
+  border-color: rgba(45, 140, 235, 0.55);
+  color: var(--landing-text);
+  box-shadow: inset 0 0 0 1px rgba(45, 140, 235, 0.14);
 }
 
 .landing-button {
   display: inline-flex;
+  font-size: 0.95rem;
   font-weight: 700;
   justify-content: center;
-  min-width: 11.5rem;
-  padding: 1rem 1.45rem;
+  min-width: 11.25rem;
+  padding: 0.95rem 1.3rem;
 }
 
 .landing-button-primary {
-  background: linear-gradient(135deg, var(--landing-accent) 0%, #ff8d57 100%);
-  box-shadow: 0 20px 40px rgba(214, 59, 20, 0.24);
+  background: linear-gradient(180deg, #2d8ceb, #1a5fb0);
+  border: 1px solid rgba(77, 163, 240, 0.6);
+  box-shadow: 0 12px 32px rgba(45, 140, 235, 0.22);
   color: white;
-}
-
-.landing-button-primary:hover {
-  box-shadow: 0 24px 44px rgba(214, 59, 20, 0.3);
 }
 
 .landing-button-secondary {
-  background: rgba(255, 255, 255, 0.54);
+  background: rgba(255, 255, 255, 0.04);
   border: 1px solid var(--landing-border);
-  color: var(--landing-ink);
+  color: var(--landing-text);
 }
 
-.landing-signal-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
+.landing-route-strip {
+  margin-top: auto;
 }
 
-.landing-signal-chip {
-  background: rgba(255, 255, 255, 0.62);
-  border: 1px solid rgba(22, 22, 22, 0.1);
-  border-radius: 999px;
-  font-size: 0.92rem;
-  padding: 0.55rem 0.85rem;
-}
-
-.landing-stage {
+.landing-route-chip {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--landing-border);
+  border-radius: 18px;
   display: grid;
-  gap: 1rem;
-  perspective: 1200px;
+  gap: 0.35rem;
+  min-width: 220px;
+  padding: 0.9rem 1rem;
 }
 
-.landing-stage-card {
-  backdrop-filter: blur(16px);
-  background: rgba(255, 251, 242, 0.7);
-  border: 1px solid rgba(22, 22, 22, 0.1);
-  border-radius: 1.6rem;
-  box-shadow: var(--landing-shadow);
-  padding: 1.35rem;
+.landing-route-chip-active {
+  border-color: rgba(45, 140, 235, 0.42);
+  box-shadow: inset 0 0 0 1px rgba(45, 140, 235, 0.1);
+}
+
+.landing-route-chip span,
+.landing-route-card span {
+  color: var(--landing-text-muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.landing-route-chip code,
+.landing-route-card code {
+  color: var(--landing-text);
+  font-family: "Cascadia Code", "Consolas", monospace;
+  font-size: 0.9rem;
+  overflow-wrap: anywhere;
+}
+
+.landing-hero-media {
+  min-height: 0;
   position: relative;
 }
 
-.landing-stage-card-inputs {
-  animation: landingFloat 6s ease-in-out infinite;
-  justify-self: end;
-  max-width: 20rem;
-  transform: rotate(5deg);
+.landing-shot {
+  background: linear-gradient(180deg, rgba(20, 22, 27, 0.98), rgba(10, 12, 16, 0.98));
+  border: 1px solid var(--landing-border-strong);
+  border-radius: 24px;
+  box-shadow: var(--landing-shadow);
+  margin: 0;
+  overflow: hidden;
+  position: absolute;
 }
 
-.landing-stage-card-core {
-  animation: landingFloat 7s ease-in-out infinite reverse;
-  min-height: 17rem;
-  transform: rotate(-3deg);
-}
-
-.landing-stage-card-output {
-  animation: landingFloat 5.5s ease-in-out infinite;
-  justify-self: start;
-  max-width: 16rem;
-  transform: rotate(4deg);
-}
-
-.landing-stage-list {
-  display: grid;
-  gap: 0.7rem;
-  margin-top: 0.9rem;
-}
-
-.landing-stage-list span,
-.landing-stage-card-core p,
-.landing-stage-card-output small {
-  color: var(--landing-muted);
-  line-height: 1.6;
-}
-
-.landing-stage-card-core strong {
+.landing-shot img,
+.landing-gallery-image {
   display: block;
-  font-family: "Aptos Display", "Bahnschrift", sans-serif;
-  font-size: clamp(1.8rem, 4vw, 2.6rem);
-  line-height: 1.02;
-  margin: 0.6rem 0 0.8rem;
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
 }
 
-.landing-stage-cta {
-  align-items: center;
-  background: linear-gradient(135deg, var(--landing-teal), #3db5a0);
-  border-radius: 1.05rem;
-  box-shadow: 0 18px 34px rgba(14, 124, 134, 0.26);
-  color: white;
-  display: inline-flex;
-  font-weight: 700;
-  justify-content: center;
-  margin: 1rem 0 0.5rem;
-  min-height: 3.8rem;
-  padding: 0 1rem;
+.landing-shot figcaption {
+  background: linear-gradient(180deg, transparent, rgba(5, 6, 10, 0.88));
+  bottom: 0;
+  color: rgba(243, 244, 246, 0.88);
+  font-size: 0.88rem;
+  left: 0;
+  padding: 2.2rem 1rem 1rem;
+  position: absolute;
+  right: 0;
 }
 
-.landing-metrics,
-.landing-columns,
-.landing-route-grid {
+.landing-shot-primary {
+  inset: 0 8% 6% 0;
+  transform: rotate(-1.2deg);
+}
+
+.landing-shot-secondary {
+  bottom: 0;
+  max-width: 38%;
+  right: 0;
+  top: 54%;
+  transform: rotate(3.4deg);
+}
+
+.landing-gallery,
+.landing-info-grid,
+.landing-pricing-section {
   display: grid;
   gap: 1rem;
 }
 
-.landing-metrics,
-.landing-route-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+.landing-gallery {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.landing-metrics article,
-.landing-column-card,
-.landing-route-card {
-  background: rgba(255, 252, 246, 0.72);
-  border: 1px solid rgba(22, 22, 22, 0.1);
-  border-radius: 1.4rem;
-  box-shadow: 0 18px 40px rgba(84, 46, 19, 0.08);
+.landing-gallery-card,
+.landing-info-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.landing-gallery-image-wrap {
+  aspect-ratio: 16 / 9;
+  border-radius: 18px;
+  overflow: hidden;
+}
+
+.landing-gallery-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.2rem 0.15rem 0.35rem;
+}
+
+.landing-gallery-copy h2 {
+  font-size: clamp(1.5rem, 2.2vw, 2.15rem);
+}
+
+.landing-gallery-copy p,
+.landing-info-card p {
+  margin: 0;
+}
+
+.landing-info-grid {
+  grid-template-columns: 1fr 1fr;
+}
+
+.landing-info-card {
   padding: 1.25rem;
 }
 
-.landing-metrics strong,
-.landing-column-card h3,
-.landing-section-heading h2 {
-  font-size: clamp(1.55rem, 3vw, 2.5rem);
+.landing-info-card h3 {
+  font-size: clamp(1.4rem, 2vw, 2rem);
 }
 
-.landing-metrics strong,
-.landing-column-card h3 {
-  display: block;
-  line-height: 1.1;
-  margin: 0.55rem 0 0.65rem;
-}
-
-.landing-metrics p,
-.landing-column-card li,
-.landing-route-card p {
-  color: var(--landing-muted);
-  line-height: 1.7;
-}
-
-.landing-section {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.landing-section-heading {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-  max-width: 48rem;
-}
-
-.landing-columns {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.landing-column-card ul {
+.landing-info-card ul {
   display: grid;
   gap: 0.65rem;
   list-style: none;
-  margin: 0.95rem 0 0;
+  margin: 0;
   padding: 0;
 }
 
-.landing-column-card li::before {
-  color: var(--landing-accent);
-  content: '•';
-  margin-right: 0.55rem;
+.landing-info-card li {
+  margin: 0;
+  padding-left: 1rem;
+  position: relative;
 }
 
-.landing-routes {
-  margin-bottom: 1rem;
+.landing-info-card li::before {
+  color: var(--landing-blue);
+  content: '*';
+  left: 0;
+  position: absolute;
 }
 
-.landing-route-card-accent {
-  background: linear-gradient(145deg, rgba(239, 86, 47, 0.1), rgba(255, 255, 255, 0.82));
+.landing-pricing-section {
+  background: linear-gradient(180deg, rgba(22, 24, 29, 0.96), rgba(14, 16, 20, 0.98));
+  border: 1px solid var(--landing-border);
+  border-radius: 24px;
+  box-shadow: var(--landing-shadow);
+  padding: 1.25rem;
 }
 
-.landing-route-card code {
-  background: rgba(22, 22, 22, 0.06);
-  border-radius: 0.9rem;
+.landing-pricing-header {
+  align-items: end;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.landing-pricing-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  max-width: 54rem;
+}
+
+.landing-pricing-copy h3 {
+  font-family: "Bahnschrift", "Segoe UI Variable Display", sans-serif;
+  font-size: clamp(1.6rem, 2.3vw, 2.25rem);
+  letter-spacing: -0.04em;
+  line-height: 1;
+  margin: 0;
+}
+
+.landing-pricing-copy p,
+.landing-pricing-detail-note,
+.landing-usage-copy p {
+  color: var(--landing-text-soft);
+  line-height: 1.7;
+  margin: 0;
+}
+
+.landing-pricing-toggle {
+  flex: 0 0 auto;
+}
+
+.landing-pricing-reference-bar,
+.landing-usage-list,
+.landing-pricing-tab-row {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.landing-pricing-reference-bar {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.landing-pricing-reference-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--landing-border);
+  border-radius: 18px;
+  color: var(--landing-text);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  min-height: 132px;
+  padding: 0.95rem 1rem;
+  text-align: left;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.landing-pricing-reference-card:hover {
+  transform: translateY(-1px);
+}
+
+.landing-pricing-reference-card-active {
+  background: rgba(45, 140, 235, 0.1);
+  border-color: rgba(45, 140, 235, 0.34);
+  box-shadow: inset 0 0 0 1px rgba(45, 140, 235, 0.1);
+}
+
+.landing-pricing-reference-eyebrow,
+.landing-pricing-reference-note {
+  color: var(--landing-text-muted);
+}
+
+.landing-pricing-reference-eyebrow {
+  font-size: 0.76rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.landing-pricing-reference-value {
+  font-family: "Bahnschrift", "Segoe UI Variable Display", sans-serif;
+  font-size: clamp(1.35rem, 1.9vw, 1.9rem);
+  letter-spacing: -0.04em;
+  line-height: 1;
+}
+
+.landing-pricing-reference-note {
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin-top: auto;
+}
+
+.landing-plan-table-wrap {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--landing-border);
+  border-radius: 22px;
+  overflow-x: auto;
+}
+
+.landing-plan-table {
+  border-collapse: separate;
+  border-spacing: 0;
+  min-width: 980px;
+  width: 100%;
+}
+
+.landing-plan-table th,
+.landing-plan-table td {
+  border-bottom: 1px solid var(--landing-border);
+  padding: 1rem 1.05rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.landing-plan-table tbody tr:last-child th,
+.landing-plan-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.landing-plan-table-corner {
+  min-width: 280px;
+  width: 28%;
+}
+
+.landing-plan-table-corner p {
+  color: var(--landing-text-soft);
+  line-height: 1.6;
+  margin: 0.7rem 0 0;
+}
+
+.landing-plan-column {
+  background: rgba(255, 255, 255, 0.02);
+  min-width: 168px;
+}
+
+.landing-plan-column-featured,
+.landing-plan-table-cell-featured {
+  background: rgba(45, 140, 235, 0.08);
+}
+
+.landing-plan-column-badge {
+  color: var(--landing-text-muted);
+  display: inline-flex;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  margin-bottom: 0.8rem;
+  text-transform: uppercase;
+}
+
+.landing-plan-column-name {
   display: block;
-  font-family: "Cascadia Code", "Consolas", monospace;
+  font-family: "Bahnschrift", "Segoe UI Variable Display", sans-serif;
+  font-size: 1.45rem;
+  letter-spacing: -0.04em;
+  line-height: 1;
+}
+
+.landing-plan-column-price-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin-top: 0.75rem;
+}
+
+.landing-plan-column-price {
+  font-family: "Bahnschrift", "Segoe UI Variable Display", sans-serif;
+  font-size: 2rem;
+  letter-spacing: -0.05em;
+  line-height: 1;
+}
+
+.landing-plan-column-price-note {
+  color: var(--landing-text-muted);
+  font-size: 0.86rem;
+}
+
+.landing-plan-row-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+}
+
+.landing-plan-row-label {
+  color: var(--landing-text);
   font-size: 0.95rem;
-  margin: 0.8rem 0 0.9rem;
-  overflow-wrap: anywhere;
-  padding: 0.8rem 0.95rem;
+  font-weight: 600;
 }
 
-@keyframes landingFloat {
-  0%,
-  100% {
-    transform: translateY(0) rotate(var(--landing-tilt, 0deg));
-  }
-  50% {
-    transform: translateY(-8px) rotate(var(--landing-tilt, 0deg));
-  }
+.landing-plan-row-note,
+.landing-plan-fit-copy {
+  color: var(--landing-text-muted);
+  font-size: 0.84rem;
+  line-height: 1.45;
 }
 
-.landing-stage-card-inputs {
-  --landing-tilt: 5deg;
+.landing-plan-table-value {
+  color: var(--landing-text);
+  display: block;
+  font-family: "Bahnschrift", "Segoe UI Variable Display", sans-serif;
+  font-size: 1.4rem;
+  letter-spacing: -0.04em;
+  line-height: 1;
 }
 
-.landing-stage-card-core {
-  --landing-tilt: -3deg;
+.landing-plan-fit-copy {
+  display: block;
+  max-width: 18ch;
 }
 
-.landing-stage-card-output {
-  --landing-tilt: 4deg;
+.landing-pricing-detail {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--landing-border);
+  border-radius: 22px;
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
 }
 
-@media (max-width: 1080px) {
+.landing-pricing-detail-topbar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.landing-pricing-tab-row {
+  grid-template-columns: repeat(4, minmax(0, max-content));
+}
+
+.landing-pricing-tab {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--landing-border);
+  border-radius: 999px;
+  color: var(--landing-text-soft);
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 0.72rem 1rem;
+}
+
+.landing-pricing-tab-active {
+  background: var(--landing-blue-dim);
+  border-color: rgba(45, 140, 235, 0.45);
+  color: var(--landing-text);
+}
+
+.landing-usage-row {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--landing-border);
+  border-radius: 18px;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 1rem;
+}
+
+.landing-usage-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.landing-usage-copy strong {
+  color: var(--landing-text);
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.landing-usage-value {
+  background: rgba(45, 140, 235, 0.12);
+  border: 1px solid rgba(45, 140, 235, 0.24);
+  border-radius: 999px;
+  color: var(--landing-text);
+  flex: 0 0 auto;
+  font-size: 0.92rem;
+  font-weight: 700;
+  padding: 0.65rem 0.9rem;
+}
+
+.landing-route-list {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.landing-route-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--landing-border);
+  border-radius: 18px;
+  display: grid;
+  gap: 0.45rem;
+  padding: 1rem;
+}
+
+.landing-route-card-active {
+  border-color: rgba(45, 140, 235, 0.34);
+  box-shadow: inset 0 0 0 1px rgba(45, 140, 235, 0.1);
+}
+
+@media (max-width: 1220px) {
   .landing-hero,
-  .landing-metrics,
-  .landing-columns,
-  .landing-route-grid {
+  .landing-gallery,
+  .landing-info-grid,
+  .landing-pricing-reference-bar {
     grid-template-columns: 1fr;
   }
 
-  .landing-stage-card-inputs,
-  .landing-stage-card-output {
-    justify-self: stretch;
-    max-width: none;
+  .landing-hero-media {
+    aspect-ratio: 16 / 11;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 840px) {
   .landing-header {
     align-items: flex-start;
     flex-direction: column;
-    gap: 1rem;
   }
 
-  .landing-copy h1 {
-    max-width: 100%;
+  .landing-nav {
+    width: 100%;
   }
 
-  .landing-actions {
+  .landing-button {
+    width: 100%;
+  }
+
+  .landing-pricing-header {
+    align-items: stretch;
     flex-direction: column;
   }
 
-  .landing-button,
-  .landing-header-link {
-    width: 100%;
+  .landing-pricing-tab-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .landing-usage-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .landing-shot-primary {
+    inset: 0 0 18% 0;
+    transform: none;
+  }
+
+  .landing-shot-secondary {
+    bottom: 0;
+    left: 12%;
+    max-width: none;
+    right: 12%;
+    top: 62%;
+    transform: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .landing-copy h1 {
+    max-width: none;
+  }
+
+  .landing-copy,
+  .landing-gallery-card,
+  .landing-info-card,
+  .landing-shot {
+    border-radius: 20px;
+  }
+
+  .landing-hero-media {
+    aspect-ratio: 1 / 1.02;
+  }
+
+  .landing-shot-primary {
+    inset: 0 0 24% 0;
+  }
+
+  .landing-shot-secondary {
+    left: 6%;
+    right: 6%;
+    top: 66%;
   }
 }

--- a/src/services/cloudApi.ts
+++ b/src/services/cloudApi.ts
@@ -146,12 +146,15 @@ export interface CloudAiChatMessage {
   tool_call_id?: string;
 }
 
+export type CloudAiReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
 export interface CloudAiChatRequest {
   max_completion_tokens?: number;
   idempotencyKey?: string;
   max_tokens?: number;
   messages: CloudAiChatMessage[];
   model?: string;
+  reasoning_effort?: CloudAiReasoningEffort;
   response_format?: Record<string, unknown>;
   stream?: boolean;
   tool_choice?: unknown;

--- a/src/services/flashboard/FlashBoardModelCatalog.ts
+++ b/src/services/flashboard/FlashBoardModelCatalog.ts
@@ -2,6 +2,22 @@ import { getVideoProviders } from '../piApiService';
 import { getKieAiProviders } from '../kieAiService';
 import type { CatalogEntry } from './types';
 
+const KIEAI_SEEDANCE_2_ENTRY: CatalogEntry = {
+  service: 'kieai',
+  providerId: 'seedance-2',
+  name: 'Seedance 2.0 (Kie.ai)',
+  description: 'ByteDance Seedance 2.0 via Kie.ai for text-to-video and image-to-video',
+  versions: ['2.0'],
+  modes: [],
+  durations: [4, 8, 12],
+  aspectRatios: ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+  supportsTextToVideo: true,
+  supportsImageToVideo: true,
+  supportsGenerateAudio: true,
+  supportsMultiShot: false,
+  outputType: 'video',
+};
+
 export function getCatalogEntries(): CatalogEntry[] {
   const entries: CatalogEntry[] = [];
 
@@ -40,6 +56,8 @@ export function getCatalogEntries(): CatalogEntry[] {
       ...(isImageOnly ? { supportsTextToImage: true, outputType: 'image' as const } : { outputType: 'video' as const }),
     });
   }
+
+  entries.push(KIEAI_SEEDANCE_2_ENTRY);
 
   entries.push({
     service: 'kieai',

--- a/src/services/flashboard/FlashBoardPricing.ts
+++ b/src/services/flashboard/FlashBoardPricing.ts
@@ -25,6 +25,7 @@ export interface FlashBoardPriceEstimate {
 export interface FlashBoardPricingInput {
   duration?: number;
   generateAudio?: boolean;
+  hasStartFrame?: boolean;
   imageSize?: string;
   mode?: string;
   multiShots?: boolean;
@@ -85,7 +86,15 @@ function buildHostedImageEstimate(input: FlashBoardPricingInput): FlashBoardPric
 function buildKieVideoEstimate(input: FlashBoardPricingInput): FlashBoardPriceEstimate {
   const duration = normalizeVideoDuration(input.duration);
   const mode = normalizeMode(input.mode);
-  const kieCredits = calculateKieAiCost(input.providerId, mode, duration, resolveEffectiveAudio(input));
+  const kieCredits = calculateKieAiCost(
+    input.providerId,
+    mode,
+    duration,
+    resolveEffectiveAudio(input),
+    {
+      hasStartFrame: input.hasStartFrame,
+    },
+  );
 
   return {
     compactLabel: `${kieCredits} cr`,
@@ -147,6 +156,7 @@ export function getCatalogEntryPriceEstimate(
   return getFlashBoardPriceEstimate({
     duration: entry.durations.includes(overrides.duration ?? -1) ? overrides.duration : entry.durations[0],
     generateAudio: overrides.generateAudio ?? false,
+    hasStartFrame: overrides.hasStartFrame ?? false,
     imageSize: entry.imageSizes?.includes(overrides.imageSize ?? '') ? overrides.imageSize : entry.imageSizes?.[0],
     mode: entry.modes.includes(overrides.mode ?? '') ? overrides.mode : entry.modes[0],
     multiShots: overrides.multiShots ?? false,

--- a/src/services/kieAiService.ts
+++ b/src/services/kieAiService.ts
@@ -1,5 +1,5 @@
 // Kie.ai Service - Unified API for AI media generation via kie.ai
-// Currently supports: Kling 3.0 video and Nano Banana 2 images
+// Currently supports: Kling 3.0 + Seedance 2.0 video and Nano Banana 2 images
 // Docs: https://kie.ai
 
 import { Logger } from './logger';
@@ -16,6 +16,10 @@ const log = Logger.create('KieAI');
 
 const BASE_URL = 'https://api.kie.ai';
 const UPLOAD_URL = 'https://kieai.redpandaai.co/api/file-stream-upload';
+
+const KIEAI_SEEDANCE_2_PROVIDER_ID = 'seedance-2';
+const KIEAI_SEEDANCE_2_MODEL_ID = 'bytedance/seedance-2';
+const KIEAI_SEEDANCE_2_DEFAULT_RESOLUTION = '720p';
 
 // Kie.ai providers (Kling 3.0 only for now)
 const KIEAI_PROVIDERS: VideoProvider[] = [
@@ -44,6 +48,12 @@ const KIEAI_CREDITS_PER_SECOND: Record<string, Record<string, { normal: number; 
     'std': { normal: 14, audio: 20 },
     'pro': { normal: 18, audio: 27 },
   },
+  [KIEAI_SEEDANCE_2_PROVIDER_ID]: {
+    // Based on the current Kie.ai Seedance 2.0 pricing:
+    // text-to-video 720p: ~$0.205/s, image-to-video 720p: ~$0.125/s
+    // Kie credits currently map 1 credit = $0.005.
+    'std': { normal: 41, audio: 41 },
+  },
 };
 
 export function getKieAiProviders(): VideoProvider[] {
@@ -55,7 +65,20 @@ export function getKieAiProvider(providerId: string): VideoProvider | undefined 
 }
 
 // Calculate cost in credits for Kie.ai
-export function calculateKieAiCost(provider: string, mode: string, duration: number, sound = false): number {
+export function calculateKieAiCost(
+  provider: string,
+  mode: string,
+  duration: number,
+  sound = false,
+  options?: {
+    hasStartFrame?: boolean;
+  },
+): number {
+  if (provider === KIEAI_SEEDANCE_2_PROVIDER_ID) {
+    const ratePerSecond = options?.hasStartFrame ? 25 : 41;
+    return duration * ratePerSecond;
+  }
+
   const providerRates = KIEAI_CREDITS_PER_SECOND[provider];
   if (!providerRates) return duration * 14; // fallback
   const modeRates = providerRates[mode];
@@ -117,6 +140,10 @@ interface KieAiStatusResponse {
     costTime?: string;
     failMsg?: string;
   };
+}
+
+function isSeedance2Provider(provider: string | undefined): boolean {
+  return provider === KIEAI_SEEDANCE_2_PROVIDER_ID;
 }
 
 function normalizeKieTaskStatus(state: string | undefined): TaskStatus {
@@ -212,6 +239,11 @@ class KieAiService {
     return result.data.downloadUrl;
   }
 
+  private async prepareUploadedImageUrl(sourceUrl: string): Promise<string> {
+    const compressed = await this.compressImage(sourceUrl);
+    return this.uploadImage(compressed);
+  }
+
   // Compress image before upload
   private async compressImage(dataUrl: string, maxWidth = 1280, quality = 0.8): Promise<string> {
     return new Promise((resolve, reject) => {
@@ -284,6 +316,31 @@ class KieAiService {
   }
 
   async createTextToVideo(params: TextToVideoParams): Promise<string> {
+    if (isSeedance2Provider(params.provider)) {
+      const input: Record<string, unknown> = {
+        prompt: params.prompt,
+        duration: params.duration,
+        aspect_ratio: params.aspectRatio || '16:9',
+        resolution: KIEAI_SEEDANCE_2_DEFAULT_RESOLUTION,
+        generate_audio: Boolean(params.sound),
+      };
+
+      const body = {
+        model: KIEAI_SEEDANCE_2_MODEL_ID,
+        input,
+      };
+
+      log.debug('Creating Seedance 2.0 text-to-video task:', JSON.stringify(body, null, 2));
+
+      const result = await this.request<KieAiTaskResponse>('/api/v1/jobs/createTask', 'POST', body);
+
+      if (result.code !== 200 || !result.data?.taskId) {
+        throw new Error(`Kie.ai error: ${result.msg || 'Failed to create task'}`);
+      }
+
+      return result.data.taskId;
+    }
+
     const multiPrompt = params.multiShots ? normalizeMultiShotPrompt(params.multiPrompt) : undefined;
     const effectiveSound = params.multiShots ? true : (params.sound ?? false);
 
@@ -352,6 +409,44 @@ class KieAiService {
   }
 
   async createImageToVideo(params: ImageToVideoParams): Promise<string> {
+    if (isSeedance2Provider(params.provider)) {
+      const input: Record<string, unknown> = {
+        prompt: params.prompt || '',
+        duration: params.duration,
+        aspect_ratio: params.aspectRatio || '16:9',
+        resolution: KIEAI_SEEDANCE_2_DEFAULT_RESOLUTION,
+        generate_audio: Boolean(params.sound),
+      };
+
+      if (params.startImageUrl) {
+        log.debug('Compressing and uploading Seedance 2 start image...');
+        input.first_frame_url = await this.prepareUploadedImageUrl(params.startImageUrl);
+      }
+
+      if (params.endImageUrl) {
+        log.debug('Compressing and uploading Seedance 2 end image...');
+        input.last_frame_url = await this.prepareUploadedImageUrl(params.endImageUrl);
+      }
+
+      const body = {
+        model: KIEAI_SEEDANCE_2_MODEL_ID,
+        input,
+      };
+
+      log.debug('Creating Seedance 2.0 image-to-video task:', {
+        hasStartImage: Boolean(input.first_frame_url),
+        hasEndImage: Boolean(input.last_frame_url),
+      });
+
+      const result = await this.request<KieAiTaskResponse>('/api/v1/jobs/createTask', 'POST', body);
+
+      if (result.code !== 200 || !result.data?.taskId) {
+        throw new Error(`Kie.ai error: ${result.msg || 'Failed to create task'}`);
+      }
+
+      return result.data.taskId;
+    }
+
     const imageUrls: string[] = [];
     const multiPrompt = params.multiShots ? normalizeMultiShotPrompt(params.multiPrompt) : undefined;
     const effectiveSound = params.multiShots ? true : (params.sound ?? false);
@@ -359,16 +454,14 @@ class KieAiService {
     // Upload start image
     if (params.startImageUrl) {
       log.debug('Compressing and uploading start image...');
-      const compressed = await this.compressImage(params.startImageUrl);
-      const url = await this.uploadImage(compressed);
+      const url = await this.prepareUploadedImageUrl(params.startImageUrl);
       imageUrls.push(url);
     }
 
     // Upload end image (passed as second element in image_urls)
     if (params.endImageUrl && !params.multiShots) {
       log.debug('Compressing and uploading end image...');
-      const compressed = await this.compressImage(params.endImageUrl);
-      const url = await this.uploadImage(compressed);
+      const url = await this.prepareUploadedImageUrl(params.endImageUrl);
       imageUrls.push(url);
     }
 

--- a/src/services/layerBuilder/LayerBuilderService.ts
+++ b/src/services/layerBuilder/LayerBuilderService.ts
@@ -1083,7 +1083,57 @@ export class LayerBuilderService {
       if (clip.startTime > rangeEnd || clip.startTime + clip.duration < rangeStart) continue;
 
       const mediaFile = getMediaFileForClip(ctx, clip);
-      if (clip.source?.gaussianSplatSequence || mediaFile?.gaussianSplatSequence) continue;
+      const gaussianSplatSequence = this.getClipGaussianSplatSequence(clip);
+      if (gaussianSplatSequence) {
+        const fps = Number.isFinite(gaussianSplatSequence.fps) && gaussianSplatSequence.fps > 0
+          ? gaussianSplatSequence.fps
+          : LAYER_BUILDER_CONSTANTS.FRAME_RATE;
+        const frameDuration = 1 / Math.max(fps, 1);
+        const requestedMaxSplats = clip.source?.gaussianSplatSettings?.render.maxSplats ?? 0;
+        const currentLocalTime = Math.max(0, Math.min(clip.duration, ctx.playheadPosition - clip.startTime));
+        const localRangeEnd = Math.max(
+          currentLocalTime,
+          Math.min(clip.duration, Math.max(0, rangeEnd - clip.startTime)),
+        );
+        const lookaheadFrames = ctx.isPlaying
+          ? Math.max(4, Math.min(12, Math.ceil(fps * 0.4)))
+          : 4;
+        const seenRuntimeKeys = new Set<string>();
+
+        for (let offset = 0; offset < lookaheadFrames; offset += 1) {
+          const sampleTime = Math.min(localRangeEnd, currentLocalTime + offset * frameDuration);
+          const sequenceFrame = getGaussianSplatSequenceFrame(gaussianSplatSequence, sampleTime);
+          const runtimeKey = getGaussianSplatSequenceFrameRuntimeKey(
+            gaussianSplatSequence,
+            sampleTime,
+            clip.source?.gaussianSplatRuntimeKey ??
+              mediaFile?.id ??
+              clip.source?.mediaFileId ??
+              clip.id,
+          );
+          if (!sequenceFrame || !runtimeKey || seenRuntimeKeys.has(runtimeKey)) {
+            continue;
+          }
+
+          const frameFile = sequenceFrame.file;
+          const frameUrl = sequenceFrame.splatUrl;
+          if (!frameFile && !frameUrl) {
+            continue;
+          }
+
+          seenRuntimeKeys.add(runtimeKey);
+          prewarmGaussianSplatRuntime({
+            cacheKey: runtimeKey,
+            file: frameFile,
+            url: frameUrl,
+            fileName: sequenceFrame.name ?? clip.source?.gaussianSplatFileName ?? clip.file?.name ?? clip.name,
+            gaussianSplatSequence,
+            requestedMaxSplats,
+          });
+        }
+        continue;
+      }
+
       const file = mediaFile?.file ?? clip.file;
       if (!file) continue;
 

--- a/src/shared/openAiModelCatalog.ts
+++ b/src/shared/openAiModelCatalog.ts
@@ -1,0 +1,344 @@
+export type OpenAiModelTier = 'low' | 'mid' | 'high' | 'premium';
+export type OpenAiReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
+export interface OpenAiModelCatalogEntry {
+  creditCost: number;
+  defaultReasoningEffort: OpenAiReasoningEffort | null;
+  id: string;
+  inputUsdPerMillionTokens: number;
+  label: string;
+  outputUsdPerMillionTokens: number;
+  supportedReasoningEfforts: OpenAiReasoningEffort[];
+  tier: OpenAiModelTier;
+  visibleInChatDropdown: boolean;
+}
+
+const REPRESENTATIVE_INPUT_TOKENS = 1_000;
+const REPRESENTATIVE_OUTPUT_TOKENS = 500;
+const CREDIT_ROUNDING_EPSILON = 1e-9;
+const GPT_5_LATEST_REASONING_EFFORTS: OpenAiReasoningEffort[] = ['none', 'low', 'medium', 'high', 'xhigh'];
+const GPT_5_1_REASONING_EFFORTS: OpenAiReasoningEffort[] = ['none', 'low', 'medium', 'high'];
+const GPT_5_LEGACY_REASONING_EFFORTS: OpenAiReasoningEffort[] = ['minimal', 'low', 'medium', 'high'];
+const O_SERIES_REASONING_EFFORTS: OpenAiReasoningEffort[] = ['low', 'medium', 'high'];
+
+// Approximate one hosted credit from current paid plan pricing in PricingDialog.
+// This keeps chat requests close to break-even instead of the older, looser mapping.
+const USD_PER_HOSTED_CREDIT = 0.00125;
+
+function estimateCreditCost(inputUsdPerMillionTokens: number, outputUsdPerMillionTokens: number): number {
+  const estimatedRequestUsd =
+    (inputUsdPerMillionTokens * REPRESENTATIVE_INPUT_TOKENS) / 1_000_000
+    + (outputUsdPerMillionTokens * REPRESENTATIVE_OUTPUT_TOKENS) / 1_000_000;
+
+  return Math.max(1, Math.ceil((estimatedRequestUsd / USD_PER_HOSTED_CREDIT) - CREDIT_ROUNDING_EPSILON));
+}
+
+function inferTier(creditCost: number): OpenAiModelTier {
+  if (creditCost <= 1) {
+    return 'low';
+  }
+
+  if (creditCost <= 3) {
+    return 'mid';
+  }
+
+  if (creditCost <= 8) {
+    return 'high';
+  }
+
+  return 'premium';
+}
+
+function defineModel(input: Omit<OpenAiModelCatalogEntry, 'creditCost' | 'tier'>): OpenAiModelCatalogEntry {
+  const creditCost = estimateCreditCost(input.inputUsdPerMillionTokens, input.outputUsdPerMillionTokens);
+
+  return {
+    ...input,
+    creditCost,
+    tier: inferTier(creditCost),
+  };
+}
+
+export const DEFAULT_OPENAI_MODEL_ID = 'gpt-5.1';
+
+export const OPENAI_MODEL_CATALOG: OpenAiModelCatalogEntry[] = [
+  // Current frontier GPT-5.4 family
+  defineModel({
+    defaultReasoningEffort: 'none',
+    id: 'gpt-5.4',
+    inputUsdPerMillionTokens: 2.5,
+    label: 'GPT-5.4',
+    outputUsdPerMillionTokens: 15,
+    supportedReasoningEfforts: GPT_5_LATEST_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'none',
+    id: 'gpt-5.4-mini',
+    inputUsdPerMillionTokens: 0.75,
+    label: 'GPT-5.4 Mini',
+    outputUsdPerMillionTokens: 4.5,
+    supportedReasoningEfforts: GPT_5_LATEST_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'none',
+    id: 'gpt-5.4-nano',
+    inputUsdPerMillionTokens: 0.2,
+    label: 'GPT-5.4 Nano',
+    outputUsdPerMillionTokens: 1.25,
+    supportedReasoningEfforts: GPT_5_LATEST_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+
+  // Chat-oriented and coding-oriented GPT-5 successors
+  defineModel({
+    defaultReasoningEffort: 'none',
+    id: 'gpt-5.3-chat-latest',
+    inputUsdPerMillionTokens: 1.75,
+    label: 'GPT-5.3 Chat',
+    outputUsdPerMillionTokens: 14,
+    supportedReasoningEfforts: GPT_5_LATEST_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'none',
+    id: 'gpt-5.3-codex',
+    inputUsdPerMillionTokens: 1.75,
+    label: 'GPT-5.3 Codex',
+    outputUsdPerMillionTokens: 14,
+    supportedReasoningEfforts: GPT_5_LATEST_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'none',
+    id: 'gpt-5.2',
+    inputUsdPerMillionTokens: 1.75,
+    label: 'GPT-5.2',
+    outputUsdPerMillionTokens: 14,
+    supportedReasoningEfforts: GPT_5_LATEST_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'none',
+    id: 'gpt-5.2-codex',
+    inputUsdPerMillionTokens: 1.75,
+    label: 'GPT-5.2 Codex',
+    outputUsdPerMillionTokens: 14,
+    supportedReasoningEfforts: GPT_5_LATEST_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'none',
+    id: 'gpt-5.1',
+    inputUsdPerMillionTokens: 1.25,
+    label: 'GPT-5.1',
+    outputUsdPerMillionTokens: 10,
+    supportedReasoningEfforts: GPT_5_1_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'none',
+    id: 'gpt-5.1-codex-mini',
+    inputUsdPerMillionTokens: 0.25,
+    label: 'GPT-5.1 Codex Mini',
+    outputUsdPerMillionTokens: 2,
+    supportedReasoningEfforts: GPT_5_1_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+
+  // Previous GPT-5 generation
+  defineModel({
+    defaultReasoningEffort: 'medium',
+    id: 'gpt-5',
+    inputUsdPerMillionTokens: 1.25,
+    label: 'GPT-5',
+    outputUsdPerMillionTokens: 10,
+    supportedReasoningEfforts: GPT_5_LEGACY_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'medium',
+    id: 'gpt-5-mini',
+    inputUsdPerMillionTokens: 0.25,
+    label: 'GPT-5 Mini',
+    outputUsdPerMillionTokens: 2,
+    supportedReasoningEfforts: GPT_5_LEGACY_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'medium',
+    id: 'gpt-5-nano',
+    inputUsdPerMillionTokens: 0.05,
+    label: 'GPT-5 Nano',
+    outputUsdPerMillionTokens: 0.4,
+    supportedReasoningEfforts: GPT_5_LEGACY_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+
+  // Reasoning models that still work with Chat Completions
+  defineModel({
+    defaultReasoningEffort: 'medium',
+    id: 'o3',
+    inputUsdPerMillionTokens: 2,
+    label: 'o3',
+    outputUsdPerMillionTokens: 8,
+    supportedReasoningEfforts: O_SERIES_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'medium',
+    id: 'o4-mini',
+    inputUsdPerMillionTokens: 1.1,
+    label: 'o4-mini',
+    outputUsdPerMillionTokens: 4.4,
+    supportedReasoningEfforts: O_SERIES_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'medium',
+    id: 'o3-mini',
+    inputUsdPerMillionTokens: 1.1,
+    label: 'o3-mini',
+    outputUsdPerMillionTokens: 4.4,
+    supportedReasoningEfforts: O_SERIES_REASONING_EFFORTS,
+    visibleInChatDropdown: true,
+  }),
+
+  // GPT-4.x and GPT-4o fallbacks
+  defineModel({
+    defaultReasoningEffort: null,
+    id: 'gpt-4.1',
+    inputUsdPerMillionTokens: 2,
+    label: 'GPT-4.1',
+    outputUsdPerMillionTokens: 8,
+    supportedReasoningEfforts: [],
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: null,
+    id: 'gpt-4.1-mini',
+    inputUsdPerMillionTokens: 0.4,
+    label: 'GPT-4.1 Mini',
+    outputUsdPerMillionTokens: 1.6,
+    supportedReasoningEfforts: [],
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: null,
+    id: 'gpt-4.1-nano',
+    inputUsdPerMillionTokens: 0.1,
+    label: 'GPT-4.1 Nano',
+    outputUsdPerMillionTokens: 0.4,
+    supportedReasoningEfforts: [],
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: null,
+    id: 'gpt-4o',
+    inputUsdPerMillionTokens: 2.5,
+    label: 'GPT-4o',
+    outputUsdPerMillionTokens: 10,
+    supportedReasoningEfforts: [],
+    visibleInChatDropdown: true,
+  }),
+  defineModel({
+    defaultReasoningEffort: null,
+    id: 'gpt-4o-mini',
+    inputUsdPerMillionTokens: 0.15,
+    label: 'GPT-4o Mini',
+    outputUsdPerMillionTokens: 0.6,
+    supportedReasoningEfforts: [],
+    visibleInChatDropdown: true,
+  }),
+
+  // Hidden pricing entries for models we should not expose in this Chat Completions UI.
+  defineModel({
+    defaultReasoningEffort: 'high',
+    id: 'gpt-5.4-pro',
+    inputUsdPerMillionTokens: 30,
+    label: 'GPT-5.4 Pro',
+    outputUsdPerMillionTokens: 180,
+    supportedReasoningEfforts: ['high'],
+    visibleInChatDropdown: false,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'none',
+    id: 'gpt-5.2-pro',
+    inputUsdPerMillionTokens: 21,
+    label: 'GPT-5.2 Pro',
+    outputUsdPerMillionTokens: 168,
+    supportedReasoningEfforts: GPT_5_LATEST_REASONING_EFFORTS,
+    visibleInChatDropdown: false,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'high',
+    id: 'gpt-5-pro',
+    inputUsdPerMillionTokens: 15,
+    label: 'GPT-5 Pro',
+    outputUsdPerMillionTokens: 120,
+    supportedReasoningEfforts: ['high'],
+    visibleInChatDropdown: false,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'medium',
+    id: 'o3-pro',
+    inputUsdPerMillionTokens: 20,
+    label: 'o3-pro',
+    outputUsdPerMillionTokens: 80,
+    supportedReasoningEfforts: O_SERIES_REASONING_EFFORTS,
+    visibleInChatDropdown: false,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'medium',
+    id: 'gpt-5-codex',
+    inputUsdPerMillionTokens: 1.25,
+    label: 'GPT-5 Codex',
+    outputUsdPerMillionTokens: 10,
+    supportedReasoningEfforts: GPT_5_LEGACY_REASONING_EFFORTS,
+    visibleInChatDropdown: false,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'none',
+    id: 'gpt-5.1-codex',
+    inputUsdPerMillionTokens: 1.25,
+    label: 'GPT-5.1 Codex',
+    outputUsdPerMillionTokens: 10,
+    supportedReasoningEfforts: GPT_5_1_REASONING_EFFORTS,
+    visibleInChatDropdown: false,
+  }),
+  defineModel({
+    defaultReasoningEffort: 'none',
+    id: 'gpt-5.1-codex-max',
+    inputUsdPerMillionTokens: 1.25,
+    label: 'GPT-5.1 Codex Max',
+    outputUsdPerMillionTokens: 10,
+    supportedReasoningEfforts: GPT_5_LATEST_REASONING_EFFORTS,
+    visibleInChatDropdown: false,
+  }),
+];
+
+export const DEFAULT_OPENAI_MODEL_PRICING = {
+  creditCost: 5,
+  tier: 'high' as const,
+};
+
+const OPENAI_MODEL_PRICING_MAP = Object.fromEntries(
+  OPENAI_MODEL_CATALOG.map((model) => [
+    model.id,
+    {
+      creditCost: model.creditCost,
+      tier: model.tier,
+    },
+  ]),
+) as Record<string, { creditCost: number; tier: OpenAiModelTier }>;
+
+export const OPENAI_CHAT_DROPDOWN_MODELS = OPENAI_MODEL_CATALOG.filter((model) => model.visibleInChatDropdown);
+
+export function getOpenAiModelPricing(modelId: string): { creditCost: number; tier: OpenAiModelTier } {
+  return OPENAI_MODEL_PRICING_MAP[modelId] ?? DEFAULT_OPENAI_MODEL_PRICING;
+}
+
+export function getOpenAiModelEntry(modelId: string): OpenAiModelCatalogEntry | undefined {
+  return OPENAI_MODEL_CATALOG.find((model) => model.id === modelId);
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,6 +1,6 @@
 // App version
 // Format: MAJOR.MINOR.PATCH
-export const APP_VERSION = '1.5.5';
+export const APP_VERSION = '1.5.6';
 
 export interface ChangelogNotice {
   type: 'info' | 'warning' | 'success' | 'danger';

--- a/tests/unit/layerBuilderSequencePrewarm.test.ts
+++ b/tests/unit/layerBuilderSequencePrewarm.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { prewarmGaussianSplatRuntime } = vi.hoisted(() => ({
+  prewarmGaussianSplatRuntime: vi.fn(),
+}));
+
+vi.mock('../../src/engine/three/splatRuntimeCache', () => ({
+  prewarmGaussianSplatRuntime,
+}));
+
+import { LayerBuilderService } from '../../src/services/layerBuilder/LayerBuilderService';
+import { useTimelineStore } from '../../src/stores/timeline';
+import { useMediaStore } from '../../src/stores/mediaStore';
+import { DEFAULT_TRANSFORM } from '../../src/stores/timeline/constants';
+
+const initialTimelineState = useTimelineStore.getState();
+const initialMediaState = useMediaStore.getState();
+
+describe('LayerBuilderService gaussian splat sequence prewarm', () => {
+  beforeEach(() => {
+    prewarmGaussianSplatRuntime.mockReset();
+    useTimelineStore.setState(initialTimelineState);
+    useMediaStore.setState(initialMediaState);
+  });
+
+  it('prewarms upcoming gaussian splat sequence frames during playback', () => {
+    const service = new LayerBuilderService();
+    const frameFiles = [
+      new File(['0'], 'scan000000.ply', { type: 'application/octet-stream' }),
+      new File(['1'], 'scan000001.ply', { type: 'application/octet-stream' }),
+      new File(['2'], 'scan000002.ply', { type: 'application/octet-stream' }),
+    ];
+    const gaussianSplatSequence = {
+      fps: 2,
+      frameCount: 3,
+      playbackMode: 'clamp' as const,
+      sequenceName: 'scan',
+      frames: [
+        { name: 'scan000000.ply', projectPath: 'Raw/scan000000.ply', file: frameFiles[0], splatUrl: 'blob:scan-0' },
+        { name: 'scan000001.ply', projectPath: 'Raw/scan000001.ply', file: frameFiles[1], splatUrl: 'blob:scan-1' },
+        { name: 'scan000002.ply', projectPath: 'Raw/scan000002.ply', file: frameFiles[2], splatUrl: 'blob:scan-2' },
+      ],
+    };
+
+    useMediaStore.setState({
+      activeCompositionId: null,
+      activeLayerSlots: {},
+      layerOpacities: {},
+      files: [{
+        id: 'media-splat-seq-1',
+        name: 'scan (3f)',
+        type: 'gaussian-splat',
+        createdAt: 1,
+        gaussianSplatSequence,
+      }],
+      compositions: [],
+      proxyEnabled: false,
+    } as any);
+
+    useTimelineStore.setState({
+      tracks: [
+        {
+          id: 'track-v1',
+          name: 'Video 1',
+          type: 'video',
+          visible: true,
+          muted: false,
+          solo: false,
+        },
+      ],
+      clips: [
+        {
+          id: 'clip-splat-seq-1',
+          trackId: 'track-v1',
+          name: 'Scan Sequence',
+          mediaFileId: 'media-splat-seq-1',
+          file: frameFiles[0],
+          startTime: 0,
+          duration: 2,
+          inPoint: 0,
+          outPoint: 2,
+          effects: [],
+          transform: { ...DEFAULT_TRANSFORM },
+          source: {
+            type: 'gaussian-splat',
+            mediaFileId: 'media-splat-seq-1',
+            gaussianSplatSequence,
+            gaussianSplatSettings: {
+              render: {
+                useNativeRenderer: false,
+                maxSplats: 4096,
+                splatScale: 1,
+                nearPlane: 0.1,
+                farPlane: 1000,
+                backgroundColor: 'transparent',
+                sortFrequency: 8,
+              },
+            },
+          },
+          isLoading: false,
+          is3D: true,
+        },
+      ],
+      playheadPosition: 0,
+      isPlaying: true,
+      isDraggingPlayhead: false,
+      playbackSpeed: 1,
+    } as any);
+
+    service.buildLayersFromStore();
+
+    expect(prewarmGaussianSplatRuntime).toHaveBeenCalledTimes(3);
+    expect(prewarmGaussianSplatRuntime.mock.calls.map(([options]) => options.cacheKey)).toEqual([
+      'Raw/scan000000.ply',
+      'Raw/scan000001.ply',
+      'Raw/scan000002.ply',
+    ]);
+    expect(prewarmGaussianSplatRuntime.mock.calls.every(([options]) => options.gaussianSplatSequence === gaussianSplatSequence)).toBe(true);
+  });
+});

--- a/tests/unit/openAiModelCatalog.test.ts
+++ b/tests/unit/openAiModelCatalog.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_OPENAI_MODEL_ID,
+  getOpenAiModelEntry,
+  getOpenAiModelPricing,
+  OPENAI_CHAT_DROPDOWN_MODELS,
+} from '../../src/shared/openAiModelCatalog';
+import { getModelPricing } from '../../functions/lib/modelPricing';
+
+describe('OpenAI model catalog', () => {
+  it('uses the intended default chat model', () => {
+    expect(DEFAULT_OPENAI_MODEL_ID).toBe('gpt-5.1');
+  });
+
+  it('maps current chat-capable models to the expected credit cost', () => {
+    expect(getOpenAiModelPricing('gpt-5.4')).toEqual({ creditCost: 8, tier: 'high' });
+    expect(getOpenAiModelPricing('gpt-5.4-mini')).toEqual({ creditCost: 3, tier: 'mid' });
+    expect(getOpenAiModelPricing('gpt-5.2')).toEqual({ creditCost: 7, tier: 'high' });
+    expect(getOpenAiModelPricing('gpt-4o')).toEqual({ creditCost: 6, tier: 'high' });
+  });
+
+  it('keeps the backend pricing helper in sync with the shared catalog', () => {
+    for (const modelId of ['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.2', 'gpt-4o']) {
+      expect(getModelPricing(modelId)).toEqual(getOpenAiModelPricing(modelId));
+    }
+  });
+
+  it('exposes reasoning-effort capabilities for chat models that support them', () => {
+    expect(getOpenAiModelEntry('gpt-5.4')?.supportedReasoningEfforts).toEqual([
+      'none',
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+    ]);
+    expect(getOpenAiModelEntry('gpt-5')?.supportedReasoningEfforts).toEqual([
+      'minimal',
+      'low',
+      'medium',
+      'high',
+    ]);
+    expect(getOpenAiModelEntry('gpt-4.1')?.supportedReasoningEfforts).toEqual([]);
+  });
+
+  it('hides non-chat-completions or internal-only models from the dropdown', () => {
+    const dropdownModelIds = OPENAI_CHAT_DROPDOWN_MODELS.map((entry) => entry.id);
+
+    expect(dropdownModelIds).toContain('gpt-5.4');
+    expect(dropdownModelIds).toContain('gpt-5.3-chat-latest');
+    expect(dropdownModelIds).not.toContain('gpt-5.4-pro');
+    expect(dropdownModelIds).not.toContain('gpt-5.1-codex');
+    expect(dropdownModelIds).not.toContain('o3-pro');
+  });
+});

--- a/tests/unit/renderDispatcherExportReadiness.test.ts
+++ b/tests/unit/renderDispatcherExportReadiness.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getPreparedSplatRuntimeSync: vi.fn(),
+  waitForBasePreparedSplatRuntime: vi.fn(),
+  waitForTargetPreparedSplatRuntime: vi.fn(),
+  loggerWarn: vi.fn(),
+}));
+
+vi.mock('../../src/services/logger', () => ({
+  Logger: {
+    create: vi.fn(() => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: mocks.loggerWarn,
+      error: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock('../../src/engine/three/splatRuntimeCache', () => ({
+  getPreparedSplatRuntimeSync: mocks.getPreparedSplatRuntimeSync,
+  waitForBasePreparedSplatRuntime: mocks.waitForBasePreparedSplatRuntime,
+  waitForTargetPreparedSplatRuntime: mocks.waitForTargetPreparedSplatRuntime,
+}));
+
+vi.mock('../../src/stores/renderTargetStore', () => ({
+  useRenderTargetStore: {
+    getState: () => ({}),
+  },
+}));
+
+vi.mock('../../src/stores/sliceStore', () => ({
+  useSliceStore: {
+    getState: () => ({}),
+  },
+}));
+
+vi.mock('../../src/stores/engineStore', () => ({
+  useEngineStore: {
+    getState: () => ({}),
+  },
+}));
+
+vi.mock('../../src/stores/timeline', () => ({
+  useTimelineStore: {
+    getState: () => ({
+      playheadPosition: 0,
+      clips: [],
+      tracks: [],
+    }),
+  },
+}));
+
+vi.mock('../../src/stores/mediaStore', () => ({
+  DEFAULT_SCENE_CAMERA_SETTINGS: {
+    fov: 50,
+    near: 0.1,
+    far: 1000,
+  },
+  useMediaStore: {
+    getState: () => ({
+      files: [],
+    }),
+  },
+}));
+
+import { RenderDispatcher } from '../../src/engine/render/RenderDispatcher';
+
+function createDispatcher(): RenderDispatcher {
+  return new RenderDispatcher({
+    getDevice: () => null,
+    isRecovering: () => false,
+    sampler: null,
+    previewContext: null,
+    targetCanvases: new Map(),
+    compositorPipeline: null,
+    outputPipeline: null,
+    slicePipeline: null,
+    textureManager: null,
+    maskTextureManager: null,
+    renderTargetManager: {
+      getResolution: () => ({ width: 1920, height: 1080 }),
+    },
+    layerCollector: null,
+    compositor: null,
+    nestedCompRenderer: null,
+    cacheManager: {} as any,
+    exportCanvasManager: {} as any,
+    performanceStats: {} as any,
+    renderLoop: null,
+    threeSceneRenderer: null,
+  } as any);
+}
+
+function createThreeSplatLayer() {
+  return [
+    {
+      id: 'layer-splat',
+      name: 'Hero Splat',
+      visible: true,
+      opacity: 1,
+      is3D: true,
+      sourceClipId: 'clip-splat',
+      source: {
+        type: 'gaussian-splat',
+        gaussianSplatUrl: 'blob:hero-splat',
+        gaussianSplatFileName: 'hero.ply',
+        file: new File([new Uint8Array([1, 2, 3])], 'hero.ply', {
+          type: 'application/octet-stream',
+        }),
+        gaussianSplatSettings: {
+          render: {
+            useNativeRenderer: false,
+            maxSplats: 0,
+          },
+        },
+      },
+    },
+  ] as any;
+}
+
+describe('RenderDispatcher.ensureExportLayersReady', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPreparedSplatRuntimeSync.mockReturnValue(null);
+    mocks.waitForBasePreparedSplatRuntime.mockResolvedValue({});
+    mocks.waitForTargetPreparedSplatRuntime.mockResolvedValue({});
+  });
+
+  it('falls back to a cached base three.js splat runtime when the full export runtime cannot be allocated', async () => {
+    const dispatcher = createDispatcher();
+    vi.spyOn(dispatcher, 'ensureThreeSceneRendererInitialized').mockResolvedValue(true);
+
+    mocks.waitForTargetPreparedSplatRuntime.mockRejectedValueOnce(new Error('Array buffer allocation failed'));
+    mocks.getPreparedSplatRuntimeSync.mockReturnValueOnce({
+      runtimeKey: 'cached-base-runtime',
+    });
+
+    await expect(dispatcher.ensureExportLayersReady(createThreeSplatLayer())).resolves.toBeUndefined();
+
+    expect(mocks.waitForTargetPreparedSplatRuntime).toHaveBeenCalledTimes(1);
+    expect(mocks.waitForBasePreparedSplatRuntime).not.toHaveBeenCalled();
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      'Precise export falling back to cached base Three.js splat runtime',
+      expect.objectContaining({
+        fileName: 'hero.ply',
+      }),
+    );
+  });
+
+  it('rebuilds the base runtime once and caches export readiness after a recoverable target runtime failure', async () => {
+    const dispatcher = createDispatcher();
+    vi.spyOn(dispatcher, 'ensureThreeSceneRendererInitialized').mockResolvedValue(true);
+
+    mocks.waitForTargetPreparedSplatRuntime.mockRejectedValueOnce(new Error('Array buffer allocation failed'));
+
+    await expect(dispatcher.ensureExportLayersReady(createThreeSplatLayer())).resolves.toBeUndefined();
+    await expect(dispatcher.ensureExportLayersReady(createThreeSplatLayer())).resolves.toBeUndefined();
+
+    expect(mocks.waitForTargetPreparedSplatRuntime).toHaveBeenCalledTimes(1);
+    expect(mocks.waitForBasePreparedSplatRuntime).toHaveBeenCalledTimes(1);
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      'Precise export falling back to rebuilt base Three.js splat runtime',
+      expect.objectContaining({
+        fileName: 'hero.ply',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- fall back to a base Three.js gaussian splat runtime when precise export cannot allocate the full target runtime
- keep export readiness cached so the failing target build is not retried on every frame
- add regression coverage for the export-readiness fallback path

## Verification
- npm run build
- npm run lint
- npm run test

No version bump in this release path per request.