### PR TITLE
Add browser MIDI mapping controls and stop markers

### DIFF
--- a/docs/Features/Project-Persistence.md
+++ b/docs/Features/Project-Persistence.md
@@ -292,6 +292,7 @@ interface ProjectFile {
 
 ### Per Composition
 - All tracks and clips
+- Timeline markers and per-marker MIDI bindings
 - Clip positions and durations
 - Trim points (inPoint/outPoint)
 - Transform properties (position, scale, rotation, anchor, opacity, blend mode)
@@ -323,6 +324,7 @@ interface ProjectFile {
 - Composition view state per composition (playhead, zoom, scroll, in/out points)
 - Media panel column order and name width
 - Transcript language preference
+- Global MIDI state: enabled flag and transport bindings (`Play / Pause`, `Stop`)
 - View toggles: thumbnails, waveforms, proxy, transcript markers
 - Changelog preferences (`showChangelogOnStartup`, `lastSeenChangelogVersion`)
 - Export panel state: live export settings, named export presets, and the selected preset

--- a/docs/Features/Timeline.md
+++ b/docs/Features/Timeline.md
@@ -192,6 +192,9 @@ The toolbar and wheel gestures still drive playback and navigation:
 - `I` and `O` set in/out points.
 - `X` clears in/out.
 - `M` adds a marker at the playhead.
+- Right-clicking a marker opens marker transport and MIDI actions.
+- Markers can be turned into `Stop Marker`s that automatically pause playback when crossed.
+- Marker MIDI bindings support `Jump To Marker`, `Play From Marker`, and `Jump To Marker And Stop`.
 - Left/Right arrows step frame by frame.
 - `Alt+Scroll` or `Ctrl+Scroll` zooms the timeline around the playhead.
 - `Shift+Scroll` pans horizontally.

--- a/docs/Features/UI-Panels.md
+++ b/docs/Features/UI-Panels.md
@@ -33,7 +33,6 @@ Dockable desktop panel system with an After Effects-style menu bar, unified clip
 | **Edit** | Copy, Paste, Settings |
 | **View** | Panels submenu, Layouts submenu |
 | **Output** | New Output Window, Open Output Manager, Active Outputs |
-| **Window** | MIDI Control |
 | **Info** | Where are you coming from?, Tutorials, Quick Tour, Timeline Tour, Changelog, About, Imprint, Privacy Policy, Contact |
 
 ### Keyboard Shortcuts
@@ -106,7 +105,7 @@ All docked panels can be:
 
 ## Available Panels
 
-MasterSelects currently exposes 16 dockable panel types, plus the Slot Grid overlay that sits on top of the Timeline.
+MasterSelects currently exposes 17 dockable panel types, plus the Slot Grid overlay that sits on top of the Timeline.
 
 | Panel | Type ID | Surface |
 |-------|---------|---------|
@@ -116,6 +115,7 @@ MasterSelects currently exposes 16 dockable panel types, plus the Slot Grid over
 | **Media** | `media` | Media browser, folders, and project items |
 | **Properties** | `clip-properties` | Unified clip inspector |
 | **Export** | `export` | Render and export controls |
+| **MIDI Mapping** | `midi-mapping` | Overview and editor for assigned MIDI notes |
 | **AI Chat** | `ai-chat` | Editing assistant chat |
 | **AI Video** | `ai-video` | Classic generator plus FlashBoard workspace |
 | **AI Segment** | `ai-segment` | Local SAM2 segmentation tools |
@@ -174,6 +174,17 @@ MasterSelects currently exposes 16 dockable panel types, plus the Slot Grid over
 - In/Out export and FCPXML export
 - Stacked alpha export
 - Progress with phase display
+
+### MIDI Mapping Panel
+
+- Open from `View -> Panels -> MIDI Mapping`
+- Shows all currently assigned MIDI notes in one list
+- Includes both global transport bindings and per-marker bindings
+- Each row shows the note, target, and resulting command behavior
+- Existing entries can be edited directly:
+- Change channel and note manually
+- Relearn the binding from incoming MIDI
+- Move a marker binding to another available marker from a dropdown list
 
 ### AI Chat Panel
 
@@ -384,7 +395,7 @@ Multi Preview is available from the View menu and can be floated or docked, but 
 
 ### Enabling MIDI
 
-Window menu -> MIDI Control
+Edit menu -> Settings -> MIDI
 
 ### Requirements
 
@@ -397,6 +408,12 @@ Window menu -> MIDI Control
 ```
 MIDI Control (N devices)
 ```
+
+### Mapping Overview
+
+- `View -> Panels -> MIDI Mapping` opens the dedicated mapping panel
+- The panel lists all assigned transport and marker bindings
+- Empty-state guidance points back to Settings and the marker right-click menu
 
 ---
 
@@ -441,6 +458,7 @@ Edit menu -> Settings
 |----------|----------|
 | **Appearance** | Theme selection and custom theme controls |
 | **General** | Save mode, autosave interval/enable state, import copy behavior, and mobile/desktop view mode |
+| **MIDI** | Browser MIDI permission state, transport learning, and device list |
 | **Previews** | Preview resolution quality and transparency grid info |
 | **Import** | Copy media to project folder toggle |
 | **Transcription** | Provider selection and pricing |

--- a/src/App.css
+++ b/src/App.css
@@ -7623,6 +7623,12 @@ input[type="checkbox"] {
   box-shadow: 0 0 8px var(--marker-color);
 }
 
+.timeline-marker.is-stop-marker .timeline-marker-head {
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--warning-light) 45%, transparent),
+    0 0 10px color-mix(in srgb, var(--warning-light) 20%, transparent);
+}
+
 .timeline-marker .timeline-marker-line {
   width: 2px;
   min-height: calc(100vh - 50px);
@@ -7630,6 +7636,15 @@ input[type="checkbox"] {
   background: var(--marker-color);
   margin-top: -2px;
   opacity: 0.7;
+}
+
+.timeline-marker.is-stop-marker .timeline-marker-line {
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      var(--marker-color) 0 10px,
+      color-mix(in srgb, var(--warning-light) 42%, var(--marker-color)) 10px 16px
+    );
 }
 
 .timeline-marker:hover .timeline-marker-line,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import { useTheme } from './hooks/useTheme';
 import { useGlobalHistory } from './hooks/useGlobalHistory';
 import { useClipPanelSync } from './hooks/useClipPanelSync';
 import { useIsMobile, useForceMobile } from './hooks/useIsMobile';
+import { useMIDIRuntime } from './hooks/useMIDIRuntime';
 import { useAccountStore } from './stores/accountStore';
 import { useSettingsStore } from './stores/settingsStore';
 import { projectDB } from './services/projectDB';
@@ -62,6 +63,9 @@ function App() {
 
   // Auto-switch panels based on clip selection
   useClipPanelSync();
+
+  // Browser MIDI runtime
+  useMIDIRuntime();
 
   // Check if there's a stored project in IndexedDB (the only allowed browser storage)
   const [isChecking, setIsChecking] = useState(true);

--- a/src/changelog-data.json
+++ b/src/changelog-data.json
@@ -1,5 +1,25 @@
 [
   {
+    "date": "2026-04-23",
+    "type": "new",
+    "title": "Browser MIDI Control Added with Learn Mode and a Dedicated Mapping Panel",
+    "description": "MasterSelects now supports direct browser MIDI input over Web MIDI with a dedicated Settings tab, transport bindings, a dockable MIDI Mapping panel, note learn mode, manual reassignment, and project-persistent marker plus transport mappings.",
+    "section": "MIDI / Workflow",
+    "commits": [
+      "8e2701c3"
+    ]
+  },
+  {
+    "date": "2026-04-23",
+    "type": "improve",
+    "title": "Timeline Markers Can Now Trigger Playback and Auto-Stop the Playhead",
+    "description": "Markers now expose right-click MIDI actions for Jump, Play From Marker, and Jump To Marker And Stop, and any marker can be turned into a Stop Marker so playback halts automatically when the playhead crosses it.",
+    "section": "Timeline / Markers",
+    "commits": [
+      "8e2701c3"
+    ]
+  },
+  {
     "date": "2026-04-18",
     "type": "new",
     "title": "MasterSelects Now Opens Through a Dedicated Landing Page",

--- a/src/components/common/SettingsDialog.tsx
+++ b/src/components/common/SettingsDialog.tsx
@@ -5,6 +5,7 @@ import { useSettingsStore } from '../../stores/settingsStore';
 import { useDraggableDialog } from './settings/useDraggableDialog';
 import { AppearanceSettings } from './settings/AppearanceSettings';
 import { GeneralSettings } from './settings/GeneralSettings';
+import { MidiSettings } from './settings/MidiSettings';
 import { TranscriptionSettings } from './settings/TranscriptionSettings';
 import { ApiKeysSettings } from './settings/ApiKeysSettings';
 import { NativeHelperSettings } from './settings/NativeHelperSettings';
@@ -17,6 +18,7 @@ interface SettingsDialogProps {
 
 type SettingsCategory =
   | 'general'
+  | 'midi'
   | 'shortcuts'
   | 'appearance'
   | 'transcription'
@@ -31,6 +33,7 @@ interface CategoryConfig {
 
 const categories: CategoryConfig[] = [
   { id: 'general', label: 'General', icon: '\u2699' },
+  { id: 'midi', label: 'MIDI', icon: '\u266B' },
   { id: 'shortcuts', label: 'Shortcuts', icon: '\u2328' },
   { id: 'appearance', label: 'Appearance', icon: '\uD83C\uDFA8' },
   { id: 'transcription', label: 'Transcription', icon: '\uD83C\uDFA4' },
@@ -62,6 +65,7 @@ export function SettingsDialog({ onClose }: SettingsDialogProps) {
   const renderCategoryContent = () => {
     switch (activeCategory) {
       case 'general': return <GeneralSettings />;
+      case 'midi': return <MidiSettings />;
       case 'shortcuts': return <ShortcutsSettings />;
       case 'appearance': return <AppearanceSettings />;
       case 'transcription': return <TranscriptionSettings localKeys={localKeys} />;

--- a/src/components/common/settings/GeneralSettings.tsx
+++ b/src/components/common/settings/GeneralSettings.tsx
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 import { useSettingsStore, type AutosaveInterval, type SaveMode, type PreviewQuality, type GPUPowerPreference } from '../../../stores/settingsStore';
 // AutosaveInterval used in interval select onChange cast
 import { useIsMobile } from '../../../hooks/useIsMobile';
-import { useMIDI } from '../../../hooks/useMIDI';
 import { OutputSettings } from './OutputSettings';
 import { AIFeaturesSettings } from './AIFeaturesSettings';
 
@@ -23,8 +22,6 @@ export function GeneralSettings() {
   } = useSettingsStore();
 
   const isMobileDevice = useIsMobile();
-  const { isSupported, isEnabled, devices, lastMessage, enableMIDI, disableMIDI } = useMIDI();
-
   const handleSwitchToMobile = useCallback(() => {
     setForceDesktopMode(false);
     window.location.reload();
@@ -148,67 +145,6 @@ export function GeneralSettings() {
         <p className="settings-hint">
           Requires page reload to take effect.
         </p>
-      </div>
-
-      {/* MIDI */}
-      <div className="settings-group">
-        <div className="settings-group-title">MIDI Control</div>
-
-        {isSupported ? (
-          <>
-            <label className="settings-row">
-              <span className="settings-label">Enable MIDI</span>
-              <input
-                type="checkbox"
-                checked={isEnabled}
-                onChange={(e) => { if (e.target.checked) enableMIDI(); else disableMIDI(); }}
-                className="settings-checkbox"
-              />
-            </label>
-
-            {isEnabled && (
-              <>
-                <div className="settings-status">
-                  <span className={`status-indicator ${devices.length > 0 ? 'connected' : 'disconnected'}`} />
-                  <span className="status-text">
-                    {devices.length > 0
-                      ? `${devices.length} device${devices.length > 1 ? 's' : ''} connected`
-                      : 'No devices detected'}
-                  </span>
-                </div>
-
-                {devices.length > 0 && (
-                  <div className="settings-group" style={{ marginTop: 8 }}>
-                    <div className="settings-group-title">Devices</div>
-                    {devices.map((device) => (
-                      <div key={device.id} className="settings-row">
-                        <span className="settings-label">{device.name}</span>
-                        <span className="settings-hint" style={{ margin: 0 }}>
-                          {device.manufacturer !== 'Unknown' ? device.manufacturer : ''}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-
-                {lastMessage && (
-                  <div className="settings-group" style={{ marginTop: 8 }}>
-                    <div className="settings-group-title">Last Message</div>
-                    <div className="settings-row">
-                      <span className="settings-label">
-                        CH {lastMessage.channel} / CC {lastMessage.control} / Val {lastMessage.value}
-                      </span>
-                    </div>
-                  </div>
-                )}
-              </>
-            )}
-          </>
-        ) : (
-          <p className="settings-hint">
-            MIDI is not supported in this browser. Use Chrome or Edge for Web MIDI API support.
-          </p>
-        )}
       </div>
 
       {/* AI Features */}

--- a/src/components/common/settings/MidiSettings.tsx
+++ b/src/components/common/settings/MidiSettings.tsx
@@ -1,11 +1,76 @@
 import { useMIDI } from '../../../hooks/useMIDI';
+import {
+  describeMIDILearnTarget,
+  describeMIDIPermissionState,
+  formatMIDINoteBinding,
+  getMIDIPermissionHelpText,
+  getMIDINoteName,
+} from '../../../types/midi';
+
+function formatLastMessage(
+  lastMessage: ReturnType<typeof useMIDI>['lastMessage']
+): string | null {
+  if (!lastMessage) {
+    return null;
+  }
+
+  if (lastMessage.type === 'note-on' || lastMessage.type === 'note-off') {
+    return `Ch ${lastMessage.channel} / ${lastMessage.type === 'note-on' ? 'Note On' : 'Note Off'} / ${lastMessage.noteName ?? getMIDINoteName(lastMessage.note ?? 0)} (${lastMessage.note ?? 0}) / Vel ${lastMessage.velocity ?? 0}`;
+  }
+
+  return `Ch ${lastMessage.channel} / CC ${lastMessage.control ?? 0} / Val ${lastMessage.value ?? 0}`;
+}
 
 export function MidiSettings() {
-  const { isSupported, isEnabled, devices, lastMessage, enableMIDI, disableMIDI } = useMIDI();
+  const {
+    isSupported,
+    isEnabled,
+    connectionStatus,
+    connectionError,
+    permissionState,
+    devices,
+    lastMessage,
+    learnTarget,
+    transportBindings,
+    enableMIDI,
+    disableMIDI,
+    startLearningTransportBinding,
+    clearTransportBinding,
+    cancelLearning,
+  } = useMIDI();
+
+  const learnDescription = describeMIDILearnTarget(learnTarget);
+  const permissionDescription = describeMIDIPermissionState(permissionState);
+  const permissionHelpText = getMIDIPermissionHelpText(permissionState);
+  const lastMessageLabel = formatLastMessage(lastMessage);
+  const statusText =
+    connectionStatus === 'requesting'
+      ? 'Requesting MIDI access...'
+      : connectionStatus === 'error'
+        ? permissionState === 'denied'
+          ? 'Browser MIDI permission is blocked for this site.'
+          : connectionError || 'Could not connect to MIDI.'
+        : devices.length > 0
+          ? `${devices.length} device${devices.length > 1 ? 's' : ''} connected`
+          : permissionState === 'granted'
+            ? 'Permission granted. No devices detected'
+            : 'No devices detected';
+  const shouldShowConnectionState =
+    isEnabled
+    || connectionStatus === 'requesting'
+    || connectionStatus === 'error'
+    || (permissionState !== null && permissionState !== 'unsupported');
 
   return (
     <div className="settings-category-content">
       <h2>MIDI Control</h2>
+
+      <div className="settings-group">
+        <div className="settings-group-title">Overview</div>
+        <p className="settings-description">
+          Browser MIDI runs directly over the Web MIDI API. Marker-specific bindings are assigned from the marker right-click menu in the timeline.
+        </p>
+      </div>
 
       <div className="settings-group">
         <div className="settings-group-title">Connection</div>
@@ -17,21 +82,39 @@ export function MidiSettings() {
               <input
                 type="checkbox"
                 checked={isEnabled}
-                onChange={(e) => { if (e.target.checked) enableMIDI(); else disableMIDI(); }}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    void enableMIDI();
+                  } else {
+                    disableMIDI();
+                  }
+                }}
                 className="settings-checkbox"
               />
             </label>
 
-            {isEnabled && (
+            {shouldShowConnectionState && (
               <>
                 <div className="settings-status">
-                  <span className={`status-indicator ${devices.length > 0 ? 'connected' : 'disconnected'}`} />
+                  <span
+                    className={`status-indicator ${connectionStatus === 'connected' && devices.length > 0 ? 'connected' : 'disconnected'}`}
+                  />
                   <span className="status-text">
-                    {devices.length > 0
-                      ? `${devices.length} device${devices.length > 1 ? 's' : ''} connected`
-                      : 'No devices detected'}
+                    {statusText}
                   </span>
                 </div>
+
+                {permissionDescription && (
+                  <p className="settings-hint">
+                    {permissionDescription}
+                  </p>
+                )}
+
+                {permissionHelpText && (
+                  <p className="settings-hint">
+                    {permissionHelpText}
+                  </p>
+                )}
 
                 {devices.length > 0 && (
                   <div className="settings-group" style={{ marginTop: 8 }}>
@@ -47,13 +130,20 @@ export function MidiSettings() {
                   </div>
                 )}
 
-                {lastMessage && (
+                {learnDescription && (
+                  <div className="midi-learn-status">
+                    <span>{learnDescription}</span>
+                    <button className="settings-button" onClick={cancelLearning}>
+                      Cancel Learn
+                    </button>
+                  </div>
+                )}
+
+                {lastMessageLabel && (
                   <div className="settings-group" style={{ marginTop: 8 }}>
                     <div className="settings-group-title">Last Message</div>
                     <div className="settings-row">
-                      <span className="settings-label">
-                        CH {lastMessage.channel} / CC {lastMessage.control} / Val {lastMessage.value}
-                      </span>
+                      <span className="settings-label">{lastMessageLabel}</span>
                     </div>
                   </div>
                 )}
@@ -67,9 +157,47 @@ export function MidiSettings() {
         )}
       </div>
 
-      <p className="settings-hint">
-        MIDI mappings for timeline and effect parameters will be available in a future update.
-      </p>
+      <div className="settings-group">
+        <div className="settings-group-title">Transport</div>
+
+        <div className="settings-row">
+          <span className="settings-label">Play / Pause</span>
+          <div className="settings-row-actions">
+            <span className="midi-binding-value">{formatMIDINoteBinding(transportBindings.playPause)}</span>
+            <button className="settings-button" onClick={() => startLearningTransportBinding('playPause')}>
+              Learn
+            </button>
+            <button
+              className="settings-button"
+              onClick={() => clearTransportBinding('playPause')}
+              disabled={!transportBindings.playPause}
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+
+        <div className="settings-row">
+          <span className="settings-label">Stop</span>
+          <div className="settings-row-actions">
+            <span className="midi-binding-value">{formatMIDINoteBinding(transportBindings.stop)}</span>
+            <button className="settings-button" onClick={() => startLearningTransportBinding('stop')}>
+              Learn
+            </button>
+            <button
+              className="settings-button"
+              onClick={() => clearTransportBinding('stop')}
+              disabled={!transportBindings.stop}
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+
+        <p className="settings-hint">
+          Marker commands are assigned per marker: right-click a timeline marker, then choose Jump To Marker or Play From Marker learning.
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/components/common/settings/SettingsDialog.css
+++ b/src/components/common/settings/SettingsDialog.css
@@ -258,6 +258,33 @@
   border-color: var(--text-secondary);
 }
 
+.settings-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.midi-binding-value {
+  min-width: 150px;
+  text-align: right;
+  font-size: 10px;
+  color: var(--text-secondary);
+}
+
+.midi-learn-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 8px 10px;
+  border: 1px solid rgba(77, 159, 255, 0.35);
+  border-radius: 4px;
+  background: rgba(77, 159, 255, 0.08);
+  color: var(--text-primary);
+  font-size: 11px;
+}
+
 /* Preset buttons */
 .preset-buttons {
   display: flex;

--- a/src/components/dock/DockPanelContent.tsx
+++ b/src/components/dock/DockPanelContent.tsx
@@ -16,6 +16,7 @@ const MultiCamPanel = lazy(() => import('../panels/MultiCamPanel').then(m => ({ 
 const AIChatPanel = lazy(() => import('../panels/AIChatPanel').then(m => ({ default: m.AIChatPanel })));
 const AIVideoPanel = lazy(() => import('../panels/AIVideoPanel').then(m => ({ default: m.AIVideoPanel })));
 const DownloadPanel = lazy(() => import('../panels/DownloadPanel').then(m => ({ default: m.DownloadPanel })));
+const MIDIMappingPanel = lazy(() => import('../panels/MIDIMappingPanel').then(m => ({ default: m.MIDIMappingPanel })));
 const TransitionsPanel = lazy(() => import('../panels/TransitionsPanel').then(m => ({ default: m.TransitionsPanel })));
 const SAM2Panel = lazy(() => import('../panels/SAM2Panel').then(m => ({ default: m.SAM2Panel })));
 const SceneDescriptionPanel = lazy(() => import('../panels/SceneDescriptionPanel').then(m => ({ default: m.SceneDescriptionPanel })));
@@ -62,6 +63,8 @@ export function DockPanelContent({ panel }: DockPanelContentProps) {
       return <Timeline />;
     case 'media':
       return <MediaPanel />;
+    case 'midi-mapping':
+      return <Suspense fallback={<PanelLoading />}><MIDIMappingPanel /></Suspense>;
     case 'multicam':
       return <Suspense fallback={<PanelLoading />}><MultiCamPanel /></Suspense>;
     case 'ai-chat':

--- a/src/components/panels/MIDIMappingPanel.css
+++ b/src/components/panels/MIDIMappingPanel.css
@@ -1,0 +1,292 @@
+.midi-mapping-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  overflow: hidden;
+}
+
+.midi-mapping-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  padding: var(--sp-2-5) var(--sp-3);
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-tertiary);
+}
+
+.midi-mapping-header h2 {
+  margin: 0;
+  font-size: var(--font-lg);
+  font-weight: var(--font-semibold);
+}
+
+.midi-mapping-header p {
+  margin: var(--sp-1) 0 0;
+  font-size: var(--font-sm);
+  color: var(--text-muted);
+}
+
+.midi-mapping-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1-5);
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.midi-mapping-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-muted);
+}
+
+.midi-mapping-status-dot.is-live {
+  background: var(--success-light);
+  box-shadow: 0 0 8px var(--success-light);
+}
+
+.midi-mapping-learn-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3);
+  border-bottom: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--accent-subtle) 70%, transparent);
+  font-size: var(--font-sm);
+  color: var(--text-secondary);
+}
+
+.midi-mapping-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--sp-3);
+  display: grid;
+  gap: var(--sp-2);
+  align-content: start;
+}
+
+.midi-mapping-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-tertiary);
+  padding: var(--sp-2-5);
+  transition:
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    transform 140ms ease,
+    background-color 140ms ease;
+}
+
+.midi-mapping-card.is-clickable {
+  cursor: pointer;
+}
+
+.midi-mapping-card.is-clickable:hover {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border-color));
+  transform: translateY(-1px);
+}
+
+.midi-mapping-card.is-clickable:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 55%, transparent);
+}
+
+.midi-mapping-card.is-previewing {
+  border-color: color-mix(in srgb, var(--accent) 65%, var(--border-color));
+  background: color-mix(in srgb, var(--accent-subtle) 55%, var(--bg-tertiary));
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--accent) 45%, transparent),
+    0 0 20px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.midi-mapping-card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-2);
+}
+
+.midi-mapping-binding {
+  font-family: var(--font-mono);
+  font-size: var(--font-sm);
+  color: var(--accent);
+}
+
+.midi-mapping-scope {
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: var(--font-xs);
+  font-weight: var(--font-medium);
+}
+
+.midi-mapping-scope-transport {
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+
+.midi-mapping-scope-marker {
+  background: var(--warning-dim);
+  color: var(--warning-light);
+}
+
+.midi-mapping-card-main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-0-5);
+}
+
+.midi-mapping-card-main strong {
+  font-size: var(--font-md);
+  color: var(--text-primary);
+}
+
+.midi-mapping-card-main span {
+  font-size: var(--font-sm);
+  color: var(--text-secondary);
+}
+
+.midi-mapping-card-footer {
+  margin-top: var(--sp-2);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+}
+
+.midi-mapping-card-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  flex-wrap: wrap;
+}
+
+.midi-mapping-editor {
+  margin-top: var(--sp-2);
+  padding-top: var(--sp-2);
+  border-top: 1px solid var(--border-color);
+  display: grid;
+  gap: var(--sp-2);
+}
+
+.midi-mapping-editor-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--sp-2);
+}
+
+.midi-mapping-field {
+  display: grid;
+  gap: var(--sp-1);
+  min-width: 0;
+}
+
+.midi-mapping-field span {
+  font-size: var(--font-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.midi-mapping-field input,
+.midi-mapping-field select {
+  width: 100%;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  padding: 8px 10px;
+  font-size: var(--font-sm);
+}
+
+.midi-mapping-field input:focus,
+.midi-mapping-field select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.midi-mapping-field small {
+  font-size: var(--font-xs);
+  color: var(--accent);
+}
+
+.midi-mapping-field-wide {
+  grid-column: 1 / -1;
+}
+
+.midi-mapping-editor-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-1);
+  flex-wrap: wrap;
+}
+
+.midi-mapping-editor-hint {
+  margin: 0;
+  font-size: var(--font-xs);
+  line-height: var(--leading-relaxed);
+  color: var(--text-muted);
+}
+
+.midi-mapping-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: var(--sp-2);
+  padding: var(--sp-5);
+  color: var(--text-muted);
+}
+
+.midi-mapping-empty p {
+  margin: 0;
+  max-width: 420px;
+  font-size: var(--font-md);
+  line-height: var(--leading-relaxed);
+}
+
+.midi-mapping-empty-muted {
+  color: var(--text-secondary);
+}
+
+.midi-mapping-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.midi-mapping-list::-webkit-scrollbar-track {
+  background: var(--bg-secondary);
+}
+
+.midi-mapping-list::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: var(--radius-sm);
+}
+
+.midi-mapping-list::-webkit-scrollbar-thumb:hover {
+  background: var(--text-secondary);
+}
+
+@media (max-width: 900px) {
+  .midi-mapping-header,
+  .midi-mapping-card-footer,
+  .midi-mapping-learn-banner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .midi-mapping-editor-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/panels/MIDIMappingPanel.tsx
+++ b/src/components/panels/MIDIMappingPanel.tsx
@@ -1,0 +1,442 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type SyntheticEvent,
+} from 'react';
+import { useMIDI } from '../../hooks/useMIDI';
+import { useTimelineStore } from '../../stores/timeline';
+import {
+  collectMIDIMappingSummary,
+  getMarkerTargetLabel,
+  type MIDIMappingSummaryEntry,
+} from '../../services/midi/midiMappingSummary';
+import {
+  moveMarkerMIDIBinding,
+  setMarkerMIDIBinding,
+  setTransportMIDIBinding,
+} from '../../services/midi/midiBindingMutations';
+import {
+  triggerMIDITransportAction,
+  triggerMarkerMIDIAction,
+} from '../../services/midi/midiCommands';
+import {
+  describeMIDILearnTarget,
+  getMIDINoteName,
+  type MarkerMIDIAction,
+  type MIDITransportAction,
+} from '../../types/midi';
+import './MIDIMappingPanel.css';
+
+function MIDIMappingEmptyState({ isEnabled }: { isEnabled: boolean }) {
+  return (
+    <div className="midi-mapping-empty">
+      <p>No MIDI mappings assigned yet.</p>
+      <p>
+        Add transport bindings in Settings / MIDI and marker bindings from the timeline marker right-click menu.
+      </p>
+      {!isEnabled && (
+        <p className="midi-mapping-empty-muted">
+          MIDI is currently disabled. Enable it in Settings before learning new notes.
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface MIDIMappingDraft {
+  mappingId: string;
+  channel: string;
+  note: string;
+  markerId?: string;
+}
+
+function clampInteger(value: string, fallback: number, min: number, max: number): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  return Math.max(min, Math.min(max, parsed));
+}
+
+export function MIDIMappingPanel() {
+  const {
+    transportBindings,
+    isEnabled,
+    connectionStatus,
+    devices,
+    learnTarget,
+    startLearningTransportBinding,
+    startLearningMarkerBinding,
+    cancelLearning,
+  } = useMIDI();
+  const markers = useTimelineStore((state) => state.markers);
+  const [draft, setDraft] = useState<MIDIMappingDraft | null>(null);
+  const [previewingMappingId, setPreviewingMappingId] = useState<string | null>(null);
+  const previewResetTimeoutRef = useRef<number | null>(null);
+
+  const mappings = useMemo(
+    () => collectMIDIMappingSummary(transportBindings, markers),
+    [markers, transportBindings]
+  );
+  const learnDescription = describeMIDILearnTarget(learnTarget);
+
+  useEffect(() => () => {
+    if (previewResetTimeoutRef.current !== null) {
+      window.clearTimeout(previewResetTimeoutRef.current);
+    }
+  }, []);
+
+  const stopEventPropagation = (event: SyntheticEvent) => {
+    event.stopPropagation();
+  };
+
+  const flashPreviewState = (mappingId: string) => {
+    if (previewResetTimeoutRef.current !== null) {
+      window.clearTimeout(previewResetTimeoutRef.current);
+    }
+
+    setPreviewingMappingId(mappingId);
+    previewResetTimeoutRef.current = window.setTimeout(() => {
+      setPreviewingMappingId((current) => (current === mappingId ? null : current));
+      previewResetTimeoutRef.current = null;
+    }, 900);
+  };
+
+  const resolvePreviewMarkerTime = (mapping: MIDIMappingSummaryEntry): number | undefined => {
+    if (mapping.scope !== 'marker') {
+      return undefined;
+    }
+
+    if (draft?.mappingId === mapping.id) {
+      const draftMarkerId = draft.markerId ?? mapping.markerId;
+      return markers.find((marker) => marker.id === draftMarkerId)?.time;
+    }
+
+    return mapping.markerTime;
+  };
+
+  const previewMapping = (mapping: MIDIMappingSummaryEntry) => {
+    flashPreviewState(mapping.id);
+
+    if (mapping.scope === 'transport') {
+      void triggerMIDITransportAction(mapping.action as MIDITransportAction);
+      return;
+    }
+
+    const previewMarkerTime = resolvePreviewMarkerTime(mapping);
+    if (previewMarkerTime === undefined) {
+      return;
+    }
+
+    void triggerMarkerMIDIAction(mapping.action as MarkerMIDIAction, previewMarkerTime);
+  };
+
+  const handleMappingCardKeyDown = (
+    event: ReactKeyboardEvent<HTMLDivElement>,
+    mapping: MIDIMappingSummaryEntry
+  ) => {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return;
+    }
+
+    event.preventDefault();
+    previewMapping(mapping);
+  };
+
+  const openEditor = (mapping: MIDIMappingSummaryEntry) => {
+    setDraft({
+      mappingId: mapping.id,
+      channel: String(mapping.binding.channel),
+      note: String(mapping.binding.note),
+      markerId: mapping.markerId,
+    });
+  };
+
+  const closeEditor = () => {
+    setDraft(null);
+  };
+
+  const clearMapping = (mapping: MIDIMappingSummaryEntry) => {
+    if (mapping.scope === 'transport') {
+      setTransportMIDIBinding(mapping.action as MIDITransportAction, null);
+    } else if (mapping.markerId) {
+      setMarkerMIDIBinding(mapping.markerId, mapping.action as MarkerMIDIAction, null);
+    }
+
+    const sourceMarkerId =
+      learnTarget?.kind === 'marker'
+        ? learnTarget.sourceMarkerId ?? learnTarget.markerId
+        : null;
+    const isLearningCurrentMapping =
+      (learnTarget?.kind === 'transport'
+        && mapping.scope === 'transport'
+        && learnTarget.action === mapping.action)
+      || (
+        learnTarget?.kind === 'marker'
+        && mapping.scope === 'marker'
+        && learnTarget.action === mapping.action
+        && sourceMarkerId === mapping.markerId
+      );
+
+    if (isLearningCurrentMapping) {
+      cancelLearning();
+    }
+
+    if (draft?.mappingId === mapping.id) {
+      closeEditor();
+    }
+  };
+
+  const saveDraft = (mapping: MIDIMappingSummaryEntry) => {
+    if (!draft || draft.mappingId !== mapping.id) {
+      return;
+    }
+
+    const nextBinding = {
+      channel: clampInteger(draft.channel, mapping.binding.channel, 1, 16),
+      note: clampInteger(draft.note, mapping.binding.note, 0, 127),
+    };
+
+    if (mapping.scope === 'transport') {
+      setTransportMIDIBinding(mapping.action as MIDITransportAction, nextBinding);
+      closeEditor();
+      return;
+    }
+
+    const nextMarkerId = draft.markerId ?? mapping.markerId;
+    if (!nextMarkerId || !mapping.markerId) {
+      return;
+    }
+
+    if (nextMarkerId !== mapping.markerId) {
+      moveMarkerMIDIBinding({
+        fromMarkerId: mapping.markerId,
+        toMarkerId: nextMarkerId,
+        action: mapping.action as MarkerMIDIAction,
+        binding: nextBinding,
+      });
+    } else {
+      setMarkerMIDIBinding(nextMarkerId, mapping.action as MarkerMIDIAction, nextBinding);
+    }
+
+    closeEditor();
+  };
+
+  const startLearningForMapping = (mapping: MIDIMappingSummaryEntry) => {
+    if (mapping.scope === 'transport') {
+      startLearningTransportBinding(mapping.action as MIDITransportAction);
+      return;
+    }
+
+    const targetMarkerId =
+      draft?.mappingId === mapping.id
+        ? draft.markerId ?? mapping.markerId
+        : mapping.markerId;
+
+    if (!targetMarkerId || !mapping.markerId) {
+      return;
+    }
+
+    const marker = markers.find((candidate) => candidate.id === targetMarkerId);
+    startLearningMarkerBinding(
+      targetMarkerId,
+      marker?.label.trim() || 'Marker',
+      mapping.action as MarkerMIDIAction,
+      mapping.markerId
+    );
+  };
+
+  return (
+    <div className="midi-mapping-panel">
+      <div className="midi-mapping-header">
+        <div>
+          <h2>MIDI Mapping</h2>
+          <p>All assigned MIDI notes and their linked editor commands. Click a mapping card to preview its trigger.</p>
+        </div>
+        <div className="midi-mapping-status">
+          <span className={`midi-mapping-status-dot ${isEnabled && connectionStatus === 'connected' ? 'is-live' : ''}`} />
+          <span>
+            {isEnabled ? 'MIDI On' : 'MIDI Off'}
+            {devices.length > 0 ? `, ${devices.length} device${devices.length > 1 ? 's' : ''}` : ''}
+          </span>
+        </div>
+      </div>
+
+      {learnDescription && (
+        <div className="midi-mapping-learn-banner">
+          <span>{learnDescription}</span>
+          <button className="settings-button" onClick={cancelLearning}>
+            Cancel Learn
+          </button>
+        </div>
+      )}
+
+      {mappings.length === 0 ? (
+        <MIDIMappingEmptyState isEnabled={isEnabled} />
+      ) : (
+        <div className="midi-mapping-list">
+          {mappings.map((mapping) => {
+            const isEditing = draft?.mappingId === mapping.id;
+            const channelValue = isEditing ? draft.channel : String(mapping.binding.channel);
+            const noteValue = isEditing ? draft.note : String(mapping.binding.note);
+            const selectedMarkerId = isEditing ? draft.markerId ?? mapping.markerId : mapping.markerId;
+            const isPreviewable = mapping.scope === 'transport' || mapping.markerTime !== undefined;
+            const notePreview = getMIDINoteName(
+              clampInteger(noteValue, mapping.binding.note, 0, 127)
+            );
+            const sourceMarkerId =
+              learnTarget?.kind === 'marker'
+                ? learnTarget.sourceMarkerId ?? learnTarget.markerId
+                : null;
+            const isLearningCurrentMapping =
+              (learnTarget?.kind === 'transport'
+                && mapping.scope === 'transport'
+                && learnTarget.action === mapping.action)
+              || (
+                learnTarget?.kind === 'marker'
+                && mapping.scope === 'marker'
+                && learnTarget.action === mapping.action
+                && sourceMarkerId === mapping.markerId
+              );
+
+            return (
+              <div
+                key={mapping.id}
+                className={`midi-mapping-card${isPreviewable && !isEditing ? ' is-clickable' : ''}${previewingMappingId === mapping.id ? ' is-previewing' : ''}`}
+                role={isPreviewable && !isEditing ? 'button' : undefined}
+                tabIndex={isPreviewable && !isEditing ? 0 : undefined}
+                onClick={isPreviewable && !isEditing ? () => previewMapping(mapping) : undefined}
+                onKeyDown={isPreviewable && !isEditing ? (event) => handleMappingCardKeyDown(event, mapping) : undefined}
+                aria-label={isPreviewable && !isEditing ? `Preview ${mapping.actionLabel}` : undefined}
+              >
+                <div className="midi-mapping-card-top">
+                  <span className="midi-mapping-binding">{mapping.bindingLabel}</span>
+                  <span className={`midi-mapping-scope midi-mapping-scope-${mapping.scope}`}>
+                    {mapping.scope === 'transport' ? 'Transport' : 'Marker'}
+                  </span>
+                </div>
+                <div className="midi-mapping-card-main">
+                  <strong>{mapping.actionLabel}</strong>
+                  <span>{mapping.targetLabel}</span>
+                </div>
+                <div className="midi-mapping-card-footer">
+                  <span>{mapping.behaviorLabel}</span>
+                  {!isEditing && (
+                    <div
+                      className="midi-mapping-card-actions"
+                      onClick={stopEventPropagation}
+                      onKeyDown={stopEventPropagation}
+                    >
+                      <button className="settings-button" onClick={() => openEditor(mapping)}>
+                        Edit
+                      </button>
+                      <button className="settings-button" onClick={() => startLearningForMapping(mapping)}>
+                        {isLearningCurrentMapping ? 'Listening...' : 'Learn'}
+                      </button>
+                      <button className="settings-button" onClick={() => clearMapping(mapping)}>
+                        Clear
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                {isEditing && (
+                  <div
+                    className="midi-mapping-editor"
+                    onClick={stopEventPropagation}
+                    onKeyDown={stopEventPropagation}
+                  >
+                    <div className="midi-mapping-editor-grid">
+                      <label className="midi-mapping-field">
+                        <span>Channel</span>
+                        <input
+                          type="number"
+                          min={1}
+                          max={16}
+                          value={channelValue}
+                          onChange={(event) => {
+                            const value = event.target.value;
+                            setDraft((currentDraft) => currentDraft && currentDraft.mappingId === mapping.id
+                              ? { ...currentDraft, channel: value }
+                              : currentDraft
+                            );
+                          }}
+                        />
+                      </label>
+
+                      <label className="midi-mapping-field">
+                        <span>Note</span>
+                        <input
+                          type="number"
+                          min={0}
+                          max={127}
+                          value={noteValue}
+                          onChange={(event) => {
+                            const value = event.target.value;
+                            setDraft((currentDraft) => currentDraft && currentDraft.mappingId === mapping.id
+                              ? { ...currentDraft, note: value }
+                              : currentDraft
+                            );
+                          }}
+                        />
+                        <small>{notePreview}</small>
+                      </label>
+
+                      {mapping.scope === 'marker' && (
+                        <label className="midi-mapping-field midi-mapping-field-wide">
+                          <span>Marker</span>
+                          <select
+                            value={selectedMarkerId ?? ''}
+                            onChange={(event) => {
+                              const value = event.target.value;
+                              setDraft((currentDraft) => currentDraft && currentDraft.mappingId === mapping.id
+                                ? { ...currentDraft, markerId: value }
+                                : currentDraft
+                              );
+                            }}
+                          >
+                            {markers.map((marker) => (
+                              <option key={marker.id} value={marker.id}>
+                                {getMarkerTargetLabel(marker)}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      )}
+                    </div>
+
+                    <div className="midi-mapping-editor-actions">
+                      <button className="settings-button" onClick={() => saveDraft(mapping)}>
+                        Save
+                      </button>
+                      <button className="settings-button" onClick={() => previewMapping(mapping)}>
+                        Trigger
+                      </button>
+                      <button className="settings-button" onClick={() => startLearningForMapping(mapping)}>
+                        {isLearningCurrentMapping ? 'Listening...' : 'Learn'}
+                      </button>
+                      <button className="settings-button" onClick={() => clearMapping(mapping)}>
+                        Clear
+                      </button>
+                      <button className="settings-button" onClick={closeEditor}>
+                        Cancel
+                      </button>
+                    </div>
+
+                    <p className="midi-mapping-editor-hint">
+                      Notes stay unique across transport and marker mappings. Saving or learning here replaces any existing assignment using the same channel and note.
+                    </p>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/panels/index.ts
+++ b/src/components/panels/index.ts
@@ -8,5 +8,6 @@ export { AnalysisPanel } from './AnalysisPanel';
 export { AIChatPanel } from './AIChatPanel';
 export { AIVideoPanel } from './AIVideoPanel';
 export { DownloadPanel } from './DownloadPanel';
+export { MIDIMappingPanel } from './MIDIMappingPanel';
 export { TransitionsPanel } from './TransitionsPanel';
 export { SceneDescriptionPanel } from './SceneDescriptionPanel';

--- a/src/components/timeline/MarkerContextMenu.tsx
+++ b/src/components/timeline/MarkerContextMenu.tsx
@@ -1,0 +1,260 @@
+import { useEffect } from 'react';
+import type { TimelineMarker } from '../../stores/timeline/types';
+import { useContextMenuPosition } from '../../hooks/useContextMenuPosition';
+import { useMIDI } from '../../hooks/useMIDI';
+import { formatMIDINoteBinding } from '../../types/midi';
+import {
+  jumpToMarkerAndStopTime,
+  jumpToMarkerTime,
+  playFromMarkerTime,
+} from '../../services/midi/midiCommands';
+
+export interface MarkerContextMenuState {
+  x: number;
+  y: number;
+  markerId: string;
+}
+
+interface MarkerContextMenuProps {
+  menu: MarkerContextMenuState | null;
+  markers: TimelineMarker[];
+  updateMarker: (markerId: string, updates: Partial<Omit<TimelineMarker, 'id'>>) => void;
+  removeMarker: (markerId: string) => void;
+  onClose: () => void;
+}
+
+export function MarkerContextMenu({
+  menu,
+  markers,
+  updateMarker,
+  removeMarker,
+  onClose,
+}: MarkerContextMenuProps) {
+  const { menuRef, adjustedPosition } = useContextMenuPosition(menu);
+  const {
+    learnTarget,
+    startLearningMarkerBinding,
+    cancelLearning,
+  } = useMIDI();
+
+  const marker = menu ? markers.find((candidate) => candidate.id === menu.markerId) ?? null : null;
+  const playBinding = marker?.midiBindings?.find((binding) => binding.action === 'playFromMarker') ?? null;
+  const jumpBinding = marker?.midiBindings?.find((binding) => binding.action === 'jumpToMarker') ?? null;
+  const jumpStopBinding = marker?.midiBindings?.find((binding) => binding.action === 'jumpToMarkerAndStop') ?? null;
+  const isLearningThisMarker = learnTarget?.kind === 'marker' && learnTarget.markerId === marker?.id;
+
+  useEffect(() => {
+    if (!menu) {
+      return;
+    }
+
+    const handleClickOutside = () => onClose();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    const timeoutId = setTimeout(() => {
+      window.addEventListener('click', handleClickOutside);
+    }, 0);
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      clearTimeout(timeoutId);
+      window.removeEventListener('click', handleClickOutside);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [menu, onClose]);
+
+  if (!menu || !marker) {
+    return null;
+  }
+
+  const setMarkerBinding = (
+    action: 'playFromMarker' | 'jumpToMarker' | 'jumpToMarkerAndStop',
+    binding: typeof playBinding | null
+  ) => {
+    const existingBindings = marker.midiBindings ?? [];
+    const nextBindings = binding
+      ? [...existingBindings.filter((candidate) => candidate.action !== action), binding]
+      : existingBindings.filter((candidate) => candidate.action !== action);
+
+    updateMarker(marker.id, {
+      midiBindings: nextBindings.length > 0 ? nextBindings : undefined,
+    });
+  };
+
+  return (
+    <div
+      ref={menuRef}
+      className="timeline-context-menu"
+      style={{
+        position: 'fixed',
+        left: adjustedPosition?.x ?? menu.x,
+        top: adjustedPosition?.y ?? menu.y,
+        zIndex: 10000,
+      }}
+      onClick={(event) => event.stopPropagation()}
+      onContextMenu={(event) => event.preventDefault()}
+    >
+      <div
+        className="context-menu-item"
+        onClick={() => {
+          void jumpToMarkerTime(marker.time);
+          onClose();
+        }}
+      >
+        Jump To Marker
+      </div>
+      <div
+        className="context-menu-item"
+        onClick={() => {
+          void playFromMarkerTime(marker.time);
+          onClose();
+        }}
+      >
+        Play From Marker
+      </div>
+      <div
+        className="context-menu-item"
+        onClick={() => {
+          void jumpToMarkerAndStopTime(marker.time);
+          onClose();
+        }}
+      >
+        Jump To Marker And Stop
+      </div>
+
+      <div className="context-menu-separator" />
+
+      <div
+        className="context-menu-item"
+        onClick={() => {
+          updateMarker(marker.id, {
+            stopPlayback: !marker.stopPlayback,
+          });
+          onClose();
+        }}
+      >
+        {marker.stopPlayback ? 'Disable Stop Marker' : 'Enable Stop Marker'}
+      </div>
+
+      {marker.stopPlayback && (
+        <div className="context-menu-item disabled">
+          Playback stops automatically when the playhead crosses this marker.
+        </div>
+      )}
+
+      <div className="context-menu-separator" />
+
+      <div
+        className="context-menu-item"
+        onClick={() => {
+          startLearningMarkerBinding(marker.id, marker.label || 'Marker', 'jumpToMarker');
+          onClose();
+        }}
+      >
+        Learn MIDI Note: Jump To Marker
+      </div>
+      <div
+        className="context-menu-item"
+        onClick={() => {
+          startLearningMarkerBinding(marker.id, marker.label || 'Marker', 'playFromMarker');
+          onClose();
+        }}
+      >
+        Learn MIDI Note: Play From Marker
+      </div>
+      <div
+        className="context-menu-item"
+        onClick={() => {
+          startLearningMarkerBinding(marker.id, marker.label || 'Marker', 'jumpToMarkerAndStop');
+          onClose();
+        }}
+      >
+        Learn MIDI Note: Jump To Marker And Stop
+      </div>
+
+      {isLearningThisMarker && (
+        <div
+          className="context-menu-item"
+          onClick={() => {
+            cancelLearning();
+            onClose();
+          }}
+        >
+          Cancel MIDI Learn
+        </div>
+      )}
+
+      {(jumpBinding || playBinding || jumpStopBinding) && <div className="context-menu-separator" />}
+
+      {jumpBinding && (
+        <>
+          <div className="context-menu-item disabled">
+            Jump To Marker: {formatMIDINoteBinding(jumpBinding)}
+          </div>
+          <div
+            className="context-menu-item"
+            onClick={() => {
+              setMarkerBinding('jumpToMarker', null);
+              onClose();
+            }}
+          >
+            Clear Jump Binding
+          </div>
+        </>
+      )}
+
+      {jumpStopBinding && (
+        <>
+          <div className="context-menu-item disabled">
+            Jump To Marker And Stop: {formatMIDINoteBinding(jumpStopBinding)}
+          </div>
+          <div
+            className="context-menu-item"
+            onClick={() => {
+              setMarkerBinding('jumpToMarkerAndStop', null);
+              onClose();
+            }}
+          >
+            Clear Jump And Stop Binding
+          </div>
+        </>
+      )}
+
+      {playBinding && (
+        <>
+          <div className="context-menu-item disabled">
+            Play From Marker: {formatMIDINoteBinding(playBinding)}
+          </div>
+          <div
+            className="context-menu-item"
+            onClick={() => {
+              setMarkerBinding('playFromMarker', null);
+              onClose();
+            }}
+          >
+            Clear Play Binding
+          </div>
+        </>
+      )}
+
+      <div className="context-menu-separator" />
+
+      <div
+        className="context-menu-item danger"
+        onClick={() => {
+          if (isLearningThisMarker) {
+            cancelLearning();
+          }
+          removeMarker(marker.id);
+          onClose();
+        }}
+      >
+        Delete Marker
+      </div>
+    </div>
+  );
+}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -20,6 +20,7 @@ import { TimelineRuler } from './TimelineRuler';
 import { TimelineControls } from './TimelineControls';
 import { TimelineHeader } from './TimelineHeader';
 import { TrackContextMenu, type TrackContextMenuState } from './TrackContextMenu';
+import { MarkerContextMenu, type MarkerContextMenuState } from './MarkerContextMenu';
 import { TimelineTrack } from './TimelineTrack';
 import { TimelineClip } from './TimelineClip';
 import { TimelineKeyframes } from './TimelineKeyframes';
@@ -140,7 +141,7 @@ export function Timeline() {
   const { setToolMode, toggleCutTool, toggleThumbnailsEnabled, toggleWaveformsEnabled } = store;
 
   // Marker actions
-  const { addMarker, moveMarker, removeMarker } = store;
+  const { addMarker, moveMarker, removeMarker, updateMarker } = store;
 
   // Clipboard actions
   const { copyClips, pasteClips, copyKeyframes, pasteKeyframes } = store;
@@ -337,6 +338,9 @@ export function Timeline() {
 
   // Context menu state for track header right-click
   const [trackContextMenu, setTrackContextMenu] = useState<TrackContextMenuState | null>(null);
+
+  // Context menu state for marker right-click
+  const [markerContextMenu, setMarkerContextMenu] = useState<MarkerContextMenuState | null>(null);
 
   // Transcript markers visibility toggle (from store for persistence)
   const showTranscriptMarkers = useTimelineStore(s => s.showTranscriptMarkers);
@@ -1293,20 +1297,24 @@ export function Timeline() {
           {markers.map(marker => (
             <div
               key={marker.id}
-              className={`timeline-marker ${timelineMarkerDrag?.markerId === marker.id ? 'dragging' : ''} ${aiAnimatedMarkers.get(marker.id) === 'add' ? 'ai-marker-added' : aiAnimatedMarkers.get(marker.id) === 'remove' ? 'ai-marker-removed' : ''}`}
+              className={`timeline-marker ${marker.stopPlayback ? 'is-stop-marker' : ''} ${timelineMarkerDrag?.markerId === marker.id ? 'dragging' : ''} ${aiAnimatedMarkers.get(marker.id) === 'add' ? 'ai-marker-added' : aiAnimatedMarkers.get(marker.id) === 'remove' ? 'ai-marker-removed' : ''}`}
               style={{
                 left: timeToPixel(marker.time) - scrollX + 150,
                 '--marker-color': marker.color,
               } as React.CSSProperties}
-              title={`${marker.label || 'Marker'}: ${formatTime(marker.time)} (drag to move, right-click to delete)`}
+              title={`${marker.stopPlayback ? 'Stop Marker' : (marker.label || 'Marker')}: ${formatTime(marker.time)} (drag to move, right-click for MIDI and transport actions)${marker.stopPlayback ? ' - playback stops automatically here' : ''}`}
               onMouseDown={(e) => handleTimelineMarkerMouseDown(e, marker.id)}
               onContextMenu={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                removeMarker(marker.id);
+                setMarkerContextMenu({
+                  x: e.clientX,
+                  y: e.clientY,
+                  markerId: marker.id,
+                });
               }}
             >
-              <div className="timeline-marker-head">M</div>
+              <div className="timeline-marker-head">{marker.stopPlayback ? 'S' : 'M'}</div>
               <div className="timeline-marker-line" />
             </div>
           ))}
@@ -1371,6 +1379,14 @@ export function Timeline() {
       <TrackContextMenu
         menu={trackContextMenu}
         onClose={() => setTrackContextMenu(null)}
+      />
+
+      <MarkerContextMenu
+        menu={markerContextMenu}
+        markers={markers}
+        updateMarker={updateMarker}
+        removeMarker={removeMarker}
+        onClose={() => setMarkerContextMenu(null)}
       />
 
       {/* Multicam Dialog */}

--- a/src/components/timeline/hooks/useMarkerDrag.ts
+++ b/src/components/timeline/hooks/useMarkerDrag.ts
@@ -75,6 +75,10 @@ export function useMarkerDrag({
 
   // Handle timeline marker drag start
   const handleTimelineMarkerMouseDown = useCallback((e: React.MouseEvent, markerId: string) => {
+    if (e.button !== 0) {
+      return;
+    }
+
     e.preventDefault();
     e.stopPropagation();
     const marker = markers.find(m => m.id === markerId);

--- a/src/components/timeline/hooks/usePlaybackLoop.ts
+++ b/src/components/timeline/hooks/usePlaybackLoop.ts
@@ -6,6 +6,7 @@ import {
   clearInternalPlaybackHold,
   playheadState,
 } from '../../../services/layerBuilder';
+import { findStopMarkerInPlaybackRange } from '../../../services/timeline/stopMarkers';
 
 interface UsePlaybackLoopProps {
   isPlaying: boolean;
@@ -41,6 +42,20 @@ export function usePlaybackLoop({ isPlaying }: UsePlaybackLoopProps) {
     playheadState.isUsingInternalPosition = true;
     playheadState.playbackJustStarted = true; // Signal for initial audio sync
 
+    const stopPlaybackAt = (position: number) => {
+      const timelineStore = useTimelineStore.getState();
+      timelineStore.pause();
+      clearInternalPlaybackHold();
+      playheadState.position = position;
+      playheadState.isUsingInternalPosition = false;
+      playheadState.hasMasterAudio = false;
+      playheadState.masterAudioElement = null;
+      useTimelineStore.setState({
+        playheadPosition: position,
+        playbackSpeed: 1,
+      });
+    };
+
     const updatePlayhead = (currentTime: number) => {
       try {
         const state = useTimelineStore.getState();
@@ -51,10 +66,12 @@ export function usePlaybackLoop({ isPlaying }: UsePlaybackLoopProps) {
           loopPlayback: lp,
           pause: ps,
           clips,
+          markers,
           playbackSpeed,
         } = state;
         const effectiveEnd = op !== null ? op : dur;
         const effectiveStart = ip !== null ? ip : 0;
+        const previousPosition = playheadState.position;
 
         let newPosition: number;
         const heldPlaybackPosition = playheadState.heldPlaybackPosition;
@@ -89,6 +106,12 @@ export function usePlaybackLoop({ isPlaying }: UsePlaybackLoopProps) {
         }
         lastTime = currentTime;
 
+        const stopMarker = findStopMarkerInPlaybackRange(markers, previousPosition, newPosition);
+        if (stopMarker) {
+          stopPlaybackAt(stopMarker.time);
+          return;
+        }
+
         // Handle end of timeline / looping (forward playback)
         if (newPosition >= effectiveEnd && playbackSpeed > 0) {
           if (lp) {
@@ -110,13 +133,7 @@ export function usePlaybackLoop({ isPlaying }: UsePlaybackLoopProps) {
           } else {
             newPosition = effectiveEnd;
             ps();
-            // Reset playback speed to normal when stopping
-            useTimelineStore.setState({ playbackSpeed: 1 });
-            playheadState.position = newPosition;
-            playheadState.isUsingInternalPosition = false;
-            playheadState.hasMasterAudio = false;
-            playheadState.masterAudioElement = null;
-            useTimelineStore.setState({ playheadPosition: newPosition });
+            stopPlaybackAt(newPosition);
             return;
           }
         }
@@ -142,13 +159,7 @@ export function usePlaybackLoop({ isPlaying }: UsePlaybackLoopProps) {
           } else {
             newPosition = effectiveStart;
             ps();
-            // Reset playback speed to normal when stopping
-            useTimelineStore.setState({ playbackSpeed: 1 });
-            playheadState.position = newPosition;
-            playheadState.isUsingInternalPosition = false;
-            playheadState.hasMasterAudio = false;
-            playheadState.masterAudioElement = null;
-            useTimelineStore.setState({ playheadPosition: newPosition });
+            stopPlaybackAt(newPosition);
             return;
           }
         }

--- a/src/hooks/useMIDI.ts
+++ b/src/hooks/useMIDI.ts
@@ -1,117 +1,162 @@
-// MIDI input hook - simplified version (VJ layer control removed)
+import { useCallback, useEffect, useState } from 'react';
+import { useMIDIStore } from '../stores/midiStore';
+import type {
+  MIDILearnTarget,
+  MIDINoteBinding,
+  MIDIPermissionState,
+  MIDITransportAction,
+  MarkerMIDIAction,
+} from '../types/midi';
 
-import { useEffect, useState, useCallback } from 'react';
-import { Logger } from '../services/logger';
+type MIDIPermissionDescriptor = PermissionDescriptor & {
+  name: 'midi';
+  sysex?: boolean;
+};
 
-const log = Logger.create('MIDI');
+async function queryMIDIPermissionState(): Promise<MIDIPermissionState> {
+  if (!navigator.requestMIDIAccess) {
+    return 'unsupported';
+  }
 
-interface MIDIDevice {
-  id: string;
-  name: string;
-  manufacturer: string;
+  if (!navigator.permissions?.query) {
+    return 'unknown';
+  }
+
+  try {
+    const status = await navigator.permissions.query({
+      name: 'midi',
+      sysex: false,
+    } as MIDIPermissionDescriptor);
+    return status.state;
+  } catch {
+    return 'unknown';
+  }
 }
 
 export function useMIDI() {
-  const [midiAccess, setMidiAccess] = useState<MIDIAccess | null>(null);
-  const [devices, setDevices] = useState<MIDIDevice[]>([]);
-  const [isSupported, setIsSupported] = useState(false);
-  const [isEnabled, setIsEnabled] = useState(false);
-  const [lastMessage, setLastMessage] = useState<{
-    channel: number;
-    control: number;
-    value: number;
-  } | null>(null);
+  const {
+    isSupported,
+    isEnabled,
+    connectionStatus,
+    connectionError,
+    devices,
+    lastMessage,
+    learnTarget,
+    transportBindings,
+    setSupported,
+    setEnabled,
+    setConnectionStatus,
+    setTransportBinding,
+    startLearning,
+    cancelLearning,
+  } = useMIDIStore();
+  const [permissionState, setPermissionState] = useState<MIDIPermissionState | null>(null);
 
-  // Check MIDI support and request access
   useEffect(() => {
-    if (!navigator.requestMIDIAccess) {
-      setIsSupported(false);
-      return;
-    }
+    let cancelled = false;
 
-    setIsSupported(true);
-
-    if (!isEnabled) return;
-
-    navigator.requestMIDIAccess().then(
-      (access) => {
-        setMidiAccess(access);
-
-        // Get input devices
-        const inputDevices: MIDIDevice[] = [];
-        access.inputs.forEach((input) => {
-          inputDevices.push({
-            id: input.id,
-            name: input.name || 'Unknown',
-            manufacturer: input.manufacturer || 'Unknown',
-          });
-        });
-        setDevices(inputDevices);
-
-        // Listen for device changes
-        access.onstatechange = () => {
-          const newDevices: MIDIDevice[] = [];
-          access.inputs.forEach((input) => {
-            newDevices.push({
-              id: input.id,
-              name: input.name || 'Unknown',
-              manufacturer: input.manufacturer || 'Unknown',
-            });
-          });
-          setDevices(newDevices);
-        };
-      },
-      (error) => {
-        log.error('MIDI access denied', error);
-        setIsSupported(false);
+    const loadPermissionState = async () => {
+      const nextState = await queryMIDIPermissionState();
+      if (!cancelled) {
+        setPermissionState(nextState);
       }
-    );
-  }, [isEnabled]);
-
-  // Handle MIDI messages (just log them for now - can be extended later)
-  useEffect(() => {
-    if (!midiAccess || !isEnabled) return;
-
-    const handleMIDIMessage = (event: MIDIMessageEvent) => {
-      const [status, control, value] = event.data as Uint8Array;
-      const channel = status & 0x0f;
-      const messageType = status & 0xf0;
-
-      // Only handle Control Change messages (0xB0)
-      if (messageType !== 0xb0) return;
-
-      setLastMessage({ channel, control, value });
-      // MIDI mappings can be implemented here in the future
     };
 
-    // Attach listeners to all inputs
-    midiAccess.inputs.forEach((input) => {
-      input.onmidimessage = handleMIDIMessage;
-    });
+    void loadPermissionState();
 
     return () => {
-      midiAccess.inputs.forEach((input) => {
-        input.onmidimessage = null;
-      });
+      cancelled = true;
     };
-  }, [midiAccess, isEnabled]);
+  }, [connectionStatus, isEnabled]);
 
-  const enableMIDI = useCallback(() => {
-    setIsEnabled(true);
-  }, []);
+  const enableMIDI = useCallback(async () => {
+    if (!navigator.requestMIDIAccess) {
+      setPermissionState('unsupported');
+      setSupported(false);
+      setEnabled(false);
+      setConnectionStatus('error', 'Web MIDI API is not supported in this browser.');
+      return false;
+    }
+
+    const currentPermissionState = await queryMIDIPermissionState();
+    setPermissionState(currentPermissionState);
+    setSupported(true);
+
+    if (currentPermissionState === 'denied') {
+      setEnabled(false);
+      setConnectionStatus('error', 'Browser MIDI permission is blocked for this site.');
+      return false;
+    }
+
+    setConnectionStatus('requesting');
+
+    try {
+      await navigator.requestMIDIAccess();
+      setPermissionState(await queryMIDIPermissionState());
+      setEnabled(true);
+      return true;
+    } catch (error) {
+      const nextPermissionState = await queryMIDIPermissionState();
+      setPermissionState(nextPermissionState);
+      setEnabled(false);
+      setConnectionStatus(
+        'error',
+        nextPermissionState === 'denied'
+          ? 'Browser MIDI permission is blocked for this site.'
+          : error instanceof Error
+            ? error.message
+            : 'Failed to access MIDI devices.'
+      );
+      return false;
+    }
+  }, [setConnectionStatus, setEnabled, setSupported]);
 
   const disableMIDI = useCallback(() => {
-    setIsEnabled(false);
-    setMidiAccess(null);
-    setDevices([]);
-  }, []);
+    setEnabled(false);
+    cancelLearning();
+  }, [cancelLearning, setEnabled]);
+
+  const startLearningTransportBinding = useCallback((action: MIDITransportAction) => {
+    startLearning({
+      kind: 'transport',
+      action,
+    });
+  }, [startLearning]);
+
+  const startLearningMarkerBinding = useCallback((
+    markerId: string,
+    markerLabel: string,
+    action: MarkerMIDIAction,
+    sourceMarkerId?: string
+  ) => {
+    startLearning({
+      kind: 'marker',
+      markerId,
+      markerLabel,
+      action,
+      sourceMarkerId,
+    });
+  }, [startLearning]);
+
+  const clearTransportBinding = useCallback((action: MIDITransportAction) => {
+    setTransportBinding(action, null);
+  }, [setTransportBinding]);
 
   return {
     isSupported,
     isEnabled,
+    connectionStatus,
+    connectionError,
+    permissionState,
     devices,
     lastMessage,
+    learnTarget: learnTarget as MIDILearnTarget | null,
+    transportBindings: transportBindings as Record<MIDITransportAction, MIDINoteBinding | null>,
     enableMIDI,
     disableMIDI,
+    startLearningTransportBinding,
+    startLearningMarkerBinding,
+    clearTransportBinding,
+    cancelLearning,
   };
 }

--- a/src/hooks/useMIDIRuntime.ts
+++ b/src/hooks/useMIDIRuntime.ts
@@ -1,0 +1,195 @@
+import { useEffect } from 'react';
+import { useTimelineStore } from '../stores/timeline';
+import { useMIDIStore } from '../stores/midiStore';
+import {
+  getMIDINoteName,
+  midiBindingsMatch,
+  type MIDIDeviceInfo,
+  type MIDINoteBinding,
+} from '../types/midi';
+import {
+  triggerMarkerMIDIBinding,
+  triggerMIDITransportAction,
+} from '../services/midi/midiCommands';
+import {
+  moveMarkerMIDIBinding,
+  setMarkerMIDIBinding,
+  setTransportMIDIBinding,
+} from '../services/midi/midiBindingMutations';
+
+function buildDeviceList(access: MIDIAccess): MIDIDeviceInfo[] {
+  const devices: MIDIDeviceInfo[] = [];
+
+  access.inputs.forEach((input) => {
+    devices.push({
+      id: input.id,
+      name: input.name || 'Unknown',
+      manufacturer: input.manufacturer || 'Unknown',
+    });
+  });
+
+  return devices;
+}
+
+export function useMIDIRuntime() {
+  const isEnabled = useMIDIStore((state) => state.isEnabled);
+
+  useEffect(() => {
+    if (!navigator.requestMIDIAccess) {
+      useMIDIStore.getState().setSupported(false);
+      return;
+    }
+
+    useMIDIStore.getState().setSupported(true);
+
+    if (!isEnabled) {
+      useMIDIStore.getState().resetRuntimeState();
+      return;
+    }
+
+    let cancelled = false;
+    let midiAccess: MIDIAccess | null = null;
+
+    const attachInputListeners = (access: MIDIAccess) => {
+      const handleMessage = (event: MIDIMessageEvent) => {
+        const [status = 0, data1 = 0, data2 = 0] = Array.from(event.data ?? []);
+        const messageType = status & 0xf0;
+        const channel = (status & 0x0f) + 1;
+
+        if (messageType === 0x90 && data2 > 0) {
+          const learnedBinding: MIDINoteBinding = {
+            channel,
+            note: data1,
+          };
+
+          useMIDIStore.getState().setLastMessage({
+            channel,
+            type: 'note-on',
+            note: data1,
+            noteName: getMIDINoteName(data1),
+            velocity: data2,
+          });
+
+          const midiStore = useMIDIStore.getState();
+          const learnTarget = midiStore.learnTarget;
+          if (learnTarget) {
+            if (learnTarget.kind === 'transport') {
+              setTransportMIDIBinding(learnTarget.action, learnedBinding);
+            } else {
+              if (learnTarget.sourceMarkerId && learnTarget.sourceMarkerId !== learnTarget.markerId) {
+                moveMarkerMIDIBinding({
+                  fromMarkerId: learnTarget.sourceMarkerId,
+                  toMarkerId: learnTarget.markerId,
+                  action: learnTarget.action,
+                  binding: learnedBinding,
+                });
+              } else {
+                setMarkerMIDIBinding(
+                  learnTarget.markerId,
+                  learnTarget.action,
+                  learnedBinding
+                );
+              }
+            }
+            midiStore.cancelLearning();
+            return;
+          }
+
+          const matchedTransportAction = (Object.entries(midiStore.transportBindings) as Array<[
+            'playPause' | 'stop',
+            MIDINoteBinding | null,
+          ]>).find(([, binding]) => binding && midiBindingsMatch(binding, learnedBinding))?.[0];
+
+          if (matchedTransportAction) {
+            void triggerMIDITransportAction(matchedTransportAction);
+            return;
+          }
+
+          const markerBinding = useTimelineStore.getState().markers
+            .flatMap((marker) => marker.midiBindings ?? [])
+            .find((binding) => midiBindingsMatch(binding, learnedBinding));
+
+          if (markerBinding) {
+            void triggerMarkerMIDIBinding(markerBinding);
+          }
+          return;
+        }
+
+        if (messageType === 0x80 || (messageType === 0x90 && data2 === 0)) {
+          useMIDIStore.getState().setLastMessage({
+            channel,
+            type: 'note-off',
+            note: data1,
+            noteName: getMIDINoteName(data1),
+            velocity: data2,
+          });
+          return;
+        }
+
+        if (messageType === 0xb0) {
+          useMIDIStore.getState().setLastMessage({
+            channel,
+            type: 'control-change',
+            control: data1,
+            value: data2,
+          });
+        }
+      };
+
+      access.inputs.forEach((input) => {
+        input.onmidimessage = handleMessage;
+      });
+    };
+
+    const refreshDevices = (access: MIDIAccess) => {
+      useMIDIStore.getState().setDevices(buildDeviceList(access));
+      attachInputListeners(access);
+    };
+
+    useMIDIStore.getState().setConnectionStatus('requesting');
+
+    navigator.requestMIDIAccess().then(
+      (access) => {
+        if (cancelled) {
+          access.inputs.forEach((input) => {
+            input.onmidimessage = null;
+          });
+          return;
+        }
+
+        midiAccess = access;
+        useMIDIStore.getState().setConnectionStatus('connected');
+        refreshDevices(access);
+
+        access.onstatechange = () => {
+          if (!cancelled) {
+            refreshDevices(access);
+          }
+        };
+      },
+      (error) => {
+        if (cancelled) {
+          return;
+        }
+
+        useMIDIStore.getState().setConnectionStatus(
+          'error',
+          error instanceof Error ? error.message : 'Failed to access MIDI devices.'
+        );
+      }
+    );
+
+    return () => {
+      cancelled = true;
+
+      if (midiAccess) {
+        midiAccess.onstatechange = null;
+        midiAccess.inputs.forEach((input) => {
+          input.onmidimessage = null;
+        });
+      }
+
+      useMIDIStore.getState().setDevices([]);
+    };
+  }, [isEnabled]);
+}

--- a/src/services/midi/midiBindingMutations.ts
+++ b/src/services/midi/midiBindingMutations.ts
@@ -1,0 +1,123 @@
+import { useMIDIStore } from '../../stores/midiStore';
+import { useTimelineStore } from '../../stores/timeline';
+import type {
+  MarkerMIDIBinding,
+  MarkerMIDIAction,
+  MIDINoteBinding,
+  MIDITransportAction,
+} from '../../types/midi';
+import { midiBindingsMatch } from '../../types/midi';
+
+interface ConflictOptions {
+  transportAction?: MIDITransportAction;
+  markerId?: string;
+  markerAction?: MarkerMIDIAction;
+}
+
+function updateMarkerBindings(markerId: string, bindings: MarkerMIDIBinding[]): void {
+  useTimelineStore.getState().updateMarker(markerId, {
+    midiBindings: bindings.length > 0 ? bindings : undefined,
+  });
+}
+
+export function removeConflictingMIDIBinding(
+  binding: MIDINoteBinding,
+  options?: ConflictOptions
+): void {
+  const midiStore = useMIDIStore.getState();
+  const timelineStore = useTimelineStore.getState();
+
+  const transportBindings = midiStore.transportBindings;
+  (Object.keys(transportBindings) as MIDITransportAction[]).forEach((action) => {
+    const existingBinding = transportBindings[action];
+    const isSameTarget = options?.transportAction === action;
+    if (existingBinding && !isSameTarget && midiBindingsMatch(existingBinding, binding)) {
+      midiStore.setTransportBinding(action, null);
+    }
+  });
+
+  timelineStore.markers.forEach((marker) => {
+    if (!marker.midiBindings || marker.midiBindings.length === 0) {
+      return;
+    }
+
+    const nextBindings = marker.midiBindings.filter((existingBinding) => {
+      const isSameTarget =
+        options?.markerId === marker.id && options?.markerAction === existingBinding.action;
+
+      if (isSameTarget) {
+        return true;
+      }
+
+      return !midiBindingsMatch(existingBinding, binding);
+    });
+
+    if (nextBindings.length !== marker.midiBindings.length) {
+      updateMarkerBindings(marker.id, nextBindings);
+    }
+  });
+}
+
+export function setTransportMIDIBinding(
+  action: MIDITransportAction,
+  binding: MIDINoteBinding | null
+): void {
+  const midiStore = useMIDIStore.getState();
+
+  if (!binding) {
+    midiStore.setTransportBinding(action, null);
+    return;
+  }
+
+  removeConflictingMIDIBinding(binding, { transportAction: action });
+  midiStore.setTransportBinding(action, binding);
+}
+
+export function setMarkerMIDIBinding(
+  markerId: string,
+  action: MarkerMIDIAction,
+  binding: MIDINoteBinding | null
+): void {
+  const getMarker = () => useTimelineStore.getState().markers.find((candidate) => candidate.id === markerId);
+  const marker = getMarker();
+  if (!marker) {
+    return;
+  }
+
+  if (!binding) {
+    const nextBindings = (marker.midiBindings ?? []).filter((existingBinding) => existingBinding.action !== action);
+    updateMarkerBindings(markerId, nextBindings);
+    return;
+  }
+
+  removeConflictingMIDIBinding(binding, {
+    markerId,
+    markerAction: action,
+  });
+
+  const nextBindings = (getMarker()?.midiBindings ?? []).filter(
+    (existingBinding) => existingBinding.action !== action
+  );
+  nextBindings.push({
+    ...binding,
+    action,
+  });
+  updateMarkerBindings(markerId, nextBindings);
+}
+
+export function moveMarkerMIDIBinding(params: {
+  fromMarkerId: string;
+  toMarkerId: string;
+  action: MarkerMIDIAction;
+  binding: MIDINoteBinding;
+}): void {
+  const { fromMarkerId, toMarkerId, action, binding } = params;
+
+  if (fromMarkerId === toMarkerId) {
+    setMarkerMIDIBinding(toMarkerId, action, binding);
+    return;
+  }
+
+  setMarkerMIDIBinding(fromMarkerId, action, null);
+  setMarkerMIDIBinding(toMarkerId, action, binding);
+}

--- a/src/services/midi/midiCommands.ts
+++ b/src/services/midi/midiCommands.ts
@@ -1,0 +1,118 @@
+import { useTimelineStore } from '../../stores/timeline';
+import type {
+  MarkerMIDIBinding,
+  MarkerMIDIAction,
+  MIDITransportAction,
+} from '../../types/midi';
+
+function waitForAnimationFrame(): Promise<number> {
+  return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+async function seekTimeline(time: number, shouldPlayAfterSeek: boolean): Promise<void> {
+  const timelineStore = useTimelineStore.getState();
+  const clampedTime = Math.max(0, Math.min(time, timelineStore.duration));
+  const wasPlaying = timelineStore.isPlaying;
+  const previousSpeed = timelineStore.playbackSpeed;
+
+  if (wasPlaying) {
+    timelineStore.pause();
+    await waitForAnimationFrame();
+  }
+
+  timelineStore.setDraggingPlayhead(false);
+  timelineStore.setPlayheadPosition(clampedTime);
+  await waitForAnimationFrame();
+
+  if (shouldPlayAfterSeek || wasPlaying) {
+    await timelineStore.play();
+    timelineStore.setPlaybackSpeed(previousSpeed);
+  }
+}
+
+export async function jumpToMarkerTime(time: number): Promise<void> {
+  const timelineStore = useTimelineStore.getState();
+  await seekTimeline(time, false);
+  timelineStore.setDraggingPlayhead(false);
+}
+
+export async function jumpToMarkerAndStopTime(time: number): Promise<void> {
+  const timelineStore = useTimelineStore.getState();
+  const clampedTime = Math.max(0, Math.min(time, timelineStore.duration));
+
+  if (timelineStore.isPlaying) {
+    timelineStore.pause();
+    await waitForAnimationFrame();
+  }
+
+  timelineStore.setDraggingPlayhead(false);
+  timelineStore.setPlayheadPosition(clampedTime);
+}
+
+export async function playFromMarkerTime(time: number): Promise<void> {
+  await seekTimeline(time, true);
+}
+
+export async function togglePlaybackFromMIDI(): Promise<void> {
+  const timelineStore = useTimelineStore.getState();
+
+  if (timelineStore.isPlaying) {
+    timelineStore.pause();
+    return;
+  }
+
+  await timelineStore.play();
+}
+
+export async function stopPlaybackFromMIDI(): Promise<void> {
+  const timelineStore = useTimelineStore.getState();
+
+  if (timelineStore.isPlaying) {
+    timelineStore.pause();
+    await waitForAnimationFrame();
+  }
+
+  timelineStore.setDraggingPlayhead(false);
+  timelineStore.setPlayheadPosition(0);
+}
+
+export async function triggerMIDITransportAction(action: MIDITransportAction): Promise<void> {
+  if (action === 'stop') {
+    await stopPlaybackFromMIDI();
+    return;
+  }
+
+  await togglePlaybackFromMIDI();
+}
+
+export async function triggerMarkerMIDIAction(
+  action: MarkerMIDIAction,
+  time: number
+): Promise<void> {
+  if (action === 'playFromMarker') {
+    await playFromMarkerTime(time);
+    return;
+  }
+
+  if (action === 'jumpToMarkerAndStop') {
+    await jumpToMarkerAndStopTime(time);
+    return;
+  }
+
+  await jumpToMarkerTime(time);
+}
+
+export async function triggerMarkerMIDIBinding(binding: MarkerMIDIBinding): Promise<void> {
+  const timelineStore = useTimelineStore.getState();
+  const marker = timelineStore.markers.find((candidate) => candidate.midiBindings?.some((candidateBinding) => (
+    candidateBinding.action === binding.action
+    && candidateBinding.channel === binding.channel
+    && candidateBinding.note === binding.note
+  )));
+
+  if (!marker) {
+    return;
+  }
+
+  await triggerMarkerMIDIAction(binding.action, marker.time);
+}

--- a/src/services/midi/midiMappingSummary.ts
+++ b/src/services/midi/midiMappingSummary.ts
@@ -1,0 +1,125 @@
+import type { TimelineMarker } from '../../stores/timeline/types';
+import {
+  formatMIDINoteBinding,
+  type MarkerMIDIAction,
+  type MIDINoteBinding,
+  type MIDITransportAction,
+} from '../../types/midi';
+
+export interface MIDIMappingSummaryEntry {
+  id: string;
+  scope: 'transport' | 'marker';
+  action: MIDITransportAction | MarkerMIDIAction;
+  actionLabel: string;
+  targetLabel: string;
+  behaviorLabel: string;
+  binding: MIDINoteBinding;
+  bindingLabel: string;
+  markerId?: string;
+  markerTime?: number;
+}
+
+type MIDITransportBindings = Record<MIDITransportAction, MIDINoteBinding | null>;
+
+export function formatMarkerTime(seconds: number): string {
+  const safeSeconds = Math.max(0, seconds);
+  const hours = Math.floor(safeSeconds / 3600);
+  const minutes = Math.floor((safeSeconds % 3600) / 60);
+  const secs = Math.floor(safeSeconds % 60);
+
+  if (hours > 0) {
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  }
+
+  return `${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+}
+
+function getTransportActionLabel(action: MIDITransportAction): string {
+  return action === 'playPause' ? 'Play / Pause' : 'Stop';
+}
+
+function getTransportBehaviorLabel(action: MIDITransportAction): string {
+  return action === 'playPause'
+    ? 'Toggle timeline playback'
+    : 'Stop playback and return to the start';
+}
+
+function getMarkerActionLabel(action: MarkerMIDIAction): string {
+  if (action === 'playFromMarker') {
+    return 'Play From Marker';
+  }
+
+  if (action === 'jumpToMarkerAndStop') {
+    return 'Jump To Marker And Stop';
+  }
+
+  return 'Jump To Marker';
+}
+
+function getMarkerBehaviorLabel(action: MarkerMIDIAction): string {
+  if (action === 'playFromMarker') {
+    return 'Move the playhead to the marker time and start playback';
+  }
+
+  if (action === 'jumpToMarkerAndStop') {
+    return 'Move the playhead to the marker time and stop playback';
+  }
+
+  return 'Move the playhead to the marker time and keep the current playback state';
+}
+
+export function getMarkerTargetLabel(marker: TimelineMarker): string {
+  const label = marker.label.trim() || 'Marker';
+  return `${label} at ${formatMarkerTime(marker.time)}`;
+}
+
+export function collectMIDIMappingSummary(
+  transportBindings: MIDITransportBindings,
+  markers: TimelineMarker[]
+): MIDIMappingSummaryEntry[] {
+  const transportEntries: MIDIMappingSummaryEntry[] = (Object.entries(transportBindings) as Array<[
+    MIDITransportAction,
+    MIDINoteBinding | null,
+  ]>)
+    .flatMap(([action, binding]) => (binding ? [{
+      id: `transport-${action}-${binding.channel}-${binding.note}`,
+      scope: 'transport',
+      action,
+      actionLabel: getTransportActionLabel(action),
+      targetLabel: 'Global Transport',
+      behaviorLabel: getTransportBehaviorLabel(action),
+      binding,
+      bindingLabel: formatMIDINoteBinding(binding),
+    }] : []));
+
+  const markerEntries: MIDIMappingSummaryEntry[] = markers.flatMap((marker) => (
+    (marker.midiBindings ?? []).map((binding) => ({
+      id: `marker-${marker.id}-${binding.action}-${binding.channel}-${binding.note}`,
+      scope: 'marker' as const,
+      action: binding.action,
+      actionLabel: getMarkerActionLabel(binding.action),
+      targetLabel: getMarkerTargetLabel(marker),
+      behaviorLabel: getMarkerBehaviorLabel(binding.action),
+      binding,
+      bindingLabel: formatMIDINoteBinding(binding),
+      markerId: marker.id,
+      markerTime: marker.time,
+    }))
+  ));
+
+  return [...transportEntries, ...markerEntries].sort((left, right) => {
+    if (left.binding.channel !== right.binding.channel) {
+      return left.binding.channel - right.binding.channel;
+    }
+
+    if (left.binding.note !== right.binding.note) {
+      return left.binding.note - right.binding.note;
+    }
+
+    if (left.scope !== right.scope) {
+      return left.scope.localeCompare(right.scope);
+    }
+
+    return left.actionLabel.localeCompare(right.actionLabel);
+  });
+}

--- a/src/services/project/projectLoad.ts
+++ b/src/services/project/projectLoad.ts
@@ -12,6 +12,7 @@ import { useDockStore } from '../../stores/dockStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useFlashBoardStore } from '../../stores/flashboardStore';
 import { useExportStore } from '../../stores/exportStore';
+import { useMIDIStore } from '../../stores/midiStore';
 import { flashBoardMediaBridge } from '../flashboard/FlashBoardMediaBridge';
 import type {
   FlashBoard,
@@ -488,6 +489,14 @@ function convertProjectCompositionToStore(
       inPoint: viewState?.inPoint ?? null,
       outPoint: viewState?.outPoint ?? null,
       loopPlayback: false,
+      markers: (pc.markers || []).map((marker) => ({
+        id: marker.id,
+        time: marker.time,
+        label: marker.name || '',
+        color: marker.color,
+        stopPlayback: marker.stopPlayback === true ? true : undefined,
+        midiBindings: marker.midiBindings,
+      })),
     };
 
     const comp: Composition = {
@@ -712,6 +721,25 @@ export async function loadProjectToStores(): Promise<void> {
     }
     if (Object.keys(changelogSettings).length > 0) {
       useSettingsStore.setState(changelogSettings);
+    }
+
+    if (ui.midi) {
+      const midiState: Partial<ReturnType<typeof useMIDIStore.getState>> = {};
+
+      if (ui.midi.isEnabled !== undefined) {
+        midiState.isEnabled = ui.midi.isEnabled;
+      }
+
+      if (ui.midi.transportBindings) {
+        midiState.transportBindings = {
+          playPause: ui.midi.transportBindings.playPause ?? null,
+          stop: ui.midi.transportBindings.stop ?? null,
+        };
+      }
+
+      if (Object.keys(midiState).length > 0) {
+        useMIDIStore.setState(midiState);
+      }
     }
   }
 

--- a/src/services/project/projectSave.ts
+++ b/src/services/project/projectSave.ts
@@ -8,6 +8,7 @@ import { useDockStore } from '../../stores/dockStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useFlashBoardStore } from '../../stores/flashboardStore';
 import { getExportStoreData, useExportStore } from '../../stores/exportStore';
+import { useMIDIStore } from '../../stores/midiStore';
 import type {
   FlashBoardGenerationMetadata,
   FlashBoardStoreState,
@@ -201,8 +202,15 @@ function convertCompositions(compositions: Composition[]): ProjectComposition[] 
       sceneDescriptionStatus: c.sceneDescriptionStatus || undefined,
     }));
 
-    // Note: markers not currently stored in CompositionTimelineData
-    const markers: ProjectMarker[] = [];
+    const markers: ProjectMarker[] = (timelineData?.markers || []).map((marker: any) => ({
+      id: marker.id,
+      time: marker.time,
+      name: marker.label || '',
+      color: marker.color || '#2997E5',
+      duration: 0,
+      stopPlayback: marker.stopPlayback === true ? true : undefined,
+      midiBindings: marker.midiBindings || undefined,
+    }));
 
     return {
       id: comp.id,
@@ -370,6 +378,7 @@ export async function syncStoresToProject(): Promise<void> {
       const mediaPanelNameWidth = localStorage.getItem('media-panel-name-width');
       const transcriptLanguage = localStorage.getItem('transcriptLanguage');
       const settingsState = useSettingsStore.getState();
+      const midiState = useMIDIStore.getState();
 
       projectData.uiState = {
         dockLayout,
@@ -383,6 +392,13 @@ export async function syncStoresToProject(): Promise<void> {
         showTranscriptMarkers: timelineState.showTranscriptMarkers,
         showChangelogOnStartup: settingsState.showChangelogOnStartup,
         lastSeenChangelogVersion: settingsState.lastSeenChangelogVersion,
+        midi: {
+          isEnabled: midiState.isEnabled,
+          transportBindings: {
+            playPause: midiState.transportBindings.playPause,
+            stop: midiState.transportBindings.stop,
+          },
+        },
         exportState: getExportStoreData(useExportStore.getState()),
       };
 

--- a/src/services/project/types/index.ts
+++ b/src/services/project/types/index.ts
@@ -3,6 +3,7 @@
 export type {
   ProjectFile,
   ProjectSettings,
+  ProjectMIDIState,
   ProjectYouTubeVideo,
   ProjectYouTubeState,
 } from './project.types';

--- a/src/services/project/types/project.types.ts
+++ b/src/services/project/types/project.types.ts
@@ -30,6 +30,14 @@ export interface ProjectSettings {
   sampleRate: number;
 }
 
+export interface ProjectMIDIState {
+  isEnabled?: boolean;
+  transportBindings?: {
+    playPause?: import('../../../types/midi').MIDINoteBinding | null;
+    stop?: import('../../../types/midi').MIDINoteBinding | null;
+  };
+}
+
 // UI state that gets persisted with the project
 export interface ProjectUIState {
   // Dock/panel layout
@@ -54,6 +62,7 @@ export interface ProjectUIState {
   showTranscriptMarkers?: boolean;
   showChangelogOnStartup?: boolean;
   lastSeenChangelogVersion?: string | null;
+  midi?: ProjectMIDIState;
   exportState?: ExportStoreData;
 }
 

--- a/src/services/project/types/timeline.types.ts
+++ b/src/services/project/types/timeline.types.ts
@@ -65,4 +65,6 @@ export interface ProjectMarker {
   name: string;
   color: string;
   duration: number;
+  stopPlayback?: boolean;
+  midiBindings?: import('../../../types/midi').MarkerMIDIBinding[];
 }

--- a/src/services/timeline/stopMarkers.ts
+++ b/src/services/timeline/stopMarkers.ts
@@ -1,0 +1,38 @@
+import type { TimelineMarker } from '../../stores/timeline/types';
+
+const STOP_MARKER_EPSILON = 1 / 240;
+
+export function findStopMarkerInPlaybackRange(
+  markers: TimelineMarker[],
+  fromTime: number,
+  toTime: number
+): TimelineMarker | null {
+  if (!Number.isFinite(fromTime) || !Number.isFinite(toTime)) {
+    return null;
+  }
+
+  if (Math.abs(toTime - fromTime) <= STOP_MARKER_EPSILON) {
+    return null;
+  }
+
+  if (toTime > fromTime) {
+    return markers.find((marker) => (
+      marker.stopPlayback === true
+      && marker.time > fromTime + STOP_MARKER_EPSILON
+      && marker.time <= toTime + STOP_MARKER_EPSILON
+    )) ?? null;
+  }
+
+  for (let index = markers.length - 1; index >= 0; index -= 1) {
+    const marker = markers[index];
+    if (
+      marker.stopPlayback === true
+      && marker.time < fromTime - STOP_MARKER_EPSILON
+      && marker.time >= toTime - STOP_MARKER_EPSILON
+    ) {
+      return marker;
+    }
+  }
+
+  return null;
+}

--- a/src/stores/midiStore.ts
+++ b/src/stores/midiStore.ts
@@ -1,0 +1,85 @@
+import { create } from 'zustand';
+import { persist, subscribeWithSelector } from 'zustand/middleware';
+import type {
+  MIDIDeviceInfo,
+  MIDILastMessage,
+  MIDILearnTarget,
+  MIDINoteBinding,
+  MIDITransportAction,
+} from '../types/midi';
+
+type MIDIConnectionStatus = 'idle' | 'requesting' | 'connected' | 'error';
+
+type MIDITransportBindings = Record<MIDITransportAction, MIDINoteBinding | null>;
+
+interface MIDIStoreState {
+  isSupported: boolean;
+  isEnabled: boolean;
+  connectionStatus: MIDIConnectionStatus;
+  connectionError: string | null;
+  devices: MIDIDeviceInfo[];
+  lastMessage: MIDILastMessage | null;
+  learnTarget: MIDILearnTarget | null;
+  transportBindings: MIDITransportBindings;
+  setSupported: (supported: boolean) => void;
+  setEnabled: (enabled: boolean) => void;
+  setConnectionStatus: (status: MIDIConnectionStatus, error?: string | null) => void;
+  setDevices: (devices: MIDIDeviceInfo[]) => void;
+  setLastMessage: (message: MIDILastMessage | null) => void;
+  setTransportBinding: (action: MIDITransportAction, binding: MIDINoteBinding | null) => void;
+  startLearning: (target: MIDILearnTarget) => void;
+  cancelLearning: () => void;
+  resetRuntimeState: () => void;
+}
+
+const initialTransportBindings: MIDITransportBindings = {
+  playPause: null,
+  stop: null,
+};
+
+export const useMIDIStore = create<MIDIStoreState>()(
+  subscribeWithSelector(
+    persist(
+      (set) => ({
+        isSupported: false,
+        isEnabled: false,
+        connectionStatus: 'idle',
+        connectionError: null,
+        devices: [],
+        lastMessage: null,
+        learnTarget: null,
+        transportBindings: initialTransportBindings,
+        setSupported: (isSupported) => set({ isSupported }),
+        setEnabled: (isEnabled) => set({ isEnabled }),
+        setConnectionStatus: (connectionStatus, connectionError = null) =>
+          set({ connectionStatus, connectionError }),
+        setDevices: (devices) => set({ devices }),
+        setLastMessage: (lastMessage) => set({ lastMessage }),
+        setTransportBinding: (action, binding) =>
+          set((state) => ({
+            transportBindings: {
+              ...state.transportBindings,
+              [action]: binding,
+            },
+          })),
+        startLearning: (learnTarget) => set({ learnTarget }),
+        cancelLearning: () => set({ learnTarget: null }),
+        resetRuntimeState: () =>
+          set({
+            connectionStatus: 'idle',
+            connectionError: null,
+            devices: [],
+            lastMessage: null,
+            learnTarget: null,
+          }),
+      }),
+      {
+        name: 'masterselects-midi',
+        partialize: (state) => ({
+          isEnabled: state.isEnabled,
+          transportBindings: state.transportBindings,
+        }),
+      }
+    )
+  )
+);

--- a/src/stores/timeline/markerSlice.ts
+++ b/src/stores/timeline/markerSlice.ts
@@ -21,6 +21,8 @@ export const createMarkerSlice: SliceCreator<MarkerActions> = (set, get) => ({
       time: clampedTime,
       label: label || '',
       color: color || DEFAULT_MARKER_COLOR,
+      stopPlayback: undefined,
+      midiBindings: undefined,
     };
 
     set(state => ({

--- a/src/stores/timeline/types.ts
+++ b/src/stores/timeline/types.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../types';
 import type { Composition } from '../mediaStore';
 import type { VectorAnimationClipSettings } from '../../types/vectorAnimation';
+import type { MarkerMIDIBinding } from '../../types/midi';
 
 // Re-export imported types for convenience
 export type {
@@ -75,6 +76,8 @@ export interface TimelineMarker {
   time: number;
   label: string;
   color: string;
+  stopPlayback?: boolean;
+  midiBindings?: MarkerMIDIBinding[];
 }
 
 // Timeline state interface
@@ -203,7 +206,7 @@ export interface MeshClipActions {
   updateText3DProperties: (clipId: string, props: Partial<Text3DProperties>) => void;
 }
 
-// Camera clip actions (shared Three.js scene camera)
+// Camera clip actions (shared 3D scene camera)
 export interface CameraClipActions {
   addCameraClip: (trackId: string, startTime: number, duration?: number, skipMediaItem?: boolean) => string | null;
 }

--- a/src/types/dock.ts
+++ b/src/types/dock.ts
@@ -8,7 +8,7 @@ import type {
 
 // Panel types that can be docked
 // Note: Effects, Transcript, Analysis are now integrated into Properties panel
-export type PanelType = 'preview' | 'multi-preview' | 'timeline' | 'clip-properties' | 'media' | 'export' | 'multicam' | 'ai-chat' | 'ai-video' | 'ai-segment' | 'scene-description' | 'youtube' | 'download' | 'transitions' | 'scope-waveform' | 'scope-histogram' | 'scope-vectorscope';
+export type PanelType = 'preview' | 'multi-preview' | 'timeline' | 'clip-properties' | 'media' | 'export' | 'midi-mapping' | 'multicam' | 'ai-chat' | 'ai-video' | 'ai-segment' | 'scene-description' | 'youtube' | 'download' | 'transitions' | 'scope-waveform' | 'scope-histogram' | 'scope-vectorscope';
 
 // Scope panel types for filtering in View menu
 export const SCOPE_PANEL_TYPES: PanelType[] = ['scope-waveform', 'scope-histogram', 'scope-vectorscope'];
@@ -172,6 +172,13 @@ export const PANEL_CONFIGS: Record<PanelType, PanelConfig> = {
     title: 'Export',
     minWidth: 200,
     minHeight: 300,
+    closable: false,
+  },
+  'midi-mapping': {
+    type: 'midi-mapping',
+    title: 'MIDI Mapping',
+    minWidth: 280,
+    minHeight: 240,
     closable: false,
   },
   multicam: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,7 +72,7 @@ export interface Layer {
   position: { x: number; y: number; z: number };
   scale: { x: number; y: number; z?: number };
   rotation: number | { x: number; y: number; z: number };  // Single value (z only) or full 3D rotation
-  is3D?: boolean;  // When true, layer is rendered as a 3D plane via Three.js
+  is3D?: boolean;  // When true, layer participates in the shared 3D scene
   wireframe?: boolean;  // Debug: show as wireframe
   // Mask properties (passed from timeline clip masks for GPU processing)
   maskFeather?: number;  // Blur radius in pixels (0-50), handled in GPU shader
@@ -180,6 +180,8 @@ export interface NestedCompositionData {
   width: number;
   height: number;
   currentTime?: number;  // Current time for frame caching
+  sceneClips?: TimelineClip[];
+  sceneTracks?: TimelineTrack[];
 }
 
 // Text clip typography properties
@@ -492,7 +494,7 @@ export interface TimelineClip {
     meshType?: import('../stores/mediaStore/types').MeshPrimitiveType;  // Primitive mesh type
     text3DProperties?: Text3DProperties;
     cameraSettings?: import('../stores/mediaStore/types').SceneCameraSettings;  // Shared-scene camera settings
-    splatEffectorSettings?: import('./splatEffector').SplatEffectorSettings;  // Shared-scene Three.js splat effector settings
+    splatEffectorSettings?: import('./splatEffector').SplatEffectorSettings;  // Shared-scene splat effector settings
     gaussianAvatarUrl?: string;  // URL to gaussian splat avatar file
     gaussianBlendshapes?: Record<string, number>;  // ARKit blendshape weights
     gaussianSplatUrl?: string;  // URL to gaussian splat scene file
@@ -668,6 +670,8 @@ export interface SerializableMarker {
   time: number;
   label: string;
   color: string;
+  stopPlayback?: boolean;
+  midiBindings?: import('./midi').MarkerMIDIBinding[];
 }
 
 // Serializable timeline data for composition storage

--- a/src/types/midi.ts
+++ b/src/types/midi.ts
@@ -1,0 +1,123 @@
+export type MIDITransportAction = 'playPause' | 'stop';
+
+export type MarkerMIDIAction = 'playFromMarker' | 'jumpToMarker' | 'jumpToMarkerAndStop';
+
+export interface MIDIDeviceInfo {
+  id: string;
+  name: string;
+  manufacturer: string;
+}
+
+export interface MIDINoteBinding {
+  channel: number;
+  note: number;
+}
+
+export interface MarkerMIDIBinding extends MIDINoteBinding {
+  action: MarkerMIDIAction;
+}
+
+export interface MIDILastMessage {
+  channel: number;
+  type: 'note-on' | 'note-off' | 'control-change';
+  note?: number;
+  noteName?: string;
+  velocity?: number;
+  control?: number;
+  value?: number;
+}
+
+export type MIDILearnTarget =
+  | {
+      kind: 'transport';
+      action: MIDITransportAction;
+    }
+  | {
+      kind: 'marker';
+      markerId: string;
+      markerLabel: string;
+      action: MarkerMIDIAction;
+      sourceMarkerId?: string;
+    };
+
+export type MIDIPermissionState = PermissionState | 'unknown' | 'unsupported';
+
+const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'] as const;
+
+export function getMIDINoteName(note: number): string {
+  if (!Number.isFinite(note)) {
+    return 'Unknown';
+  }
+
+  const normalizedNote = Math.max(0, Math.min(127, Math.round(note)));
+  const octave = Math.floor(normalizedNote / 12) - 1;
+  const noteName = NOTE_NAMES[normalizedNote % 12];
+  return `${noteName}${octave}`;
+}
+
+export function formatMIDINoteBinding(binding: MIDINoteBinding | null | undefined): string {
+  if (!binding) {
+    return 'Unbound';
+  }
+
+  return `Ch ${binding.channel} / ${getMIDINoteName(binding.note)} (${binding.note})`;
+}
+
+export function describeMIDILearnTarget(target: MIDILearnTarget | null): string | null {
+  if (!target) {
+    return null;
+  }
+
+  if (target.kind === 'transport') {
+    return target.action === 'playPause'
+      ? 'Waiting for a note for Play/Pause'
+      : 'Waiting for a note for Stop';
+  }
+
+  const markerLabel = target.markerLabel || 'Marker';
+  if (target.action === 'playFromMarker') {
+    return `Waiting for a note for "${markerLabel}" -> Play From Marker`;
+  }
+
+  if (target.action === 'jumpToMarkerAndStop') {
+    return `Waiting for a note for "${markerLabel}" -> Jump To Marker And Stop`;
+  }
+
+  return `Waiting for a note for "${markerLabel}" -> Jump To Marker`;
+}
+
+export function describeMIDIPermissionState(state: MIDIPermissionState | null): string | null {
+  switch (state) {
+    case 'granted':
+      return 'Browser MIDI permission granted.';
+    case 'prompt':
+      return 'Browser can ask for MIDI permission.';
+    case 'denied':
+      return 'Browser MIDI permission is blocked for this site.';
+    case 'unsupported':
+      return 'Web MIDI API is not supported in this browser.';
+    case 'unknown':
+      return 'Browser MIDI permission state is unavailable.';
+    default:
+      return null;
+  }
+}
+
+export function getMIDIPermissionHelpText(state: MIDIPermissionState | null): string | null {
+  switch (state) {
+    case 'prompt':
+      return 'Click Enable MIDI to trigger the browser permission prompt. Once access is granted, connected devices appear in the Devices list.';
+    case 'denied':
+      return 'No new dialog will appear while the browser keeps MIDI blocked for this site. Use the site info icon next to the address bar, open Site settings, and allow MIDI for localhost.';
+    case 'granted':
+      return 'Browser access is granted. If your controller is plugged in and powered on, it should appear below automatically.';
+    case 'unknown':
+      return 'This browser does not expose MIDI permission state. If no dialog appears, check the site permissions in the address bar and allow MIDI access.';
+    default:
+      return null;
+  }
+}
+
+export function midiBindingsMatch(a: MIDINoteBinding, b: MIDINoteBinding): boolean {
+  return a.channel === b.channel && a.note === b.note;
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,6 +1,6 @@
 // App version
 // Format: MAJOR.MINOR.PATCH
-export const APP_VERSION = '1.5.5';
+export const APP_VERSION = '1.5.8';
 
 export interface ChangelogNotice {
   type: 'info' | 'warning' | 'success' | 'danger';

--- a/tests/unit/midiBindingMutations.test.ts
+++ b/tests/unit/midiBindingMutations.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createJSONStorage } from 'zustand/middleware';
+import { useMIDIStore } from '../../src/stores/midiStore';
+import { useTimelineStore } from '../../src/stores/timeline';
+import {
+  moveMarkerMIDIBinding,
+  setMarkerMIDIBinding,
+  setTransportMIDIBinding,
+} from '../../src/services/midi/midiBindingMutations';
+
+describe('midiBindingMutations', () => {
+  beforeEach(() => {
+    useMIDIStore.persist.setOptions({
+      storage: createJSONStorage(() => ({
+        getItem: () => null,
+        setItem: () => {},
+        removeItem: () => {},
+      })),
+    });
+
+    useMIDIStore.setState({
+      isSupported: true,
+      isEnabled: false,
+      connectionStatus: 'idle',
+      connectionError: null,
+      devices: [],
+      lastMessage: null,
+      learnTarget: null,
+      transportBindings: {
+        playPause: null,
+        stop: null,
+      },
+    });
+
+    useTimelineStore.setState({
+      duration: 60,
+      markers: [
+        {
+          id: 'marker-a',
+          time: 5,
+          label: 'Intro',
+          color: '#fff',
+          midiBindings: [{ action: 'jumpToMarker', channel: 1, note: 60 }],
+        },
+        {
+          id: 'marker-b',
+          time: 10,
+          label: 'Drop',
+          color: '#fff',
+          midiBindings: [{ action: 'playFromMarker', channel: 1, note: 62 }],
+        },
+      ],
+    });
+  });
+
+  it('moves conflicting marker bindings out of the way when assigning a transport note', () => {
+    setTransportMIDIBinding('playPause', { channel: 1, note: 60 });
+
+    expect(useMIDIStore.getState().transportBindings.playPause).toEqual({ channel: 1, note: 60 });
+    expect(useTimelineStore.getState().markers[0]?.midiBindings).toBeUndefined();
+    expect(useTimelineStore.getState().markers[1]?.midiBindings).toEqual([
+      { action: 'playFromMarker', channel: 1, note: 62 },
+    ]);
+  });
+
+  it('clears conflicting transport bindings when assigning a marker note', () => {
+    setTransportMIDIBinding('playPause', { channel: 1, note: 64 });
+
+    setMarkerMIDIBinding('marker-b', 'playFromMarker', { channel: 1, note: 64 });
+
+    expect(useMIDIStore.getState().transportBindings.playPause).toBeNull();
+    expect(useTimelineStore.getState().markers[1]?.midiBindings).toEqual([
+      { action: 'playFromMarker', channel: 1, note: 64 },
+    ]);
+  });
+
+  it('can move an existing marker binding to another marker', () => {
+    moveMarkerMIDIBinding({
+      fromMarkerId: 'marker-a',
+      toMarkerId: 'marker-b',
+      action: 'jumpToMarker',
+      binding: { channel: 1, note: 60 },
+    });
+
+    expect(useTimelineStore.getState().markers[0]?.midiBindings).toBeUndefined();
+    expect(useTimelineStore.getState().markers[1]?.midiBindings).toEqual([
+      { action: 'playFromMarker', channel: 1, note: 62 },
+      { action: 'jumpToMarker', channel: 1, note: 60 },
+    ]);
+  });
+});

--- a/tests/unit/midiCommands.test.ts
+++ b/tests/unit/midiCommands.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTimelineStore } from '../../src/stores/timeline';
+import {
+  triggerMIDITransportAction,
+  triggerMarkerMIDIAction,
+  triggerMarkerMIDIBinding,
+} from '../../src/services/midi/midiCommands';
+
+describe('midiCommands', () => {
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+
+  beforeEach(() => {
+    globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    vi.restoreAllMocks();
+  });
+
+  it('triggers transport playback actions', async () => {
+    const play = vi.fn(async () => undefined);
+    const pause = vi.fn();
+
+    useTimelineStore.setState({
+      isPlaying: false,
+      play,
+      pause,
+    });
+
+    await triggerMIDITransportAction('playPause');
+
+    expect(play).toHaveBeenCalledTimes(1);
+    expect(pause).not.toHaveBeenCalled();
+  });
+
+  it('triggers marker jump actions from an explicit time', async () => {
+    const setDraggingPlayhead = vi.fn();
+    const setPlayheadPosition = vi.fn();
+
+    useTimelineStore.setState({
+      duration: 60,
+      isPlaying: false,
+      setDraggingPlayhead,
+      setPlayheadPosition,
+    });
+
+    await triggerMarkerMIDIAction('jumpToMarker', 12.5);
+
+    expect(setDraggingPlayhead).toHaveBeenCalledWith(false);
+    expect(setPlayheadPosition).toHaveBeenCalledWith(12.5);
+  });
+
+  it('can force a marker jump to stop playback', async () => {
+    const pause = vi.fn();
+    const setDraggingPlayhead = vi.fn();
+    const setPlayheadPosition = vi.fn();
+
+    useTimelineStore.setState({
+      duration: 60,
+      isPlaying: true,
+      pause,
+      setDraggingPlayhead,
+      setPlayheadPosition,
+    });
+
+    await triggerMarkerMIDIAction('jumpToMarkerAndStop', 8.25);
+
+    expect(pause).toHaveBeenCalledTimes(1);
+    expect(setDraggingPlayhead).toHaveBeenCalledWith(false);
+    expect(setPlayheadPosition).toHaveBeenCalledWith(8.25);
+  });
+
+  it('resolves marker bindings through the same path as incoming MIDI notes', async () => {
+    const play = vi.fn(async () => undefined);
+    const setDraggingPlayhead = vi.fn();
+    const setPlayheadPosition = vi.fn();
+    const setPlaybackSpeed = vi.fn();
+
+    useTimelineStore.setState({
+      duration: 60,
+      isPlaying: false,
+      playbackSpeed: 1,
+      play,
+      setDraggingPlayhead,
+      setPlayheadPosition,
+      setPlaybackSpeed,
+      markers: [
+        {
+          id: 'marker-1',
+          time: 9.75,
+          label: 'Drop',
+          color: '#ff0',
+          midiBindings: [{ action: 'playFromMarker', channel: 2, note: 40 }],
+        },
+      ],
+    });
+
+    await triggerMarkerMIDIBinding({
+      action: 'playFromMarker',
+      channel: 2,
+      note: 40,
+    });
+
+    expect(setPlayheadPosition).toHaveBeenCalledWith(9.75);
+    expect(play).toHaveBeenCalledTimes(1);
+    expect(setPlaybackSpeed).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/unit/midiMappingSummary.test.ts
+++ b/tests/unit/midiMappingSummary.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { collectMIDIMappingSummary } from '../../src/services/midi/midiMappingSummary';
+import type { TimelineMarker } from '../../src/stores/timeline/types';
+
+describe('collectMIDIMappingSummary', () => {
+  it('collects transport and marker mappings into a single sorted list', () => {
+    const markers: TimelineMarker[] = [
+      {
+        id: 'marker-1',
+        time: 12,
+        label: 'Drop',
+        color: '#fff',
+        midiBindings: [{ action: 'playFromMarker', channel: 1, note: 64 }],
+      },
+      {
+        id: 'marker-3',
+        time: 18,
+        label: 'Brake',
+        color: '#fff',
+        midiBindings: [{ action: 'jumpToMarkerAndStop', channel: 1, note: 66 }],
+      },
+      {
+        id: 'marker-2',
+        time: 4,
+        label: '',
+        color: '#fff',
+        midiBindings: [{ action: 'jumpToMarker', channel: 1, note: 60 }],
+      },
+    ];
+
+    const result = collectMIDIMappingSummary(
+      {
+        playPause: { channel: 1, note: 62 },
+        stop: null,
+      },
+      markers
+    );
+
+    expect(result).toHaveLength(4);
+    expect(result.map((entry) => entry.binding.note)).toEqual([60, 62, 64, 66]);
+    expect(result[0]).toMatchObject({
+      scope: 'marker',
+      action: 'jumpToMarker',
+      targetLabel: 'Marker at 00:04',
+    });
+    expect(result[1]).toMatchObject({
+      scope: 'transport',
+      action: 'playPause',
+      targetLabel: 'Global Transport',
+    });
+    expect(result[2]).toMatchObject({
+      scope: 'marker',
+      action: 'playFromMarker',
+      targetLabel: 'Drop at 00:12',
+    });
+    expect(result[3]).toMatchObject({
+      scope: 'marker',
+      action: 'jumpToMarkerAndStop',
+      behaviorLabel: 'Move the playhead to the marker time and stop playback',
+      targetLabel: 'Brake at 00:18',
+    });
+  });
+
+  it('formats long marker times with hours', () => {
+    const result = collectMIDIMappingSummary(
+      {
+        playPause: null,
+        stop: null,
+      },
+      [{
+        id: 'marker-3',
+        time: 3723,
+        label: 'Long',
+        color: '#fff',
+        midiBindings: [{ action: 'jumpToMarker', channel: 2, note: 10 }],
+      }]
+    );
+
+    expect(result[0]?.targetLabel).toBe('Long at 01:02:03');
+  });
+});

--- a/tests/unit/midiPermissionMessaging.test.ts
+++ b/tests/unit/midiPermissionMessaging.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  describeMIDIPermissionState,
+  getMIDIPermissionHelpText,
+} from '../../src/types/midi';
+
+describe('MIDI permission messaging', () => {
+  it('describes denied permission as a site-level block', () => {
+    expect(describeMIDIPermissionState('denied')).toBe(
+      'Browser MIDI permission is blocked for this site.'
+    );
+  });
+
+  it('guides the user to site settings when permission is denied', () => {
+    expect(getMIDIPermissionHelpText('denied')).toContain('Site settings');
+    expect(getMIDIPermissionHelpText('denied')).toContain('localhost');
+  });
+
+  it('tells the user that prompt state can still request permission', () => {
+    expect(describeMIDIPermissionState('prompt')).toBe(
+      'Browser can ask for MIDI permission.'
+    );
+    expect(getMIDIPermissionHelpText('prompt')).toContain('Enable MIDI');
+  });
+});

--- a/tests/unit/projectMediaPersistence.test.ts
+++ b/tests/unit/projectMediaPersistence.test.ts
@@ -61,7 +61,15 @@ const mocks = vi.hoisted(() => ({
     lastSeenChangelogVersion: '1.0.0',
     loadApiKeys: vi.fn(async () => undefined),
   },
+  midiState: {
+    isEnabled: false,
+    transportBindings: {
+      playPause: null as { channel: number; note: number } | null,
+      stop: null as { channel: number; note: number } | null,
+    },
+  },
   mediaSetState: vi.fn(),
+  midiSetState: vi.fn(),
   createObjectURL: vi.fn(() => 'blob:project-media'),
   settingsSetState: vi.fn(),
 }));
@@ -95,6 +103,13 @@ vi.mock('../../src/stores/settingsStore', () => ({
   useSettingsStore: {
     getState: () => mocks.settingsState,
     setState: mocks.settingsSetState,
+  },
+}));
+
+vi.mock('../../src/stores/midiStore', () => ({
+  useMIDIStore: {
+    getState: () => mocks.midiState,
+    setState: mocks.midiSetState,
   },
 }));
 
@@ -158,6 +173,11 @@ describe('project media persistence', () => {
     mocks.mediaState.expandedFolderIds = [];
     mocks.mediaState.slotAssignments = {};
     mocks.mediaState.proxyEnabled = false;
+    mocks.midiState.isEnabled = false;
+    mocks.midiState.transportBindings = {
+      playPause: null,
+      stop: null,
+    };
     mocks.timelineState.clips = [];
     mocks.getProjectData.mockReturnValue({
       media: [],
@@ -175,6 +195,9 @@ describe('project media persistence', () => {
         ? partial(mocks.mediaState)
         : partial;
       Object.assign(mocks.mediaState, nextPartial);
+    });
+    mocks.midiSetState.mockImplementation((partial: Record<string, unknown>) => {
+      Object.assign(mocks.midiState, partial);
     });
     vi.spyOn(URL, 'createObjectURL').mockImplementation(mocks.createObjectURL);
     Object.defineProperty(globalThis, 'localStorage', {
@@ -218,6 +241,104 @@ describe('project media persistence', () => {
         projectPath: 'Raw/clip.mp4',
       }),
     ]);
+  });
+
+  it('persists marker MIDI bindings when syncing stores to the project file', async () => {
+    mocks.mediaState.activeCompositionId = 'comp-1';
+    mocks.mediaState.compositions = [{
+      id: 'comp-1',
+      name: 'Comp 1',
+      type: 'composition',
+      parentId: null,
+      createdAt: 1,
+      width: 1920,
+      height: 1080,
+      frameRate: 30,
+      duration: 60,
+      backgroundColor: '#000000',
+      timelineData: { tracks: [], clips: [], markers: [] },
+    }];
+    mocks.timelineState.getSerializableState.mockReturnValue({
+      tracks: [{ id: 'track-v1', name: 'Video 1', type: 'video', height: 60, muted: false, visible: true, solo: false }],
+      clips: [],
+      markers: [
+        {
+          id: 'marker-1',
+          time: 12.5,
+          label: 'Drop',
+          color: '#ff6600',
+          stopPlayback: true,
+          midiBindings: [
+            { action: 'playFromMarker', channel: 1, note: 36 },
+            { action: 'jumpToMarker', channel: 1, note: 37 },
+            { action: 'jumpToMarkerAndStop', channel: 1, note: 38 },
+          ],
+        },
+      ],
+      playheadPosition: 0,
+      duration: 60,
+      zoom: 1,
+      scrollX: 0,
+      inPoint: null,
+      outPoint: null,
+      loopPlayback: false,
+    });
+
+    const { syncStoresToProject } = await import('../../src/services/project/projectSave');
+    await syncStoresToProject();
+
+    expect(mocks.updateCompositions).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'comp-1',
+        markers: [
+          expect.objectContaining({
+            id: 'marker-1',
+            time: 12.5,
+            name: 'Drop',
+            color: '#ff6600',
+            stopPlayback: true,
+            midiBindings: [
+              { action: 'playFromMarker', channel: 1, note: 36 },
+              { action: 'jumpToMarker', channel: 1, note: 37 },
+              { action: 'jumpToMarkerAndStop', channel: 1, note: 38 },
+            ],
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it('persists transport MIDI bindings in project uiState when syncing stores to the project file', async () => {
+    const projectData = {
+      media: [],
+      compositions: [],
+      folders: [],
+      settings: { width: 1920, height: 1080, frameRate: 30 },
+      activeCompositionId: null,
+      openCompositionIds: [],
+      expandedFolderIds: [],
+      slotAssignments: {},
+      uiState: {},
+    };
+    mocks.getProjectData.mockReturnValue(projectData);
+    mocks.midiState.isEnabled = true;
+    mocks.midiState.transportBindings = {
+      playPause: { channel: 1, note: 48 },
+      stop: { channel: 1, note: 49 },
+    };
+
+    const { syncStoresToProject } = await import('../../src/services/project/projectSave');
+    await syncStoresToProject();
+
+    expect(projectData.uiState).toEqual(expect.objectContaining({
+      midi: {
+        isEnabled: true,
+        transportBindings: {
+          playPause: { channel: 1, note: 48 },
+          stop: { channel: 1, note: 49 },
+        },
+      },
+    }));
   });
 
   it('persists vector animation metadata and clip settings for lottie assets', async () => {
@@ -798,6 +919,93 @@ describe('project media persistence', () => {
           file: rawFile,
         }),
       ],
+    }));
+  });
+
+  it('restores stop markers and marker MIDI bindings when loading a composition', async () => {
+    mocks.getProjectData.mockReturnValue({
+      media: [],
+      compositions: [{
+        id: 'comp-1',
+        name: 'Comp 1',
+        width: 1920,
+        height: 1080,
+        frameRate: 30,
+        duration: 60,
+        backgroundColor: '#000000',
+        folderId: null,
+        tracks: [],
+        clips: [],
+        markers: [{
+          id: 'marker-1',
+          time: 12.5,
+          name: 'Drop',
+          color: '#ff6600',
+          duration: 0,
+          stopPlayback: true,
+          midiBindings: [
+            { action: 'jumpToMarkerAndStop', channel: 2, note: 44 },
+          ],
+        }],
+      }],
+      folders: [],
+      settings: { width: 1920, height: 1080, frameRate: 30 },
+      activeCompositionId: 'comp-1',
+      openCompositionIds: ['comp-1'],
+      expandedFolderIds: [],
+      slotAssignments: {},
+      uiState: {},
+    });
+
+    const { loadProjectToStores } = await import('../../src/services/project/projectLoad');
+    await loadProjectToStores();
+
+    expect(mocks.timelineState.loadState).toHaveBeenCalledWith(expect.objectContaining({
+      markers: [
+        expect.objectContaining({
+          id: 'marker-1',
+          time: 12.5,
+          label: 'Drop',
+          color: '#ff6600',
+          stopPlayback: true,
+          midiBindings: [
+            { action: 'jumpToMarkerAndStop', channel: 2, note: 44 },
+          ],
+        }),
+      ],
+    }));
+  });
+
+  it('restores transport MIDI bindings from project uiState', async () => {
+    mocks.getProjectData.mockReturnValue({
+      media: [],
+      compositions: [],
+      folders: [],
+      settings: { width: 1920, height: 1080, frameRate: 30 },
+      activeCompositionId: null,
+      openCompositionIds: [],
+      expandedFolderIds: [],
+      slotAssignments: {},
+      uiState: {
+        midi: {
+          isEnabled: true,
+          transportBindings: {
+            playPause: { channel: 3, note: 50 },
+            stop: { channel: 3, note: 51 },
+          },
+        },
+      },
+    });
+
+    const { loadProjectToStores } = await import('../../src/services/project/projectLoad');
+    await loadProjectToStores();
+
+    expect(mocks.midiSetState).toHaveBeenCalledWith(expect.objectContaining({
+      isEnabled: true,
+      transportBindings: {
+        playPause: { channel: 3, note: 50 },
+        stop: { channel: 3, note: 51 },
+      },
     }));
   });
 

--- a/tests/unit/serialization.test.ts
+++ b/tests/unit/serialization.test.ts
@@ -306,8 +306,24 @@ describe('CompositionTimelineData round-trip', () => {
   it('markers serialize and deserialize', () => {
     const data = makeTimelineData({
       markers: [
-        { id: 'm1', time: 5, label: 'Intro', color: '#ff0000' },
-        { id: 'm2', time: 15, label: 'Chorus', color: '#00ff00' },
+        {
+          id: 'm1',
+          time: 5,
+          label: 'Intro',
+          color: '#ff0000',
+          midiBindings: [
+            { action: 'playFromMarker', channel: 1, note: 36 },
+          ],
+        },
+        {
+          id: 'm2',
+          time: 15,
+          label: 'Chorus',
+          color: '#00ff00',
+          midiBindings: [
+            { action: 'jumpToMarker', channel: 2, note: 48 },
+          ],
+        },
       ],
     });
 
@@ -317,6 +333,12 @@ describe('CompositionTimelineData round-trip', () => {
     expect(restored.markers).toHaveLength(2);
     expect(restored.markers![0].label).toBe('Intro');
     expect(restored.markers![1].time).toBe(15);
+    expect(restored.markers![0].midiBindings).toEqual([
+      { action: 'playFromMarker', channel: 1, note: 36 },
+    ]);
+    expect(restored.markers![1].midiBindings).toEqual([
+      { action: 'jumpToMarker', channel: 2, note: 48 },
+    ]);
   });
 });
 

--- a/tests/unit/stopMarkers.test.ts
+++ b/tests/unit/stopMarkers.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { findStopMarkerInPlaybackRange } from '../../src/services/timeline/stopMarkers';
+import type { TimelineMarker } from '../../src/stores/timeline/types';
+
+describe('findStopMarkerInPlaybackRange', () => {
+  const markers: TimelineMarker[] = [
+    { id: 'marker-a', time: 3, label: 'A', color: '#fff' },
+    { id: 'marker-b', time: 5, label: 'B', color: '#fff', stopPlayback: true },
+    { id: 'marker-c', time: 8, label: 'C', color: '#fff', stopPlayback: true },
+  ];
+
+  it('finds the first forward stop marker crossed by playback', () => {
+    expect(findStopMarkerInPlaybackRange(markers, 4.4, 6.2)?.id).toBe('marker-b');
+  });
+
+  it('finds the nearest reverse stop marker crossed by playback', () => {
+    expect(findStopMarkerInPlaybackRange(markers, 8.4, 4.6)?.id).toBe('marker-c');
+  });
+
+  it('does not retrigger when playback starts exactly on a stop marker', () => {
+    expect(findStopMarkerInPlaybackRange(markers, 5, 5.01)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add browser MIDI runtime, settings tab, mapping panel, and project persistence for transport plus marker bindings
- add editable MIDI mappings, panel-side trigger previews, and marker context menu learn/binding actions
- add stop markers plus marker actions for jump, play-from-marker, and jump-and-stop

## Verification
- npm run build
- npm run lint
- npm run test

## Preview
- https://midi.masterselects.pages.dev
- https://2045ba30.masterselects.pages.dev