### PR TITLE
feat: improve 3D gizmos and splat stats

### DIFF
--- a/docs/Features/3D-Layers.md
+++ b/docs/Features/3D-Layers.md
@@ -78,6 +78,16 @@ Create mesh clips from the Media Panel via `+ Add > Mesh` or the context menu:
 - All transform properties and keyframe animation are supported.
 - Primitive meshes and 3D text render through the native shared scene contract.
 
+### Preview Scene Gizmo
+
+- Selected scene objects expose a viewport transform gizmo for Move, Rotate, and Scale.
+- Move, Rotate, and Scale visuals are drawn by the native WebGPU scene gizmo pass from the selected object's local transform basis. The React overlay only supplies hit targets and the mode toolbar.
+  - Move and Scale use larger Unreal-style colored local-axis handles with dark outlines and a white center hub. Hovering an axis brightens and thickens that native gizmo handle. Dragging the center hub moves freely in the preview plane for Move and applies proportional uniform scale for Scale.
+- Rotate mode draws larger screen-space stable colored rings from the X, Y, and Z local rotation planes, so the ring orientation changes with object rotation and the scene view without the rings visually growing or shrinking. The invisible SVG hit targets are generated from the same projected 3D ring points, and hover/drag chooses the nearest ring instead of whichever SVG stroke is visually on top.
+- Rotation dragging follows the selected projected local ring and applies the delta as a local-axis rotation before converting back to Euler transform values. This keeps red, green, and blue controls aligned with the visual local gizmo even after the object is already rotated.
+- Double-clicking an axis resets that single component, while double-clicking the white center hub resets the active transform group.
+- The W/E/R hotkeys switch between Move, Rotate, and Scale while the preview overlay is active.
+
 ### Scene Camera
 
 There are two camera concepts in the product:
@@ -104,6 +114,7 @@ Gaussian splat clips are imported through the SuperSplat-compatible `@playcanvas
 - Gaussian splats participate in scene cameras, object transforms, object-level effectors, preview, nested compositions, export, preload, and readiness checks through the same native shared-scene path.
 - Realtime splat rendering uses a worker-backed back-to-front order buffer based on the SuperSplat/PlayCanvas sorter approach. Precise export can still fall back to the existing GPU sort path.
 - Sequence splats follow the same shared runtime contract and preload nearby frames without replacing foreground playback with repeated loading overlays.
+- Imported splats and numbered splat sequences store media-panel stats: container label, file size, per-frame splat count, and total sequence splat count.
 - The Transform tab now exposes normal object transforms for gaussian splats. Scene navigation lives on camera clips.
 - Large gaussian splats show viewport loading progress during project restore, URL fetch, parser work, normalization, and GPU upload.
 

--- a/docs/Features/Media-Panel.md
+++ b/docs/Features/Media-Panel.md
@@ -76,6 +76,7 @@ Imports use a two-phase approach:
 1. **Phase 1 (instant):** A placeholder entry appears immediately in the panel with `isImporting: true`, showing file name and size
 2. **Phase 2 (background):** Full processing runs in the background:
    - Media info extraction (dimensions, duration, FPS, codec, bitrate, audio detection)
+   - Gaussian-splat stats extraction (container, file size, per-file splat count, and sequence totals)
    - Thumbnail generation (for video and image files)
    - File hash calculation (for deduplication and proxy matching)
    - Copy to project RAW folder when `copyMediaToProject` is enabled, or when the import is forced
@@ -141,15 +142,22 @@ The panel supports three view modes through the header mode control. The selecte
 
 ### Board View
 - Board canvas grouped by Media Panel folders; every folder appears as a group, including empty folders
-- Mouse wheel zooms around the cursor; left-dragging the board or a node pans the board
-- Items inside each folder snap to a fixed slot grid
-- Right-dragging nodes reorders the selected items in the target folder grid; dropping onto another folder group moves them there
+- The root area contains top-level folders instead of rendering them beside root as separate peers
+- Mouse wheel zooms around the cursor; left-dragging the board, a node, or a folder group pans the board, with the background grid moving at a subtle parallax offset
+- Folder groups grow and shrink dynamically with their contents
+- Growing folder groups push sibling groups out of the way so board groups do not overlap
+- Double-clicking a folder group name starts inline rename for that folder
+- Items inside each folder wrap into dynamic rows sized from the media aspect ratio instead of fixed slots
+- Right-dragging nodes reorders the selected items in the target folder; nearby items make space during drag hover to preview the exact insertion point
+- Right-dragging a folder group moves the group and its contents as a spatial unit; nested folder groups move along with their parent folder
+- Folder groups accept dropped items and folders from the other Media Panel views, while drops outside the root area are ignored
 - Ctrl/right-drag starts a marquee selection; right-clicking opens the normal Media Panel context menu
-- Media, compositions, text, solids, meshes, cameras, and splat effectors appear as board nodes
-- Board order and viewport are saved into the project UI state, with `localStorage` as the live-session fallback
+- Media, compositions, text, solids, meshes, cameras, and splat effectors appear as board nodes with hover-only name and metadata overlays
+- Board order, folder group offsets, and viewport are saved into the project UI state, with `localStorage` as the live-session fallback
 - Drag files or folders from the OS onto a group to import directly into that folder
 - Drag existing Media Panel items onto groups to move them between folders
 - Use the small handle on a node to drag that item to the timeline with the same drag payloads as Classic and Icons view
+- Switching to or from Board view morphs folder groups from/to their Classic rows or Icons thumbnails using the same 500ms view transition as media items
 - The board uses the same Add dropdown and context menu as Classic view; new folders appear immediately in Classic, Icons, and Board view
 - The **AI** board action opens the existing AI Video panel; generated results still import through the normal Media Store path
 
@@ -354,10 +362,10 @@ The media list displays items in a table with the following columns:
 | **Name** | File name with AE-style file type icon | Video.mp4 |
 | **Label** | Colored dot indicator (clickable) | colored circle |
 | **Duration** | Clip length (m:ss) | 4:02 |
-| **Resolution** | Width x Height | 1920x1080 |
+| **Resolution** | Width x Height, or splat count / sequence total for gaussian splats | 1920x1080, 3f / 12.4M splats |
 | **FPS** | Frame rate (video) or composition frame rate | 25 |
-| **Container** | File container format | MP4, MKV, WebM |
-| **Codec** | Video codec | H.264, VP9, AV1 |
+| **Container** | File container format | MP4, MKV, WebM, PLY Seq |
+| **Codec** | Video codec or splat runtime family | H.264, VP9, Splat Seq |
 | **Audio** | Has audio track? | Yes / No |
 | **Bitrate** | Data rate | 12.5 Mbps |
 | **Size** | File size | 125.4 MB |
@@ -411,6 +419,9 @@ interface MediaFile {
   fileSize?: number;         // File size in bytes
   bitrate?: number;          // Bits per second
   hasAudio?: boolean;        // Whether video has audio tracks
+  splatCount?: number;       // First/only gaussian-splat frame count
+  totalSplatCount?: number;  // Sequence total, abbreviated in UI as K/M/B
+  splatFrameCount?: number;  // Gaussian-splat sequence frame count
   thumbnailUrl?: string;
   fileHash?: string;         // For dedup and proxy matching
   labelColor?: LabelColor;   // 16-color label system
@@ -482,7 +493,7 @@ Media references are saved with the project file, while IndexedDB keeps the hand
 - File metadata (name, type, dimensions, duration, codec, etc.)
 - File handles (for reload on next session)
 - Folder structure
-- Media Panel view mode, Board viewport, and Board slot order
+- Media Panel view mode, Board viewport, Board folder group offsets, and Board slot order
 - Composition state with timeline data
 - Text items and solid items (via localStorage)
 - When present, `projectPath` points at the copied `Raw/<name>` file and is used for automatic relinking

--- a/src/App.css
+++ b/src/App.css
@@ -8514,6 +8514,35 @@ input[type="checkbox"] {
   flex-direction: column;
 }
 
+.media-panel-view-transition-layer {
+  position: fixed;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 10000;
+  contain: layout paint;
+}
+
+.media-panel-view-transition-clone {
+  position: absolute !important;
+  margin: 0 !important;
+  box-sizing: border-box;
+  overflow: hidden;
+  pointer-events: none !important;
+  user-select: none !important;
+  transform-origin: 0 0;
+  will-change: transform, opacity;
+}
+
+.media-panel-view-transition-clone,
+.media-panel-view-transition-clone * {
+  pointer-events: none !important;
+  transition: none !important;
+}
+
+.media-panel-view-transition-hidden {
+  visibility: hidden !important;
+}
+
 /* Table wrapper for horizontal scrolling */
 .media-panel-table-wrapper {
   min-width: 650px;
@@ -8689,8 +8718,8 @@ input[type="checkbox"] {
 }
 
 .media-col-resolution {
-  width: 80px;
-  min-width: 80px;
+  width: 118px;
+  min-width: 118px;
   text-align: right;
 }
 
@@ -8701,14 +8730,14 @@ input[type="checkbox"] {
 }
 
 .media-col-container {
-  width: 60px;
-  min-width: 60px;
+  width: 72px;
+  min-width: 72px;
   text-align: center;
 }
 
 .media-col-codec {
-  width: 56px;
-  min-width: 56px;
+  width: 68px;
+  min-width: 68px;
   text-align: center;
 }
 
@@ -8964,6 +8993,10 @@ input[type="checkbox"] {
     linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px),
     var(--bg-primary);
   background-size: 32px 32px;
+  background-position:
+    var(--media-board-grid-x, 0px) var(--media-board-grid-y, 0px),
+    var(--media-board-grid-x, 0px) var(--media-board-grid-y, 0px),
+    0 0;
 }
 
 .media-board-toolbar {
@@ -9019,13 +9052,12 @@ input[type="checkbox"] {
   cursor: grabbing;
 }
 
-.media-board-wrapper.board-interacting .media-board-node,
-.media-board-wrapper.board-interacting .media-board-group {
-  transition: none !important;
+.media-board-wrapper.board-interacting .media-board-node {
+  will-change: left, top, transform;
 }
 
-.media-board-wrapper.board-interacting .media-board-node {
-  will-change: transform;
+.media-board-wrapper.board-interacting .media-board-group {
+  will-change: left, top, width, height, transform;
 }
 
 .media-board-wrapper.board-interacting .media-board-node-thumb img {
@@ -9048,6 +9080,37 @@ input[type="checkbox"] {
   background: rgba(255, 255, 255, 0.035);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
   pointer-events: auto;
+  transition: left 0.16s ease, top 0.16s ease, width 0.16s ease, height 0.16s ease, border-color 0.1s, box-shadow 0.1s;
+}
+
+.media-board-group.folder-group {
+  cursor: grab;
+}
+
+.media-board-group.root-group {
+  background: rgba(255, 255, 255, 0.025);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.media-board-group.folder-group.depth-1 {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.media-board-group.folder-group.depth-2,
+.media-board-group.folder-group.depth-3 {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.media-board-group.folder-group .media-board-group-header {
+  cursor: grab;
+}
+
+.media-board-group.folder-group.drag-preview {
+  border-color: rgba(45, 140, 235, 0.45);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 12px 26px rgba(0, 0, 0, 0.24);
+  z-index: 15;
 }
 
 .media-board-group-header {
@@ -9070,6 +9133,10 @@ input[type="checkbox"] {
   white-space: nowrap;
 }
 
+.media-board-group.folder-group .media-board-group-header span:first-child {
+  cursor: text;
+}
+
 .media-board-group-header span:last-child {
   min-width: 22px;
   height: 18px;
@@ -9083,19 +9150,45 @@ input[type="checkbox"] {
   font-variant-numeric: tabular-nums;
 }
 
+.media-board-group-rename {
+  flex: 0 1 auto;
+  min-width: 4ch;
+  max-width: min(42ch, calc(100% - 34px));
+  height: 24px;
+  padding: 2px 6px;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+  outline: none;
+}
+
+.media-board-insert-gap {
+  position: absolute;
+  border: 1px dashed rgba(45, 140, 235, 0.68);
+  border-radius: 6px;
+  background: rgba(45, 140, 235, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(45, 140, 235, 0.1);
+  pointer-events: none;
+  transition: left 0.16s ease, top 0.16s ease, width 0.16s ease, height 0.16s ease;
+  z-index: 3;
+}
+
 .media-board-node {
   position: absolute;
-  display: flex;
-  flex-direction: column;
+  display: block;
   overflow: hidden;
   border: 1px solid var(--border-color);
   border-top: 3px solid var(--border-color);
   border-radius: 6px;
   background: var(--bg-secondary);
   box-shadow: 0 8px 18px rgba(0, 0, 0, 0.22);
-  cursor: move;
-  transition: border-color 0.1s, box-shadow 0.1s, background 0.1s;
+  cursor: grab;
+  transition: left 0.16s ease, top 0.16s ease, width 0.16s ease, height 0.16s ease, border-color 0.1s, box-shadow 0.1s, background 0.1s;
   pointer-events: auto;
+  z-index: 5;
 }
 
 .media-board-node:hover {
@@ -9106,6 +9199,10 @@ input[type="checkbox"] {
 .media-board-node.drag-preview {
   box-shadow: 0 14px 30px rgba(0, 0, 0, 0.34);
   z-index: 20;
+}
+
+.media-board-node.drag-source-preview {
+  z-index: 18;
 }
 
 .media-board-node.selected {
@@ -9119,8 +9216,8 @@ input[type="checkbox"] {
 
 .media-board-node-thumb {
   position: relative;
-  height: 82px;
-  flex-shrink: 0;
+  width: 100%;
+  height: 100%;
   background: var(--bg-primary);
   overflow: hidden;
 }
@@ -9204,8 +9301,24 @@ input[type="checkbox"] {
 }
 
 .media-board-node-body {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
   min-height: 0;
-  padding: 7px 8px 8px;
+  padding: 18px 8px 8px;
+  background: linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.82));
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(8px);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+}
+
+.media-board-node:hover .media-board-node-body,
+.media-board-node.selected .media-board-node-body,
+.media-board-node.drag-preview .media-board-node-body {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .media-board-node-name {
@@ -10851,6 +10964,48 @@ input[type="checkbox"] {
   box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.92), 0 8px 20px rgba(0, 0, 0, 0.45);
 }
 
+.preview-scene-object-handle.gizmo-center {
+  width: 34px;
+  height: 34px;
+  z-index: 5;
+  color: #0f172a;
+  background: #f8fafc;
+  border: 2px solid rgba(15, 23, 42, 0.78);
+  box-shadow:
+    0 0 0 2px rgba(255, 255, 255, 0.9),
+    0 0 14px rgba(59, 130, 246, 0.28),
+    0 8px 20px rgba(0, 0, 0, 0.52);
+}
+
+.preview-scene-object-handle.gizmo-center.center-draggable {
+  cursor: grab;
+}
+
+.preview-scene-object-handle.gizmo-center.center-draggable:active {
+  cursor: grabbing;
+}
+
+.preview-scene-object-handle.gizmo-center span {
+  display: block;
+  width: 12px;
+  height: 12px;
+  color: transparent;
+  background: #2563eb;
+  border-radius: 999px;
+  font-size: 0;
+}
+
+.preview-scene-object-handle.gizmo-center.mode-scale span {
+  border-radius: 2px;
+}
+
+.preview-scene-object-handle.gizmo-center.mode-rotate span {
+  width: 13px;
+  height: 13px;
+  background: transparent;
+  border: 2px solid #2563eb;
+}
+
 .preview-scene-gizmo-axis-layer {
   position: absolute;
   inset: 0;
@@ -10859,8 +11014,8 @@ input[type="checkbox"] {
 
 .preview-scene-gizmo-axis {
   position: absolute;
-  height: 22px;
-  margin: -11px 0 0 0;
+  height: 34px;
+  margin: -17px 0 0 0;
   padding: 0;
   background: transparent;
   border: 0;
@@ -10878,10 +11033,20 @@ input[type="checkbox"] {
   left: 0;
   right: 0;
   top: 50%;
-  height: 3px;
+  height: 5px;
   border-radius: 999px;
   background: currentColor;
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.78),
+    0 0 9px color-mix(in srgb, currentColor 58%, transparent);
   transform: translateY(-50%);
+}
+
+.preview-scene-gizmo-axis-line,
+.preview-scene-gizmo-end,
+.preview-scene-gizmo-label,
+.preview-scene-gizmo-rotate-stroke {
+  opacity: 0;
 }
 
 .preview-scene-gizmo-axis.mode-rotate .preview-scene-gizmo-axis-line {
@@ -10900,14 +11065,39 @@ input[type="checkbox"] {
 
 .preview-scene-gizmo-end {
   position: absolute;
-  right: -6px;
+  right: -7px;
   top: 50%;
-  width: 12px;
-  height: 12px;
-  background: #10141c;
-  border: 2px solid currentColor;
-  border-radius: 50%;
+  width: 14px;
+  height: 14px;
+  background: currentColor;
+  border: 2px solid rgba(8, 11, 16, 0.92);
+  border-radius: 2px;
+  box-shadow:
+    0 1px 4px rgba(0, 0, 0, 0.55),
+    0 0 8px color-mix(in srgb, currentColor 52%, transparent);
   transform: translateY(-50%);
+}
+
+.preview-scene-gizmo-axis.mode-move .preview-scene-gizmo-end {
+  right: -14px;
+  width: 0;
+  height: 0;
+  background: transparent;
+  border-top: 8px solid transparent;
+  border-bottom: 8px solid transparent;
+  border-left: 15px solid currentColor;
+  border-right: 0;
+  border-radius: 0;
+  box-shadow: none;
+  filter:
+    drop-shadow(0 0 1px rgba(0, 0, 0, 0.95))
+    drop-shadow(0 2px 4px rgba(0, 0, 0, 0.5));
+}
+
+.preview-scene-gizmo-axis.mode-scale .preview-scene-gizmo-end {
+  right: -8px;
+  width: 16px;
+  height: 16px;
 }
 
 .preview-scene-gizmo-label {
@@ -10933,6 +11123,49 @@ input[type="checkbox"] {
 
 .preview-scene-gizmo-axis.axis-z,
 .preview-scene-gizmo-label.axis-z {
+  color: #3b82f6;
+}
+
+.preview-scene-gizmo-rotate {
+  position: absolute;
+  width: 128px;
+  height: 128px;
+  overflow: visible;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+.preview-scene-gizmo-rotate-hit {
+  fill: none;
+  stroke: transparent;
+  stroke-width: 30px;
+  cursor: grab;
+  pointer-events: stroke;
+}
+
+.preview-scene-gizmo-rotate-hit:active {
+  cursor: grabbing;
+}
+
+.preview-scene-gizmo-rotate-stroke {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 4px;
+  pointer-events: none;
+  filter:
+    drop-shadow(0 0 1px rgba(0, 0, 0, 0.95))
+    drop-shadow(0 0 6px color-mix(in srgb, currentColor 55%, transparent));
+}
+
+.preview-scene-gizmo-rotate-ring.axis-x {
+  color: #ef4444;
+}
+
+.preview-scene-gizmo-rotate-ring.axis-y {
+  color: #22c55e;
+}
+
+.preview-scene-gizmo-rotate-ring.axis-z {
   color: #3b82f6;
 }
 

--- a/src/changelog-data.json
+++ b/src/changelog-data.json
@@ -1,5 +1,26 @@
 [
   {
+    "date": "2026-04-27",
+    "type": "improve",
+    "title": "Viewport Gizmos Feel Like Real Scene Objects",
+    "description": "Move, rotate, and scale gizmos now render through the native 3D path with local-axis orientation, larger stable rotate rings, hover highlighting, center-hub group actions, and double-click reset behavior.",
+    "section": "3D / Native Scene"
+  },
+  {
+    "date": "2026-04-27",
+    "type": "improve",
+    "title": "Gaussian Splat Assets Show Real Media Stats",
+    "description": "Imported splats and numbered splat sequences now store container, file size, per-frame splat count, and total sequence splat count so the Media Panel list, tooltips, and board cards show useful K/M-style stats.",
+    "section": "Media Panel"
+  },
+  {
+    "date": "2026-04-27",
+    "type": "fix",
+    "title": "Source Monitor Stays Open Until the Composition Changes",
+    "description": "Opening a source asset from the Media Panel no longer immediately clears the source monitor, while switching active compositions still closes it as expected.",
+    "section": "Preview"
+  },
+  {
     "date": "2026-04-26",
     "type": "fix",
     "title": "PLY Splat Sequences Play Smoothly",

--- a/src/components/panels/MediaPanel.tsx
+++ b/src/components/panels/MediaPanel.tsx
@@ -1,6 +1,6 @@
 // Media Panel - Project browser like After Effects
 
-import React, { useCallback, useMemo, useRef, useState, useEffect } from 'react';
+import React, { useCallback, useMemo, useRef, useState, useEffect, useLayoutEffect } from 'react';
 import { Logger } from '../../services/logger';
 import { FileTypeIcon } from './media/FileTypeIcon';
 import { LABEL_COLORS, getLabelHex } from './media/labelColors';
@@ -34,6 +34,11 @@ interface MediaBoardViewport {
   panY: number;
 }
 
+interface MediaBoardGroupOffset {
+  x: number;
+  y: number;
+}
+
 interface MediaBoardNodeLayout {
   x: number;
   y: number;
@@ -43,18 +48,28 @@ interface MediaBoardNodeLayout {
 
 interface MediaBoardGroupLayout {
   id: string | null;
+  parentId: string | null;
   name: string;
   x: number;
   y: number;
   width: number;
   height: number;
   itemCount: number;
+  depth: number;
 }
 
 interface MediaBoardNodePlacement {
   item: MediaBoardItem;
   layout: MediaBoardNodeLayout;
   defaultLayout: MediaBoardNodeLayout;
+  groupId: string | null;
+  slotIndex: number;
+  isDraggingPreview?: boolean;
+}
+
+interface MediaBoardInsertGapPlacement {
+  id: string;
+  layout: MediaBoardNodeLayout;
   groupId: string | null;
   slotIndex: number;
 }
@@ -64,6 +79,13 @@ interface MediaBoardMarquee {
   startY: number;
   currentX: number;
   currentY: number;
+}
+
+interface MediaBoardInsertionPreview {
+  movingIds: string[];
+  targetGroupId: string | null;
+  targetIndex: number;
+  sourceLayouts: Record<string, MediaBoardNodeLayout>;
 }
 
 type MediaPanelContextMenu = {
@@ -91,21 +113,59 @@ const STORAGE_KEY = 'media-panel-column-order';
 const VIEW_MODE_STORAGE_KEY = 'media-panel-view-mode';
 const BOARD_VIEWPORT_STORAGE_KEY = 'media-panel-board-viewport';
 const BOARD_ORDER_STORAGE_KEY = 'media-panel-board-order';
+const BOARD_GROUP_OFFSETS_STORAGE_KEY = 'media-panel-board-group-offsets';
 const MEDIA_PANEL_PROJECT_UI_LOADED_EVENT = 'media-panel-project-ui-loaded';
 const MEDIA_BOARD_ROOT_ORDER_KEY = '__root__';
 
 const DEFAULT_BOARD_VIEWPORT: MediaBoardViewport = { zoom: 0.82, panX: 32, panY: 28 };
-const MEDIA_BOARD_NODE_WIDTH = 156;
-const MEDIA_BOARD_NODE_HEIGHT = 132;
+const MEDIA_BOARD_NODE_TARGET_AREA = 20500;
+const MEDIA_BOARD_NODE_MIN_WIDTH = 86;
+const MEDIA_BOARD_NODE_MAX_WIDTH = 212;
+const MEDIA_BOARD_NODE_MIN_HEIGHT = 72;
+const MEDIA_BOARD_NODE_MAX_HEIGHT = 190;
+const MEDIA_BOARD_NODE_ASPECT_MIN = 0.45;
+const MEDIA_BOARD_NODE_ASPECT_MAX = 2.75;
 const MEDIA_BOARD_NODE_GAP = 14;
-const MEDIA_BOARD_GROUP_WIDTH = 732;
 const MEDIA_BOARD_GROUP_HEADER_HEIGHT = 42;
 const MEDIA_BOARD_GROUP_PADDING = 18;
-const MEDIA_BOARD_GROUP_GAP = 72;
-const MEDIA_BOARD_COLUMNS_PER_GROUP = 4;
+const MEDIA_BOARD_FOLDER_GAP = 28;
+const MEDIA_BOARD_GROUP_MIN_WIDTH = 260;
+const MEDIA_BOARD_GROUP_MAX_BODY_WIDTH = 700;
+const MEDIA_BOARD_FOLDER_ROW_MAX_WIDTH = 1480;
 const MEDIA_BOARD_PAN_ZOOM_MIN = 0.18;
 const MEDIA_BOARD_PAN_ZOOM_MAX = 2.4;
 const MEDIA_BOARD_DRAG_START_DISTANCE = 4;
+const MEDIA_BOARD_GRID_PARALLAX = 0.18;
+const MEDIA_PANEL_VIEW_TRANSITION_MS = 500;
+
+interface MediaPanelTransitionBox {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+interface MediaPanelTransitionCapture {
+  box: MediaPanelTransitionBox;
+  clone: HTMLElement;
+  baseWidth: number;
+  baseHeight: number;
+  scaleX: number;
+  scaleY: number;
+}
+
+interface PendingMediaPanelViewTransition {
+  captures: Map<string, MediaPanelTransitionCapture>;
+  overlay: HTMLDivElement;
+  panelBox: MediaPanelTransitionBox;
+}
+
+interface ActiveMediaPanelViewTransition {
+  animations: Animation[];
+  hiddenTargets: HTMLElement[];
+  overlay: HTMLDivElement;
+  timeoutId: number;
+}
 
 // Load column order from localStorage
 function loadColumnOrder(): ColumnId[] {
@@ -180,6 +240,28 @@ function loadMediaBoardOrder(): Record<string, string[]> {
   }
 }
 
+function loadMediaBoardGroupOffsets(): Record<string, MediaBoardGroupOffset> {
+  try {
+    const stored = localStorage.getItem(BOARD_GROUP_OFFSETS_STORAGE_KEY);
+    if (!stored) return {};
+    const parsed = JSON.parse(stored) as Record<string, Partial<MediaBoardGroupOffset>>;
+    if (!parsed || typeof parsed !== 'object') return {};
+
+    const valid: Record<string, MediaBoardGroupOffset> = {};
+    Object.entries(parsed).forEach(([folderId, offset]) => {
+      if (!folderId || folderId === MEDIA_BOARD_ROOT_ORDER_KEY || !offset || typeof offset !== 'object') return;
+      const x = Number(offset.x);
+      const y = Number(offset.y);
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+      if (Math.abs(x) < 0.5 && Math.abs(y) < 0.5) return;
+      valid[folderId] = { x, y };
+    });
+    return valid;
+  } catch {
+    return {};
+  }
+}
+
 function getProjectItemIconType(item: ProjectItem | undefined): string | undefined {
   if (!item || !('type' in item)) return undefined;
   if (item.type === 'model') {
@@ -188,6 +270,93 @@ function getProjectItemIconType(item: ProjectItem | undefined): string | undefin
       : 'mesh';
   }
   return item.type;
+}
+
+function formatCompactCount(value: number | undefined): string | null {
+  if (!value || !Number.isFinite(value) || value <= 0) return null;
+  if (value < 1000) return String(Math.round(value));
+  if (value < 1_000_000) return `${(value / 1000).toFixed(value < 10_000 ? 1 : 0)}K`;
+  if (value < 1_000_000_000) return `${(value / 1_000_000).toFixed(value < 10_000_000 ? 1 : 0)}M`;
+  return `${(value / 1_000_000_000).toFixed(1)}B`;
+}
+
+function getGaussianSplatFrameCount(mediaFile: MediaFile): number | undefined {
+  return mediaFile.splatFrameCount ?? mediaFile.gaussianSplatSequence?.frameCount;
+}
+
+function getGaussianSplatTotalCount(mediaFile: MediaFile): number | undefined {
+  return mediaFile.totalSplatCount ?? mediaFile.gaussianSplatSequence?.totalSplatCount ?? mediaFile.splatCount;
+}
+
+function getGaussianSplatFirstFrameCount(mediaFile: MediaFile): number | undefined {
+  return mediaFile.splatCount ?? mediaFile.gaussianSplatSequence?.frames[0]?.splatCount;
+}
+
+function getGaussianSplatResolutionLabel(item: ProjectItem): string | null {
+  if (!isImportedMediaFileItem(item) || item.type !== 'gaussian-splat') return null;
+
+  const frameCount = getGaussianSplatFrameCount(item);
+  const totalCount = getGaussianSplatTotalCount(item);
+  const firstFrameCount = getGaussianSplatFirstFrameCount(item);
+  const totalLabel = formatCompactCount(totalCount);
+  const firstFrameLabel = formatCompactCount(firstFrameCount);
+
+  if (frameCount && frameCount > 1) {
+    return totalLabel ? `${frameCount}f / ${totalLabel} splats` : `${frameCount}f`;
+  }
+
+  return firstFrameLabel ? `${firstFrameLabel} splats` : null;
+}
+
+function getGaussianSplatDetailLines(mediaFile: MediaFile): string[] {
+  if (mediaFile.type !== 'gaussian-splat') return [];
+
+  const frameCount = getGaussianSplatFrameCount(mediaFile);
+  const totalCount = getGaussianSplatTotalCount(mediaFile);
+  const firstFrameCount = getGaussianSplatFirstFrameCount(mediaFile);
+  const minCount = mediaFile.gaussianSplatSequence?.minSplatCount;
+  const maxCount = mediaFile.gaussianSplatSequence?.maxSplatCount;
+  const lines: string[] = [];
+
+  if (frameCount && frameCount > 1) {
+    lines.push(`${frameCount} frames`);
+    const totalLabel = formatCompactCount(totalCount);
+    if (totalLabel) lines.push(`${totalLabel} splats total`);
+    const minLabel = formatCompactCount(minCount);
+    const maxLabel = formatCompactCount(maxCount);
+    if (minLabel && maxLabel && minLabel !== maxLabel) {
+      lines.push(`${minLabel}-${maxLabel} splats/frame`);
+    }
+  } else {
+    const firstFrameLabel = formatCompactCount(firstFrameCount);
+    if (firstFrameLabel) lines.push(`${firstFrameLabel} splats`);
+  }
+
+  return lines;
+}
+
+function getMediaFileContainerLabel(mediaFile: MediaFile | null): string | undefined {
+  if (!mediaFile) return undefined;
+  if (mediaFile.container) return mediaFile.container;
+  if (mediaFile.type === 'gaussian-splat' && mediaFile.gaussianSplatSequence?.container) {
+    const frameCount = getGaussianSplatFrameCount(mediaFile);
+    return frameCount && frameCount > 1
+      ? `${mediaFile.gaussianSplatSequence.container} Seq`
+      : mediaFile.gaussianSplatSequence.container;
+  }
+  return undefined;
+}
+
+function getMediaFileCodecLabel(mediaFile: MediaFile | null): string | undefined {
+  if (!mediaFile) return undefined;
+  if (mediaFile.codec) return mediaFile.codec;
+  if (mediaFile.type === 'gaussian-splat') {
+    const frameCount = getGaussianSplatFrameCount(mediaFile);
+    return frameCount && frameCount > 1
+      ? 'Splat Seq'
+      : 'Splat';
+  }
+  return undefined;
 }
 
 function getMediaBoardGroupName(folderId: string | null, folders: Array<{ id: string; name: string; parentId: string | null }>): string {
@@ -203,7 +372,11 @@ function getMediaBoardGroupName(folderId: string | null, folders: Array<{ id: st
 
 function getMediaBoardTypeLabel(item: MediaBoardItem): string {
   if (item.type === 'composition') return 'Composition';
-  if (item.type === 'gaussian-splat') return 'Splat';
+  if (item.type === 'gaussian-splat') {
+    return isImportedMediaFileItem(item) && (getGaussianSplatFrameCount(item) ?? 1) > 1
+      ? 'Splat Seq'
+      : 'Splat';
+  }
   if (item.type === 'splat-effector') return 'Effector';
   if (item.type === 'solid') return 'Solid';
   if (item.type === 'model') return 'Model';
@@ -212,6 +385,81 @@ function getMediaBoardTypeLabel(item: MediaBoardItem): string {
 
 function getMediaBoardOrderKey(folderId: string | null): string {
   return folderId ?? MEDIA_BOARD_ROOT_ORDER_KEY;
+}
+
+function clampMediaBoardNumber(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function getMediaBoardItemAspectRatio(item: MediaBoardItem): number {
+  const width = 'width' in item ? Number(item.width) : undefined;
+  const height = 'height' in item ? Number(item.height) : undefined;
+  if (width && height && Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0) {
+    return clampMediaBoardNumber(width / height, MEDIA_BOARD_NODE_ASPECT_MIN, MEDIA_BOARD_NODE_ASPECT_MAX);
+  }
+
+  if (item.type === 'camera' || item.type === 'model' || item.type === 'splat-effector') {
+    return 1;
+  }
+
+  return 16 / 9;
+}
+
+function getMediaBoardNodeSize(item: MediaBoardItem): { width: number; height: number } {
+  const aspectRatio = getMediaBoardItemAspectRatio(item);
+  let width = Math.sqrt(MEDIA_BOARD_NODE_TARGET_AREA * aspectRatio);
+  let height = width / aspectRatio;
+  const maxScale = Math.min(
+    MEDIA_BOARD_NODE_MAX_WIDTH / width,
+    MEDIA_BOARD_NODE_MAX_HEIGHT / height,
+    1,
+  );
+  width *= maxScale;
+  height *= maxScale;
+
+  if (width < MEDIA_BOARD_NODE_MIN_WIDTH) {
+    width = MEDIA_BOARD_NODE_MIN_WIDTH;
+    height = width / aspectRatio;
+  }
+  if (height < MEDIA_BOARD_NODE_MIN_HEIGHT) {
+    height = MEDIA_BOARD_NODE_MIN_HEIGHT;
+    width = height * aspectRatio;
+  }
+  if (width > MEDIA_BOARD_NODE_MAX_WIDTH) {
+    width = MEDIA_BOARD_NODE_MAX_WIDTH;
+    height = width / aspectRatio;
+  }
+  if (height > MEDIA_BOARD_NODE_MAX_HEIGHT) {
+    height = MEDIA_BOARD_NODE_MAX_HEIGHT;
+    width = height * aspectRatio;
+  }
+
+  return {
+    width: Math.round(width),
+    height: Math.round(height),
+  };
+}
+
+function rectToTransitionBox(rect: DOMRect): MediaPanelTransitionBox {
+  return {
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function boxesIntersect(a: MediaPanelTransitionBox, b: MediaPanelTransitionBox): boolean {
+  return (
+    a.left < b.left + b.width
+    && a.left + a.width > b.left
+    && a.top < b.top + b.height
+    && a.top + a.height > b.top
+  );
+}
+
+function prefersReducedMotion(): boolean {
+  return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
 }
 
 export function MediaPanel() {
@@ -275,10 +523,13 @@ export function MediaPanel() {
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const itemListRef = useRef<HTMLDivElement>(null);
+  const mediaPanelContentRef = useRef<HTMLDivElement>(null);
   const boardWrapperRef = useRef<HTMLDivElement>(null);
   const boardCanvasRef = useRef<HTMLDivElement>(null);
   const boardCanvasInnerRef = useRef<HTMLDivElement>(null);
   const boardInteractionFrameRef = useRef<number | null>(null);
+  const pendingViewTransitionRef = useRef<PendingMediaPanelViewTransition | null>(null);
+  const activeViewTransitionRef = useRef<ActiveMediaPanelViewTransition | null>(null);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const renameTimerRef = useRef<number | null>(null);
@@ -301,7 +552,9 @@ export function MediaPanel() {
   const [gridFolderId, setGridFolderId] = useState<string | null>(null);
   const [mediaBoardViewport, setMediaBoardViewport] = useState<MediaBoardViewport>(loadMediaBoardViewport);
   const [mediaBoardOrder, setMediaBoardOrder] = useState<Record<string, string[]>>(loadMediaBoardOrder);
+  const [mediaBoardGroupOffsets, setMediaBoardGroupOffsets] = useState<Record<string, MediaBoardGroupOffset>>(loadMediaBoardGroupOffsets);
   const [mediaBoardMarquee, setMediaBoardMarquee] = useState<MediaBoardMarquee | null>(null);
+  const [mediaBoardInsertionPreview, setMediaBoardInsertionPreview] = useState<MediaBoardInsertionPreview | null>(null);
   const suppressMediaBoardContextMenuRef = useRef(false);
   const suppressMediaBoardContextMenuTimerRef = useRef<number | null>(null);
 
@@ -331,6 +584,10 @@ export function MediaPanel() {
     localStorage.setItem(BOARD_ORDER_STORAGE_KEY, JSON.stringify(mediaBoardOrder));
   }, [mediaBoardOrder]);
 
+  useEffect(() => {
+    localStorage.setItem(BOARD_GROUP_OFFSETS_STORAGE_KEY, JSON.stringify(mediaBoardGroupOffsets));
+  }, [mediaBoardGroupOffsets]);
+
   useEffect(() => () => {
     if (boardInteractionFrameRef.current !== null) {
       window.cancelAnimationFrame(boardInteractionFrameRef.current);
@@ -339,6 +596,289 @@ export function MediaPanel() {
       window.clearTimeout(suppressMediaBoardContextMenuTimerRef.current);
     }
   }, []);
+
+  const cleanupActiveMediaPanelViewTransition = useCallback(() => {
+    const active = activeViewTransitionRef.current;
+    if (!active) return;
+
+    activeViewTransitionRef.current = null;
+    window.clearTimeout(active.timeoutId);
+    active.animations.forEach((animation) => animation.cancel());
+    active.hiddenTargets.forEach((target) => {
+      target.classList.remove('media-panel-view-transition-hidden');
+    });
+    active.overlay.remove();
+  }, []);
+
+  const cleanupPendingMediaPanelViewTransition = useCallback(() => {
+    const pending = pendingViewTransitionRef.current;
+    if (!pending) return;
+
+    pendingViewTransitionRef.current = null;
+    pending.overlay.remove();
+  }, []);
+
+  const prepareMediaPanelViewTransition = useCallback(() => {
+    cleanupActiveMediaPanelViewTransition();
+    cleanupPendingMediaPanelViewTransition();
+
+    if (prefersReducedMotion()) return;
+
+    const content = mediaPanelContentRef.current;
+    if (!content) return;
+
+    const panelBox = rectToTransitionBox(content.getBoundingClientRect());
+    if (panelBox.width < 1 || panelBox.height < 1) return;
+
+    const overlay = document.createElement('div');
+    overlay.className = 'media-panel-view-transition-layer';
+    overlay.style.left = `${panelBox.left}px`;
+    overlay.style.top = `${panelBox.top}px`;
+    overlay.style.width = `${panelBox.width}px`;
+    overlay.style.height = `${panelBox.height}px`;
+
+    const captures = new Map<string, MediaPanelTransitionCapture>();
+    const nodes = content.querySelectorAll<HTMLElement>('[data-media-panel-anim-id]');
+    nodes.forEach((node) => {
+      const id = node.dataset.mediaPanelAnimId;
+      if (!id || node.matches(':focus-within')) return;
+
+      const box = rectToTransitionBox(node.getBoundingClientRect());
+      if (box.width < 1 || box.height < 1 || !boxesIntersect(box, panelBox)) return;
+
+      const clone = node.cloneNode(true) as HTMLElement;
+      const baseWidth = node.offsetWidth || box.width;
+      const baseHeight = node.offsetHeight || box.height;
+      const scaleX = box.width / Math.max(baseWidth, 1);
+      const scaleY = box.height / Math.max(baseHeight, 1);
+      clone.classList.add('media-panel-view-transition-clone');
+      clone.setAttribute('aria-hidden', 'true');
+      clone.setAttribute('draggable', 'false');
+      clone.querySelectorAll<HTMLElement>('[draggable]').forEach((draggableChild) => {
+        draggableChild.setAttribute('draggable', 'false');
+      });
+      clone.style.left = `${box.left - panelBox.left}px`;
+      clone.style.top = `${box.top - panelBox.top}px`;
+      clone.style.width = `${baseWidth}px`;
+      clone.style.height = `${baseHeight}px`;
+      clone.style.transform = `scale(${scaleX}, ${scaleY})`;
+
+      captures.set(id, { box, clone, baseWidth, baseHeight, scaleX, scaleY });
+      overlay.appendChild(clone);
+    });
+
+    if (captures.size === 0) {
+      overlay.remove();
+      return;
+    }
+
+    document.body.appendChild(overlay);
+    pendingViewTransitionRef.current = { captures, overlay, panelBox };
+  }, [cleanupActiveMediaPanelViewTransition, cleanupPendingMediaPanelViewTransition]);
+
+  useLayoutEffect(() => {
+    const pending = pendingViewTransitionRef.current;
+    if (!pending) return;
+
+    pendingViewTransitionRef.current = null;
+
+    const content = mediaPanelContentRef.current;
+    if (!content || prefersReducedMotion()) {
+      pending.overlay.remove();
+      return;
+    }
+
+    const nextPanelBox = rectToTransitionBox(content.getBoundingClientRect());
+    const hiddenTargets: HTMLElement[] = [];
+    const animations: Animation[] = [];
+
+    const animateCloneOut = ({ clone, scaleX, scaleY }: MediaPanelTransitionCapture) => {
+      animations.push(clone.animate(
+        [
+          { opacity: 1, transform: `scale(${scaleX}, ${scaleY}) translate3d(0, 0, 0)` },
+          { opacity: 0, transform: `scale(${scaleX}, ${scaleY}) translate3d(0, -4px, 0)` },
+        ],
+        {
+          duration: 180,
+          easing: 'ease-out',
+          fill: 'forwards',
+        }
+      ));
+    };
+
+    pending.captures.forEach((capture, id) => {
+      const { box, clone, baseWidth, baseHeight, scaleX, scaleY } = capture;
+      const target = content.querySelector<HTMLElement>(`[data-media-panel-anim-id="${CSS.escape(id)}"]`);
+      if (!target) {
+        animateCloneOut(capture);
+        return;
+      }
+
+      const targetBox = rectToTransitionBox(target.getBoundingClientRect());
+      if (targetBox.width < 1 || targetBox.height < 1 || !boxesIntersect(targetBox, nextPanelBox)) {
+        animateCloneOut(capture);
+        return;
+      }
+
+      const sourceLeft = box.left - pending.panelBox.left;
+      const sourceTop = box.top - pending.panelBox.top;
+      const targetLeft = targetBox.left - pending.panelBox.left;
+      const targetTop = targetBox.top - pending.panelBox.top;
+      const targetBaseWidth = target.offsetWidth || targetBox.width;
+      const targetBaseHeight = target.offsetHeight || targetBox.height;
+      const targetScaleX = targetBox.width / Math.max(targetBaseWidth, 1);
+      const targetScaleY = targetBox.height / Math.max(targetBaseHeight, 1);
+      const targetInitialWidth = box.width / Math.max(targetScaleX, 0.001);
+      const targetInitialHeight = box.height / Math.max(targetScaleY, 0.001);
+      const targetScaleTransform = `scale(${targetScaleX}, ${targetScaleY})`;
+
+      const targetClone = target.cloneNode(true) as HTMLElement;
+      targetClone.classList.add('media-panel-view-transition-clone', 'media-panel-view-transition-target-clone');
+      targetClone.setAttribute('aria-hidden', 'true');
+      targetClone.setAttribute('draggable', 'false');
+      targetClone.querySelectorAll<HTMLElement>('[draggable]').forEach((draggableChild) => {
+        draggableChild.setAttribute('draggable', 'false');
+      });
+      targetClone.style.left = `${sourceLeft}px`;
+      targetClone.style.top = `${sourceTop}px`;
+      targetClone.style.width = `${targetInitialWidth}px`;
+      targetClone.style.height = `${targetInitialHeight}px`;
+      targetClone.style.opacity = '0';
+      targetClone.style.transform = targetScaleTransform;
+      pending.overlay.appendChild(targetClone);
+
+      target.classList.add('media-panel-view-transition-hidden');
+      hiddenTargets.push(target);
+
+      animations.push(clone.animate(
+        [
+          {
+            left: `${sourceLeft}px`,
+            top: `${sourceTop}px`,
+            width: `${baseWidth}px`,
+            height: `${baseHeight}px`,
+            transform: `scale(${scaleX}, ${scaleY})`,
+            opacity: 1,
+          },
+          {
+            left: `${targetLeft}px`,
+            top: `${targetTop}px`,
+            width: `${targetBaseWidth}px`,
+            height: `${targetBaseHeight}px`,
+            transform: targetScaleTransform,
+            opacity: 0,
+          },
+        ],
+        {
+          duration: 260,
+          easing: 'cubic-bezier(0.4, 0, 0.2, 1)',
+          fill: 'forwards',
+        }
+      ));
+      animations.push(targetClone.animate(
+        [
+          {
+            left: `${sourceLeft}px`,
+            top: `${sourceTop}px`,
+            width: `${targetInitialWidth}px`,
+            height: `${targetInitialHeight}px`,
+            transform: targetScaleTransform,
+            opacity: 0,
+            offset: 0,
+          },
+          {
+            left: `${sourceLeft + ((targetLeft - sourceLeft) * 0.35)}px`,
+            top: `${sourceTop + ((targetTop - sourceTop) * 0.35)}px`,
+            width: `${targetInitialWidth + ((targetBaseWidth - targetInitialWidth) * 0.35)}px`,
+            height: `${targetInitialHeight + ((targetBaseHeight - targetInitialHeight) * 0.35)}px`,
+            transform: targetScaleTransform,
+            opacity: 0,
+            offset: 0.18,
+          },
+          {
+            left: `${targetLeft}px`,
+            top: `${targetTop}px`,
+            width: `${targetBaseWidth}px`,
+            height: `${targetBaseHeight}px`,
+            transform: targetScaleTransform,
+            opacity: 1,
+            offset: 1,
+          },
+        ],
+        {
+          duration: MEDIA_PANEL_VIEW_TRANSITION_MS,
+          easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+          fill: 'forwards',
+        }
+      ));
+    });
+
+    content.querySelectorAll<HTMLElement>('[data-media-panel-anim-id]').forEach((target) => {
+      const id = target.dataset.mediaPanelAnimId;
+      if (!id || pending.captures.has(id)) return;
+
+      const targetBox = rectToTransitionBox(target.getBoundingClientRect());
+      if (targetBox.width < 1 || targetBox.height < 1 || !boxesIntersect(targetBox, nextPanelBox)) return;
+
+      animations.push(target.animate(
+        [
+          { opacity: 0 },
+          { opacity: 1 },
+        ],
+        {
+          duration: 180,
+          delay: 160,
+          easing: 'ease-out',
+        }
+      ));
+    });
+
+    let finished = false;
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+
+      const active = activeViewTransitionRef.current;
+      if (active?.overlay === pending.overlay) {
+        activeViewTransitionRef.current = null;
+      }
+      window.clearTimeout(timeoutId);
+      hiddenTargets.forEach((target) => {
+        target.classList.remove('media-panel-view-transition-hidden');
+      });
+      pending.overlay.remove();
+    };
+
+    const timeoutId = window.setTimeout(finish, MEDIA_PANEL_VIEW_TRANSITION_MS + 100);
+    activeViewTransitionRef.current = {
+      animations,
+      hiddenTargets,
+      overlay: pending.overlay,
+      timeoutId,
+    };
+
+    if (animations.length === 0) {
+      finish();
+      return;
+    }
+
+    void Promise.allSettled(animations.map((animation) => animation.finished)).then(finish);
+  });
+
+  useEffect(() => () => {
+    cleanupActiveMediaPanelViewTransition();
+    cleanupPendingMediaPanelViewTransition();
+  }, [cleanupActiveMediaPanelViewTransition, cleanupPendingMediaPanelViewTransition]);
+
+  const handleViewModeChange = useCallback((nextViewMode: MediaPanelViewMode) => {
+    if (nextViewMode === viewMode) return;
+
+    prepareMediaPanelViewTransition();
+    setViewMode(nextViewMode);
+    if (nextViewMode !== 'icons') {
+      setGridFolderId(null);
+    }
+  }, [prepareMediaPanelViewTransition, viewMode]);
 
   // Column drag handlers
   const handleColumnDragStart = useCallback((e: React.DragEvent, columnId: ColumnId) => {
@@ -410,10 +950,14 @@ export function MediaPanel() {
         return idx >= 0 ? idx : 999;
       }
       case 'duration': return 'duration' in item && item.duration ? item.duration : 0;
-      case 'resolution': return 'width' in item && 'height' in item && item.width && item.height ? item.width * item.height : 0;
+      case 'resolution':
+        if (mediaFile?.type === 'gaussian-splat') {
+          return getGaussianSplatTotalCount(mediaFile) ?? getGaussianSplatFirstFrameCount(mediaFile) ?? 0;
+        }
+        return 'width' in item && 'height' in item && item.width && item.height ? item.width * item.height : 0;
       case 'fps': return mediaFile?.fps || ('type' in item && item.type === 'composition' ? (item as Composition).frameRate : 0);
-      case 'container': return mediaFile?.container?.toLowerCase() || '';
-      case 'codec': return mediaFile?.codec?.toLowerCase() || '';
+      case 'container': return getMediaFileContainerLabel(mediaFile)?.toLowerCase() || '';
+      case 'codec': return getMediaFileCodecLabel(mediaFile)?.toLowerCase() || '';
       case 'audio': return mediaFile?.hasAudio ? 1 : 0;
       case 'bitrate': return mediaFile?.bitrate || 0;
       case 'size': return mediaFile?.fileSize || 0;
@@ -587,7 +1131,7 @@ export function MediaPanel() {
         const elLeft = elRect.left - r.left + container.scrollLeft;
         const elRight = elLeft + elRect.width;
         if (elRight > mLeft && elLeft < mRight && elBottom > mTop && elTop < mBottom) {
-          const itemId = el.parentElement?.getAttribute('data-item-id');
+          const itemId = (el as HTMLElement).dataset.mediaPanelAnimId ?? el.parentElement?.getAttribute('data-item-id');
           if (itemId) hitIds.push(itemId);
         }
       });
@@ -1053,6 +1597,7 @@ export function MediaPanel() {
   const handleDragEnd = useCallback(() => {
     setInternalDragId(null);
     setDragOverFolderId(null);
+    setMediaBoardInsertionPreview(null);
     clearExternalDragPayload();
   }, []);
 
@@ -1172,6 +1717,7 @@ export function MediaPanel() {
       setViewMode(loadMediaPanelViewMode());
       setMediaBoardViewport(loadMediaBoardViewport());
       setMediaBoardOrder(loadMediaBoardOrder());
+      setMediaBoardGroupOffsets(loadMediaBoardGroupOffsets());
       const storedNameWidth = localStorage.getItem('media-panel-name-width');
       setNameColumnWidth(storedNameWidth ? parseInt(storedNameWidth, 10) : 250);
       setGridFolderId(null);
@@ -1377,8 +1923,9 @@ export function MediaPanel() {
       }
       case 'resolution':
         return (
-          <div className="media-col media-col-resolution">
-            {'width' in item && 'height' in item && item.width && item.height ? `${item.width}×${item.height}` : '–'}
+          <div className="media-col media-col-resolution" title={getGaussianSplatResolutionLabel(item) ?? undefined}>
+            {getGaussianSplatResolutionLabel(item) ??
+              ('width' in item && 'height' in item && item.width && item.height ? `${item.width}×${item.height}` : '–')}
           </div>
         );
       case 'fps':
@@ -1388,9 +1935,9 @@ export function MediaPanel() {
           </div>
         );
       case 'container':
-        return <div className="media-col media-col-container">{mediaFile?.container || '–'}</div>;
+        return <div className="media-col media-col-container">{getMediaFileContainerLabel(mediaFile) || '–'}</div>;
       case 'codec':
-        return <div className="media-col media-col-codec">{mediaFile?.codec || '–'}</div>;
+        return <div className="media-col media-col-codec">{getMediaFileCodecLabel(mediaFile) || '–'}</div>;
       case 'audio':
         return <div className="media-col media-col-audio">
           {mediaFile?.type === 'audio' ? 'Yes' :
@@ -1423,6 +1970,7 @@ export function MediaPanel() {
     return (
       <div key={item.id} data-item-id={item.id}>
         <div
+          data-media-panel-anim-id={item.id}
           className={`media-item ${isSelected ? 'selected' : ''} ${isFolder ? 'folder' : ''} ${isMediaFile && !hasFile ? 'no-file' : ''} ${isImporting ? 'importing' : ''} ${isDragTarget ? 'drag-target' : ''} ${isBeingDragged ? 'dragging' : ''}`}
           draggable={!isImporting}
           onDragStart={(e) => handleDragStart(e, item)}
@@ -1463,9 +2011,16 @@ export function MediaPanel() {
       if (comp.duration) parts.push(formatDuration(comp.duration));
     } else if ('type' in item) {
       const mf = item as MediaFile;
-      if (mf.width && mf.height) parts.push(`${mf.width}×${mf.height}`);
+      if (mf.type === 'gaussian-splat') {
+        parts.push(...getGaussianSplatDetailLines(mf));
+        const container = getMediaFileContainerLabel(mf);
+        if (container) parts.push(container);
+      } else if (mf.width && mf.height) {
+        parts.push(`${mf.width}×${mf.height}`);
+      }
       if (mf.duration) parts.push(formatDuration(mf.duration));
-      if (mf.codec) parts.push(mf.codec);
+      const codec = getMediaFileCodecLabel(mf);
+      if (codec) parts.push(codec);
       if (mf.audioCodec) parts.push(mf.audioCodec);
       if (mf.fps) parts.push(`${mf.fps} fps`);
       if (mf.fileSize) parts.push(formatFileSize(mf.fileSize));
@@ -1497,6 +2052,7 @@ export function MediaPanel() {
     return (
       <div key={item.id} data-item-id={item.id}>
         <div
+          data-media-panel-anim-id={item.id}
           className={`media-grid-item ${isSelected ? 'selected' : ''} ${isFolder ? 'folder' : ''} ${isDragTarget ? 'drag-target' : ''} ${isImporting ? 'importing' : ''}`}
           draggable={!isImporting}
           onDragStart={(e) => handleDragStart(e, item)}
@@ -1591,10 +2147,39 @@ export function MediaPanel() {
     });
   }, [folders, mediaBoardItemIds]);
 
+  useEffect(() => {
+    setMediaBoardGroupOffsets((current) => {
+      const validFolderIds = new Set(folders.map((folder) => folder.id));
+      let changed = false;
+      const next: Record<string, MediaBoardGroupOffset> = {};
+
+      Object.entries(current).forEach(([folderId, offset]) => {
+        if (!validFolderIds.has(folderId)) {
+          changed = true;
+          return;
+        }
+        next[folderId] = offset;
+      });
+
+      return changed ? next : current;
+    });
+  }, [folders]);
+
   const mediaBoardLayout = useMemo(() => {
     const groupsByParent = new Map<string | null, MediaBoardItem[]>();
     groupsByParent.set(null, []);
     folders.forEach((folder) => groupsByParent.set(folder.id, []));
+    const foldersByParent = new Map<string | null, MediaFolder[]>();
+    foldersByParent.set(null, []);
+    folders.forEach((folder) => {
+      const parentId = folder.parentId ?? null;
+      if (!foldersByParent.has(parentId)) {
+        foldersByParent.set(parentId, []);
+      }
+      foldersByParent.get(parentId)!.push(folder);
+    });
+    const itemsById = new Map(mediaBoardItems.map((item) => [item.id, item]));
+    const movingIdSet = new Set(mediaBoardInsertionPreview?.movingIds ?? []);
 
     mediaBoardItems.forEach((item) => {
       const parentId = item.parentId ?? null;
@@ -1604,20 +2189,9 @@ export function MediaPanel() {
       groupsByParent.get(parentId)!.push(item);
     });
 
-    const orderedGroupIds: Array<string | null> = [
-      null,
-      ...folders
-        .map((folder) => folder.id)
-        .sort((leftId, rightId) =>
-          getMediaBoardGroupName(leftId, folders).localeCompare(getMediaBoardGroupName(rightId, folders))
-        ),
-    ].filter((groupId, index, ids) => ids.indexOf(groupId) === index);
-
     const groups: MediaBoardGroupLayout[] = [];
     const placements: MediaBoardNodePlacement[] = [];
-    let rowY = 0;
-    let rowMaxHeight = 0;
-    let column = 0;
+    const insertGaps: MediaBoardInsertGapPlacement[] = [];
 
     const orderItemsForGroup = (groupId: string | null, items: MediaBoardItem[]): MediaBoardItem[] => {
       const sortedItems = sortItems([...items]) as MediaBoardItem[];
@@ -1635,55 +2209,314 @@ export function MediaPanel() {
       ];
     };
 
-    orderedGroupIds.forEach((groupId) => {
-      const items = orderItemsForGroup(groupId, groupsByParent.get(groupId) ?? []);
-      const rows = Math.max(1, Math.ceil(items.length / MEDIA_BOARD_COLUMNS_PER_GROUP));
-      const height = MEDIA_BOARD_GROUP_HEADER_HEIGHT
-        + (MEDIA_BOARD_GROUP_PADDING * 2)
-        + (rows * MEDIA_BOARD_NODE_HEIGHT)
-        + ((rows - 1) * MEDIA_BOARD_NODE_GAP);
-      const x = column * (MEDIA_BOARD_GROUP_WIDTH + MEDIA_BOARD_GROUP_GAP);
-      const y = rowY;
+    type MediaBoardLayoutEntry = {
+      id: string;
+      item?: MediaBoardItem;
+      width: number;
+      height: number;
+      isInsertGap: boolean;
+    };
+
+    type MediaBoardLayoutRow = {
+      entries: MediaBoardLayoutEntry[];
+      width: number;
+      height: number;
+    };
+
+    type MediaBoardFolderBlock = {
+      folder: MediaFolder;
+      width: number;
+      height: number;
+      desiredX: number;
+      desiredY: number;
+    };
+
+    type MediaBoardGroupMeasure = {
+      width: number;
+      height: number;
+      itemRows: MediaBoardLayoutRow[];
+      folderRows: Array<{ entries: MediaBoardFolderBlock[]; width: number; height: number }>;
+      itemCount: number;
+      bodyHeight: number;
+    };
+
+    const getEntriesForGroup = (groupId: string | null): MediaBoardLayoutEntry[] => {
+      const entries = orderItemsForGroup(groupId, groupsByParent.get(groupId) ?? [])
+        .filter((item) => !movingIdSet.has(item.id))
+        .map((item) => ({
+          id: item.id,
+          item,
+          ...getMediaBoardNodeSize(item),
+          isInsertGap: false,
+        }));
+
+      if (!mediaBoardInsertionPreview || mediaBoardInsertionPreview.targetGroupId !== groupId) {
+        return entries;
+      }
+
+      const gapEntries = mediaBoardInsertionPreview.movingIds
+        .map((id, index) => {
+          const item = itemsById.get(id);
+          if (!item) return null;
+          return {
+            id: `insert-gap-${id}-${index}`,
+            ...getMediaBoardNodeSize(item),
+            isInsertGap: true,
+          };
+        })
+        .filter((entry): entry is MediaBoardLayoutEntry => Boolean(entry));
+
+      if (gapEntries.length === 0) {
+        return entries;
+      }
+
+      const insertIndex = Math.max(0, Math.min(mediaBoardInsertionPreview.targetIndex, entries.length));
+      return [
+        ...entries.slice(0, insertIndex),
+        ...gapEntries,
+        ...entries.slice(insertIndex),
+      ];
+    };
+
+    function wrapEntriesIntoRows<T extends { width: number; height: number }>(
+      entries: T[],
+      maxRowWidth: number,
+    ): Array<{ entries: T[]; width: number; height: number }> {
+      const rows: Array<{ entries: T[]; width: number; height: number }> = [];
+      let currentEntries: T[] = [];
+      let currentWidth = 0;
+      let currentHeight = 0;
+
+      const flushRow = () => {
+        if (currentEntries.length === 0) return;
+        rows.push({
+          entries: currentEntries,
+          width: currentWidth,
+          height: currentHeight,
+        });
+        currentEntries = [];
+        currentWidth = 0;
+        currentHeight = 0;
+      };
+
+      entries.forEach((entry) => {
+        const nextWidth = currentEntries.length === 0
+          ? entry.width
+          : currentWidth + MEDIA_BOARD_NODE_GAP + entry.width;
+        if (currentEntries.length > 0 && nextWidth > maxRowWidth) {
+          flushRow();
+        }
+
+        currentWidth = currentEntries.length === 0
+          ? entry.width
+          : currentWidth + MEDIA_BOARD_NODE_GAP + entry.width;
+        currentHeight = Math.max(currentHeight, entry.height);
+        currentEntries.push(entry);
+      });
+
+      flushRow();
+      return rows;
+    }
+
+    const getRowsHeight = (rows: Array<{ height: number }>, gap: number): number => {
+      return rows.reduce((height, row, index) => height + row.height + (index > 0 ? gap : 0), 0);
+    };
+
+    const getChildFolders = (parentId: string | null): MediaFolder[] => {
+      return [...(foldersByParent.get(parentId) ?? [])].sort((a, b) => a.name.localeCompare(b.name));
+    };
+
+    const measureCache = new Map<string, MediaBoardGroupMeasure>();
+    const measureGroup = (groupId: string | null, stack: Set<string> = new Set()): MediaBoardGroupMeasure => {
+      const cacheKey = getMediaBoardOrderKey(groupId);
+      const cached = measureCache.get(cacheKey);
+      if (cached) return cached;
+
+      if (groupId && stack.has(groupId)) {
+        return {
+          width: MEDIA_BOARD_GROUP_MIN_WIDTH,
+          height: MEDIA_BOARD_GROUP_HEADER_HEIGHT + (MEDIA_BOARD_GROUP_PADDING * 2) + MEDIA_BOARD_NODE_MIN_HEIGHT,
+          itemRows: [],
+          folderRows: [],
+          itemCount: 0,
+          bodyHeight: MEDIA_BOARD_NODE_MIN_HEIGHT,
+        };
+      }
+
+      const nextStack = new Set(stack);
+      if (groupId) {
+        nextStack.add(groupId);
+      }
+
+      const itemRows = wrapEntriesIntoRows(getEntriesForGroup(groupId), MEDIA_BOARD_GROUP_MAX_BODY_WIDTH) as MediaBoardLayoutRow[];
+      const childFolderBlocks = getChildFolders(groupId)
+        .map((folder, index) => {
+          const childMeasure = measureGroup(folder.id, nextStack);
+          const offset = mediaBoardGroupOffsets[folder.id] ?? { x: 0, y: 0 };
+          return {
+            folder,
+            width: childMeasure.width,
+            height: childMeasure.height,
+            desiredX: Math.max(0, (index * (MEDIA_BOARD_GROUP_MIN_WIDTH + MEDIA_BOARD_FOLDER_GAP)) + offset.x),
+            desiredY: Math.max(0, offset.y),
+          };
+        })
+        .sort((a, b) => (a.desiredY - b.desiredY) || (a.desiredX - b.desiredX) || a.folder.name.localeCompare(b.folder.name));
+      const folderRows = wrapEntriesIntoRows(childFolderBlocks, MEDIA_BOARD_FOLDER_ROW_MAX_WIDTH);
+      const itemRowsHeight = getRowsHeight(itemRows, MEDIA_BOARD_NODE_GAP);
+      const folderRowsHeight = getRowsHeight(folderRows, MEDIA_BOARD_FOLDER_GAP);
+      const hasItems = itemRows.length > 0;
+      const hasFolders = folderRows.length > 0;
+      const bodyWidth = Math.max(
+        0,
+        ...itemRows.map((row) => row.width),
+        ...folderRows.map((row) => row.width),
+      );
+      const bodyHeight = hasItems || hasFolders
+        ? itemRowsHeight + folderRowsHeight + (hasItems && hasFolders ? MEDIA_BOARD_FOLDER_GAP : 0)
+        : MEDIA_BOARD_NODE_MIN_HEIGHT;
+      const measure: MediaBoardGroupMeasure = {
+        width: Math.max(MEDIA_BOARD_GROUP_MIN_WIDTH, Math.ceil(bodyWidth + (MEDIA_BOARD_GROUP_PADDING * 2))),
+        height: MEDIA_BOARD_GROUP_HEADER_HEIGHT + (MEDIA_BOARD_GROUP_PADDING * 2) + bodyHeight,
+        itemRows,
+        folderRows,
+        itemCount: (groupsByParent.get(groupId)?.length ?? 0) + (foldersByParent.get(groupId)?.length ?? 0),
+        bodyHeight,
+      };
+      measureCache.set(cacheKey, measure);
+      return measure;
+    };
+
+    const placeGroup = (groupId: string | null, x: number, y: number, depth: number, parentId: string | null) => {
+      const measure = measureGroup(groupId);
       const group: MediaBoardGroupLayout = {
         id: groupId,
+        parentId,
         name: getMediaBoardGroupName(groupId, folders),
         x,
         y,
-        width: MEDIA_BOARD_GROUP_WIDTH,
-        height,
-        itemCount: items.length,
+        width: measure.width,
+        height: measure.height,
+        itemCount: measure.itemCount,
+        depth,
       };
       groups.push(group);
 
-      items.forEach((item, index) => {
-        const col = index % MEDIA_BOARD_COLUMNS_PER_GROUP;
-        const row = Math.floor(index / MEDIA_BOARD_COLUMNS_PER_GROUP);
-        const defaultLayout: MediaBoardNodeLayout = {
-          x: x + MEDIA_BOARD_GROUP_PADDING + (col * (MEDIA_BOARD_NODE_WIDTH + MEDIA_BOARD_NODE_GAP)),
-          y: y + MEDIA_BOARD_GROUP_HEADER_HEIGHT + MEDIA_BOARD_GROUP_PADDING + (row * (MEDIA_BOARD_NODE_HEIGHT + MEDIA_BOARD_NODE_GAP)),
-          width: MEDIA_BOARD_NODE_WIDTH,
-          height: MEDIA_BOARD_NODE_HEIGHT,
-        };
+      let entryTop = y + MEDIA_BOARD_GROUP_HEADER_HEIGHT + MEDIA_BOARD_GROUP_PADDING;
+      let entrySlotIndex = 0;
+      measure.itemRows.forEach((layoutRow, rowIndex) => {
+        let entryLeft = x + MEDIA_BOARD_GROUP_PADDING;
+        if (rowIndex > 0) {
+          entryTop += MEDIA_BOARD_NODE_GAP;
+        }
+
+        layoutRow.entries.forEach((entry, entryIndex) => {
+          if (entryIndex > 0) {
+            entryLeft += MEDIA_BOARD_NODE_GAP;
+          }
+          const layout: MediaBoardNodeLayout = {
+            x: entryLeft,
+            y: entryTop + ((layoutRow.height - entry.height) / 2),
+            width: entry.width,
+            height: entry.height,
+          };
+
+          if (entry.isInsertGap) {
+            insertGaps.push({
+              id: entry.id,
+              layout,
+              groupId,
+              slotIndex: entrySlotIndex,
+            });
+          } else if (entry.item) {
+            placements.push({
+              item: entry.item,
+              defaultLayout: layout,
+              groupId,
+              layout,
+              slotIndex: entrySlotIndex,
+            });
+          }
+
+          entryLeft += entry.width;
+          entrySlotIndex += 1;
+        });
+        entryTop += layoutRow.height;
+      });
+
+      if (measure.itemRows.length > 0 && measure.folderRows.length > 0) {
+        entryTop += MEDIA_BOARD_FOLDER_GAP;
+      }
+
+      measure.folderRows.forEach((folderRow, rowIndex) => {
+        let rowCursorX = x + MEDIA_BOARD_GROUP_PADDING;
+        let rowMaxBottom = entryTop;
+        if (rowIndex > 0) {
+          entryTop += MEDIA_BOARD_FOLDER_GAP;
+          rowCursorX = x + MEDIA_BOARD_GROUP_PADDING;
+          rowMaxBottom = entryTop;
+        }
+
+        folderRow.entries.forEach((block) => {
+          const desiredX = x + MEDIA_BOARD_GROUP_PADDING + block.desiredX;
+          const desiredY = entryTop + block.desiredY;
+          const childX = Math.max(rowCursorX, desiredX);
+          const childY = Math.max(
+            y + MEDIA_BOARD_GROUP_HEADER_HEIGHT + MEDIA_BOARD_GROUP_PADDING,
+            desiredY,
+          );
+          placeGroup(
+            block.folder.id,
+            childX,
+            childY,
+            depth + 1,
+            groupId,
+          );
+          rowCursorX = childX + block.width + MEDIA_BOARD_FOLDER_GAP;
+          rowMaxBottom = Math.max(rowMaxBottom, childY + block.height);
+        });
+        entryTop = Math.max(entryTop + folderRow.height, rowMaxBottom);
+      });
+    };
+
+    placeGroup(null, 0, 0, 0, null);
+
+    const groupsByKey = new Map(groups.map((group) => [getMediaBoardOrderKey(group.id), group]));
+    [...groups]
+      .sort((a, b) => b.depth - a.depth)
+      .forEach((group) => {
+        if (group.parentId === null && group.id !== null) {
+          const parent = groupsByKey.get(MEDIA_BOARD_ROOT_ORDER_KEY);
+          if (!parent) return;
+          parent.width = Math.max(parent.width, Math.ceil(group.x + group.width - parent.x + MEDIA_BOARD_GROUP_PADDING));
+          parent.height = Math.max(parent.height, Math.ceil(group.y + group.height - parent.y + MEDIA_BOARD_GROUP_PADDING));
+          return;
+        }
+        if (!group.parentId) return;
+        const parent = groupsByKey.get(group.parentId);
+        if (!parent) return;
+        parent.width = Math.max(parent.width, Math.ceil(group.x + group.width - parent.x + MEDIA_BOARD_GROUP_PADDING));
+        parent.height = Math.max(parent.height, Math.ceil(group.y + group.height - parent.y + MEDIA_BOARD_GROUP_PADDING));
+      });
+
+    if (mediaBoardInsertionPreview) {
+      mediaBoardInsertionPreview.movingIds.forEach((id, index) => {
+        const item = itemsById.get(id);
+        const sourceLayout = mediaBoardInsertionPreview.sourceLayouts[id];
+        if (!item || !sourceLayout) return;
         placements.push({
           item,
-          defaultLayout,
-          groupId,
-          layout: defaultLayout,
+          defaultLayout: sourceLayout,
+          groupId: item.parentId ?? null,
+          isDraggingPreview: true,
+          layout: sourceLayout,
           slotIndex: index,
         });
       });
+    }
 
-      rowMaxHeight = Math.max(rowMaxHeight, height);
-      column += 1;
-      if (column >= 2) {
-        rowY += rowMaxHeight + MEDIA_BOARD_GROUP_GAP;
-        rowMaxHeight = 0;
-        column = 0;
-      }
-    });
-
-    return { groups, placements };
-  }, [folders, mediaBoardItems, mediaBoardOrder, sortItems]);
+    return { groups, placements, insertGaps };
+  }, [folders, mediaBoardGroupOffsets, mediaBoardInsertionPreview, mediaBoardItems, mediaBoardOrder, sortItems]);
 
   const mediaBoardPlacementsById = useMemo(() => {
     return new Map(mediaBoardLayout.placements.map((placement) => [placement.item.id, placement]));
@@ -1708,7 +2541,9 @@ export function MediaPanel() {
   }, []);
 
   const startMediaBoardPanGesture = useCallback((e: React.MouseEvent, options?: { clearSelectionOnTap?: boolean }) => {
-    e.preventDefault();
+    if (e.button === 1) {
+      e.preventDefault();
+    }
     closeContextMenu();
 
     const startX = e.clientX;
@@ -1724,6 +2559,8 @@ export function MediaPanel() {
         const inner = boardCanvasInnerRef.current;
         if (!inner) return;
         inner.style.transform = `translate(${pendingViewport.panX}px, ${pendingViewport.panY}px) scale(${pendingViewport.zoom})`;
+        boardWrapperRef.current?.style.setProperty('--media-board-grid-x', `${pendingViewport.panX * MEDIA_BOARD_GRID_PARALLAX}px`);
+        boardWrapperRef.current?.style.setProperty('--media-board-grid-y', `${pendingViewport.panY * MEDIA_BOARD_GRID_PARALLAX}px`);
       });
     };
 
@@ -1735,9 +2572,11 @@ export function MediaPanel() {
 
       if (!didPan) {
         didPan = true;
+        moveEvent.preventDefault();
         setMediaBoardPerformanceMode(true);
       }
 
+      moveEvent.preventDefault();
       pendingViewport = {
         ...startViewport,
         panX: startViewport.panX + dx,
@@ -1824,14 +2663,149 @@ export function MediaPanel() {
     window.addEventListener('blur', handleMouseUp);
   }, [closeContextMenu, mediaBoardLayout.placements, screenToMediaBoard, selectedIds, setSelection, suppressNextMediaBoardContextMenu]);
 
+  const startMediaBoardGroupMoveGesture = useCallback((e: React.MouseEvent, group: MediaBoardGroupLayout) => {
+    if (!group.id) return;
+
+    e.stopPropagation();
+
+    const movingGroupIds = new Set<string>([group.id]);
+    let changed = true;
+    while (changed) {
+      changed = false;
+      folders.forEach((folder) => {
+        if (folder.parentId && movingGroupIds.has(folder.parentId) && !movingGroupIds.has(folder.id)) {
+          movingGroupIds.add(folder.id);
+          changed = true;
+        }
+      });
+    }
+
+    const groupElements = [...movingGroupIds]
+      .map((folderId) => boardCanvasRef.current?.querySelector<HTMLElement>(`.media-board-group[data-board-group-key="${CSS.escape(folderId)}"]`) ?? null)
+      .filter((element): element is HTMLElement => Boolean(element));
+    const nodeElements = mediaBoardLayout.placements
+      .filter((placement) => placement.groupId !== null && movingGroupIds.has(placement.groupId))
+      .map((placement) => boardCanvasRef.current?.querySelector<HTMLElement>(`.media-board-node[data-item-id="${CSS.escape(placement.item.id)}"]`) ?? null)
+      .filter((element): element is HTMLElement => Boolean(element));
+    const movingElements = [...groupElements, ...nodeElements];
+    if (movingElements.length === 0) return;
+
+    const movingFolderIds = [group.id];
+    const startX = e.clientX;
+    const startY = e.clientY;
+    let didDrag = false;
+    let previewDx = 0;
+    let previewDy = 0;
+
+    const clearPreview = () => {
+      movingElements.forEach((element) => {
+        element.style.transform = '';
+        element.classList.remove('drag-preview');
+      });
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    const schedulePreview = () => {
+      if (boardInteractionFrameRef.current !== null) return;
+      boardInteractionFrameRef.current = window.requestAnimationFrame(() => {
+        boardInteractionFrameRef.current = null;
+        movingElements.forEach((element) => {
+          element.style.transform = `translate3d(${previewDx}px, ${previewDy}px, 0)`;
+          element.classList.add('drag-preview');
+        });
+      });
+    };
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      const distance = Math.hypot(moveEvent.clientX - startX, moveEvent.clientY - startY);
+      if (!didDrag && distance < MEDIA_BOARD_DRAG_START_DISTANCE) return;
+
+      if (!didDrag) {
+        didDrag = true;
+        closeContextMenu();
+        setMediaBoardPerformanceMode(true);
+        document.body.style.cursor = 'grabbing';
+        document.body.style.userSelect = 'none';
+      }
+
+      moveEvent.preventDefault();
+      previewDx = (moveEvent.clientX - startX) / mediaBoardViewport.zoom;
+      previewDy = (moveEvent.clientY - startY) / mediaBoardViewport.zoom;
+      schedulePreview();
+    };
+
+    const handleMouseUp = () => {
+      if (boardInteractionFrameRef.current !== null) {
+        window.cancelAnimationFrame(boardInteractionFrameRef.current);
+        boardInteractionFrameRef.current = null;
+      }
+      clearPreview();
+      setMediaBoardPerformanceMode(false);
+
+      if (didDrag) {
+        suppressNextMediaBoardContextMenu();
+        setMediaBoardGroupOffsets((current) => {
+          const next: Record<string, MediaBoardGroupOffset> = { ...current };
+          movingFolderIds.forEach((folderId) => {
+            const currentOffset = next[folderId] ?? { x: 0, y: 0 };
+            const x = currentOffset.x + previewDx;
+            const y = currentOffset.y + previewDy;
+            if (Math.abs(x) < 0.5 && Math.abs(y) < 0.5) {
+              delete next[folderId];
+            } else {
+              next[folderId] = { x, y };
+            }
+          });
+          return next;
+        });
+      }
+
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+      window.removeEventListener('blur', handleMouseUp);
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    window.addEventListener('blur', handleMouseUp);
+  }, [
+    closeContextMenu,
+    folders,
+    mediaBoardLayout.placements,
+    mediaBoardViewport.zoom,
+    setMediaBoardPerformanceMode,
+    suppressNextMediaBoardContextMenu,
+  ]);
+
   const getMediaBoardGroupAtPoint = useCallback((point: { x: number; y: number }) => {
-    return mediaBoardLayout.groups.find((group) => (
-      point.x >= group.x
-      && point.x <= group.x + group.width
-      && point.y >= group.y
-      && point.y <= group.y + group.height
-    )) ?? null;
+    return mediaBoardLayout.groups
+      .filter((group) => (
+        point.x >= group.x
+        && point.x <= group.x + group.width
+        && point.y >= group.y
+        && point.y <= group.y + group.height
+      ))
+      .sort((a, b) => b.depth - a.depth)[0] ?? null;
   }, [mediaBoardLayout.groups]);
+
+  const canMoveItemsToMediaBoardGroup = useCallback((itemIds: string[], targetGroupId: string | null) => {
+    if (!targetGroupId) return true;
+
+    return itemIds.every((itemId) => {
+      const draggedFolder = folders.find((folder) => folder.id === itemId);
+      if (!draggedFolder) return true;
+
+      let parent = folders.find((folder) => folder.id === targetGroupId);
+      while (parent) {
+        if (parent.id === itemId) {
+          return false;
+        }
+        parent = parent.parentId ? folders.find((folder) => folder.id === parent!.parentId) : undefined;
+      }
+      return true;
+    });
+  }, [folders]);
 
   const handleMediaBoardWorkspaceContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -1863,6 +2837,37 @@ export function MediaPanel() {
 
     return { groupId: targetGroup.id, index: targetIndex };
   }, [getMediaBoardGroupAtPoint, mediaBoardLayout.placements]);
+
+  const updateMediaBoardInsertionPreview = useCallback((
+    point: { x: number; y: number },
+    movingIds: string[],
+    sourceLayouts: Record<string, MediaBoardNodeLayout>,
+  ) => {
+    const target = getMediaBoardInsertTarget(point, movingIds);
+    if (!target) {
+      setMediaBoardInsertionPreview(null);
+      return null;
+    }
+
+    const movingKey = movingIds.join('\u0000');
+    setMediaBoardInsertionPreview((current) => {
+      if (
+        current
+        && current.targetGroupId === target.groupId
+        && current.targetIndex === target.index
+        && current.movingIds.join('\u0000') === movingKey
+      ) {
+        return current;
+      }
+      return {
+        movingIds,
+        sourceLayouts,
+        targetGroupId: target.groupId,
+        targetIndex: target.index,
+      };
+    });
+    return target;
+  }, [getMediaBoardInsertTarget]);
 
   const getMediaBoardAppendIndex = useCallback((groupId: string | null, movingIds: string[]) => {
     const movingIdSet = new Set(movingIds);
@@ -1933,6 +2938,10 @@ export function MediaPanel() {
 
     if (startLayouts.length === 0) return;
 
+    const sourceLayouts = startLayouts.reduce<Record<string, MediaBoardNodeLayout>>((layouts, entry) => {
+      layouts[entry.id] = entry.layout;
+      return layouts;
+    }, {});
     const startX = e.clientX;
     const startY = e.clientY;
     let didDrag = false;
@@ -1940,6 +2949,7 @@ export function MediaPanel() {
     let previewDy = 0;
     let latestClientX = startX;
     let latestClientY = startY;
+    let latestInsertTarget: { groupId: string | null; index: number } | null = null;
 
     const clearPreview = () => {
       startLayouts.forEach(({ id }) => {
@@ -1978,6 +2988,11 @@ export function MediaPanel() {
 
       previewDx = (moveEvent.clientX - startX) / mediaBoardViewport.zoom;
       previewDy = (moveEvent.clientY - startY) / mediaBoardViewport.zoom;
+      latestInsertTarget = updateMediaBoardInsertionPreview(
+        screenToMediaBoard(moveEvent.clientX, moveEvent.clientY),
+        moveIds,
+        sourceLayouts,
+      );
       schedulePreview();
     };
 
@@ -1988,10 +3003,10 @@ export function MediaPanel() {
       }
       clearPreview();
       setMediaBoardPerformanceMode(false);
+      setMediaBoardInsertionPreview(null);
 
       if (didDrag) {
-        const point = screenToMediaBoard(latestClientX, latestClientY);
-        const target = getMediaBoardInsertTarget(point, moveIds);
+        const target = latestInsertTarget ?? getMediaBoardInsertTarget(screenToMediaBoard(latestClientX, latestClientY), moveIds);
         if (target) {
           commitMediaBoardOrderChange(moveIds, target.groupId, target.index);
         }
@@ -2017,6 +3032,7 @@ export function MediaPanel() {
     screenToMediaBoard,
     setMediaBoardPerformanceMode,
     suppressNextMediaBoardContextMenu,
+    updateMediaBoardInsertionPreview,
   ]);
 
   const handleMediaBoardWheel = useCallback((e: React.WheelEvent) => {
@@ -2042,7 +3058,7 @@ export function MediaPanel() {
 
   const handleMediaBoardMouseDown = useCallback((e: React.MouseEvent) => {
     const target = e.target as HTMLElement;
-    if (target.closest('.media-board-node, button, input, .context-menu')) return;
+    if (target.closest('.media-board-node, .media-board-group.folder-group, button, input, .context-menu')) return;
 
     if (e.button === 2) {
       startMediaBoardMarqueeGesture(e);
@@ -2073,6 +3089,8 @@ export function MediaPanel() {
     if (e.button !== 0) return;
 
     e.stopPropagation();
+    if (e.detail >= 2) return;
+
     handleItemClick(item.id, e);
 
     if (!e.ctrlKey && !e.metaKey && !e.shiftKey) {
@@ -2087,10 +3105,55 @@ export function MediaPanel() {
     startMediaBoardPanGesture,
   ]);
 
+  const updateMediaBoardInsertionFromNativeDrag = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes('application/x-media-panel-item')) {
+      setMediaBoardInsertionPreview(null);
+      return false;
+    }
+
+    const itemId = e.dataTransfer.getData('application/x-media-panel-item') || internalDragId || '';
+    if (!itemId) {
+      setMediaBoardInsertionPreview(null);
+      return false;
+    }
+
+    const itemIds = selectedIds.includes(itemId) ? selectedIds : [itemId];
+    if (itemIds.some((id) => folders.some((folder) => folder.id === id))) {
+      setMediaBoardInsertionPreview(null);
+      return false;
+    }
+
+    const movingIds = itemIds.filter((id) => mediaBoardItemIds.has(id));
+    if (movingIds.length === 0) {
+      setMediaBoardInsertionPreview(null);
+      return false;
+    }
+
+    const sourceLayouts = movingIds.reduce<Record<string, MediaBoardNodeLayout>>((layouts, id) => {
+      const placement = mediaBoardPlacementsById.get(id);
+      if (placement) {
+        layouts[id] = placement.defaultLayout;
+      }
+      return layouts;
+    }, {});
+
+    updateMediaBoardInsertionPreview(screenToMediaBoard(e.clientX, e.clientY), movingIds, sourceLayouts);
+    return true;
+  }, [
+    folders,
+    internalDragId,
+    mediaBoardItemIds,
+    mediaBoardPlacementsById,
+    screenToMediaBoard,
+    selectedIds,
+    updateMediaBoardInsertionPreview,
+  ]);
+
   const handleMediaBoardDrop = useCallback(async (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
     setIsExternalDragOver(false);
+    setMediaBoardInsertionPreview(null);
 
     if (e.dataTransfer.types.includes('application/x-media-panel-item')) {
       const itemId = e.dataTransfer.getData('application/x-media-panel-item');
@@ -2098,7 +3161,11 @@ export function MediaPanel() {
         const itemsToMove = selectedIds.includes(itemId) ? selectedIds : [itemId];
         const isFolderMove = itemsToMove.some((id) => folders.some((folder) => folder.id === id));
         if (isFolderMove) {
-          moveToFolder(itemsToMove, null);
+          const point = screenToMediaBoard(e.clientX, e.clientY);
+          const targetGroup = getMediaBoardGroupAtPoint(point);
+          if (targetGroup && canMoveItemsToMediaBoardGroup(itemsToMove, targetGroup.id)) {
+            moveToFolder(itemsToMove, targetGroup.id);
+          }
         } else {
           const point = screenToMediaBoard(e.clientX, e.clientY);
           const target = getMediaBoardInsertTarget(point, itemsToMove);
@@ -2113,37 +3180,24 @@ export function MediaPanel() {
     }
 
     const point = screenToMediaBoard(e.clientX, e.clientY);
-    const targetGroup = mediaBoardLayout.groups.find((group) => (
-      point.x >= group.x
-      && point.x <= group.x + group.width
-      && point.y >= group.y
-      && point.y <= group.y + group.height
-    ));
+    const targetGroup = getMediaBoardGroupAtPoint(point);
     await handleExternalDropImport(e.dataTransfer, targetGroup?.id ?? null);
-  }, [commitMediaBoardOrderChange, folders, getMediaBoardAppendIndex, getMediaBoardInsertTarget, handleExternalDropImport, mediaBoardLayout.groups, moveToFolder, screenToMediaBoard, selectedIds]);
+  }, [canMoveItemsToMediaBoardGroup, commitMediaBoardOrderChange, folders, getMediaBoardAppendIndex, getMediaBoardGroupAtPoint, getMediaBoardInsertTarget, handleExternalDropImport, moveToFolder, screenToMediaBoard, selectedIds]);
 
   const handleMediaBoardGroupDrop = useCallback(async (e: React.DragEvent, groupId: string | null) => {
     e.preventDefault();
     e.stopPropagation();
+    setMediaBoardInsertionPreview(null);
 
     if (e.dataTransfer.types.includes('application/x-media-panel-item')) {
       const itemId = e.dataTransfer.getData('application/x-media-panel-item');
       if (itemId) {
-        if (groupId) {
-          const draggedFolder = folders.find((folder) => folder.id === itemId);
-          if (draggedFolder) {
-            let parent = folders.find((folder) => folder.id === groupId);
-            while (parent) {
-              if (parent.id === itemId) {
-                setDragOverFolderId(null);
-                setInternalDragId(null);
-                return;
-              }
-              parent = parent.parentId ? folders.find((folder) => folder.id === parent!.parentId) : undefined;
-            }
-          }
-        }
         const itemsToMove = selectedIds.includes(itemId) ? selectedIds : [itemId];
+        if (!canMoveItemsToMediaBoardGroup(itemsToMove, groupId)) {
+          setDragOverFolderId(null);
+          setInternalDragId(null);
+          return;
+        }
         const isFolderMove = itemsToMove.some((id) => folders.some((folder) => folder.id === id));
         if (isFolderMove) {
           moveToFolder(itemsToMove, groupId);
@@ -2162,17 +3216,19 @@ export function MediaPanel() {
 
     await handleExternalDropImport(e.dataTransfer, groupId);
     setIsExternalDragOver(false);
-  }, [commitMediaBoardOrderChange, folders, getMediaBoardAppendIndex, getMediaBoardInsertTarget, handleExternalDropImport, moveToFolder, screenToMediaBoard, selectedIds]);
+  }, [canMoveItemsToMediaBoardGroup, commitMediaBoardOrderChange, folders, getMediaBoardAppendIndex, getMediaBoardInsertTarget, handleExternalDropImport, moveToFolder, screenToMediaBoard, selectedIds]);
 
   const handleMediaBoardGroupDragOver = useCallback((e: React.DragEvent) => {
     if (!e.dataTransfer.types.includes('application/x-media-panel-item') && !e.dataTransfer.types.includes('Files')) return;
     e.preventDefault();
     e.stopPropagation();
     e.dataTransfer.dropEffect = e.dataTransfer.types.includes('application/x-media-panel-item') ? 'move' : 'copy';
-  }, []);
+    updateMediaBoardInsertionFromNativeDrag(e);
+  }, [updateMediaBoardInsertionFromNativeDrag]);
 
   const resetMediaBoardLayout = useCallback(() => {
     setMediaBoardOrder({});
+    setMediaBoardGroupOffsets({});
     setMediaBoardViewport(DEFAULT_BOARD_VIEWPORT);
   }, []);
 
@@ -2192,17 +3248,26 @@ export function MediaPanel() {
     const importProgress = getItemImportProgress(item);
     const labelHex = 'labelColor' in item ? getLabelHex(item.labelColor) : 'transparent';
     const title = buildGridTooltip(item, false, isComp);
-    const resolutionLabel = 'width' in item && 'height' in item && item.width && item.height
-      ? `${item.width}x${item.height}`
-      : comp
-        ? `${comp.width}x${comp.height}`
-        : null;
+    const splatStatsLabel = mediaFile?.type === 'gaussian-splat'
+      ? getGaussianSplatResolutionLabel(mediaFile)
+      : null;
+    const resolutionLabel = splatStatsLabel ??
+      ('width' in item && 'height' in item && item.width && item.height
+        ? `${item.width}x${item.height}`
+        : comp
+          ? `${comp.width}x${comp.height}`
+          : null);
+    const boardCodecLabel = mediaFile?.type === 'gaussian-splat'
+      ? getMediaFileContainerLabel(mediaFile)
+      : getMediaFileCodecLabel(mediaFile);
 
     return (
       <div
         key={item.id}
         data-item-id={item.id}
-        className={`media-board-node ${isSelected ? 'selected' : ''} ${isMediaFile && !mediaFile?.file ? 'no-file' : ''} ${importProgress !== null ? 'importing' : ''} ${isTextItem ? 'text' : ''}`}
+        data-board-group-key={getMediaBoardOrderKey(placement.groupId)}
+        data-media-panel-anim-id={item.id}
+        className={`media-board-node ${isSelected ? 'selected' : ''} ${isMediaFile && !mediaFile?.file ? 'no-file' : ''} ${importProgress !== null ? 'importing' : ''} ${isTextItem ? 'text' : ''} ${placement.isDraggingPreview ? 'drag-source-preview' : ''}`}
         style={{
           left: layout.x,
           top: layout.y,
@@ -2260,7 +3325,7 @@ export function MediaPanel() {
           <div className="media-board-node-meta">
             <span>{getMediaBoardTypeLabel(item)}</span>
             {resolutionLabel ? <span>{resolutionLabel}</span> : null}
-            {mediaFile?.codec ? <span>{mediaFile.codec}</span> : null}
+            {boardCodecLabel ? <span>{boardCodecLabel}</span> : null}
           </div>
         </div>
       </div>
@@ -2268,7 +3333,14 @@ export function MediaPanel() {
   };
 
   const renderMediaBoardView = () => (
-    <div className="media-board-wrapper" ref={boardWrapperRef}>
+    <div
+      className="media-board-wrapper"
+      ref={boardWrapperRef}
+      style={{
+        '--media-board-grid-x': `${mediaBoardViewport.panX * MEDIA_BOARD_GRID_PARALLAX}px`,
+        '--media-board-grid-y': `${mediaBoardViewport.panY * MEDIA_BOARD_GRID_PARALLAX}px`,
+      } as React.CSSProperties}
+    >
       <div className="media-board-toolbar">
         <div className="media-board-toolbar-title">
           <span>Board</span>
@@ -2302,6 +3374,12 @@ export function MediaPanel() {
           }
           e.preventDefault();
           e.dataTransfer.dropEffect = e.dataTransfer.types.includes('application/x-media-panel-item') ? 'move' : 'copy';
+          updateMediaBoardInsertionFromNativeDrag(e);
+        }}
+        onDragLeave={(e) => {
+          if (e.currentTarget === e.target) {
+            setMediaBoardInsertionPreview(null);
+          }
         }}
         onDrop={handleMediaBoardDrop}
       >
@@ -2312,24 +3390,81 @@ export function MediaPanel() {
             transform: `translate(${mediaBoardViewport.panX}px, ${mediaBoardViewport.panY}px) scale(${mediaBoardViewport.zoom})`,
           }}
         >
-          {mediaBoardLayout.groups.map((group) => (
-            <div
-              key={group.id ?? 'root'}
-              className="media-board-group"
-              style={{
-                left: group.x,
-                top: group.y,
-                width: group.width,
-                height: group.height,
-              }}
-              onDragOver={handleMediaBoardGroupDragOver}
-              onDrop={(e) => handleMediaBoardGroupDrop(e, group.id)}
-            >
-              <div className="media-board-group-header">
-                <span>{group.name}</span>
-                <span>{group.itemCount}</span>
+          {mediaBoardLayout.groups.map((group) => {
+            const folder = group.id ? folders.find((candidate) => candidate.id === group.id) : null;
+            const isRenamingGroup = group.id !== null && renamingId === group.id;
+            return (
+              <div
+                key={group.id ?? 'root'}
+                className={`media-board-group ${group.id ? 'folder-group' : 'root-group'} depth-${Math.min(group.depth, 3)}`}
+                data-board-group-key={getMediaBoardOrderKey(group.id)}
+                data-media-panel-anim-id={group.id ?? undefined}
+                draggable={false}
+                style={{
+                  left: group.x,
+                  top: group.y,
+                  width: group.width,
+                  height: group.height,
+                }}
+                onMouseDown={(e) => {
+                  e.stopPropagation();
+                  if (e.button === 2 && group.id) {
+                    startMediaBoardGroupMoveGesture(e, group);
+                    return;
+                  }
+                  if (e.button === 0 || e.button === 1) {
+                    startMediaBoardPanGesture(e);
+                  }
+                }}
+                onDragOver={handleMediaBoardGroupDragOver}
+                onDrop={(e) => handleMediaBoardGroupDrop(e, group.id)}
+              >
+                <div className="media-board-group-header">
+                  {isRenamingGroup ? (
+                    <input
+                      className="media-board-group-rename"
+                      value={renameValue}
+                      size={Math.max(1, renameValue.length)}
+                      style={{ width: `${Math.max(4, renameValue.length + 1)}ch` }}
+                      onChange={(e) => setRenameValue(e.target.value)}
+                      onBlur={finishRename}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') finishRename();
+                        if (e.key === 'Escape') setRenamingId(null);
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                      onDoubleClick={(e) => e.stopPropagation()}
+                      onMouseDown={(e) => e.stopPropagation()}
+                      autoFocus
+                    />
+                  ) : (
+                    <span
+                      title={group.name}
+                      onDoubleClick={(e) => {
+                        if (!group.id) return;
+                        e.stopPropagation();
+                        startRename(group.id, folder?.name ?? group.name);
+                      }}
+                    >
+                      {group.name}
+                    </span>
+                  )}
+                  <span>{group.itemCount}</span>
+                </div>
               </div>
-            </div>
+            );
+          })}
+          {mediaBoardLayout.insertGaps.map((gap) => (
+            <div
+              key={gap.id}
+              className="media-board-insert-gap"
+              style={{
+                left: gap.layout.x,
+                top: gap.layout.y,
+                width: gap.layout.width,
+                height: gap.layout.height,
+              }}
+            />
           ))}
           {mediaBoardLayout.placements.map(renderMediaBoardNode)}
           {mediaBoardMarquee && (() => {
@@ -2388,10 +3523,7 @@ export function MediaPanel() {
           <div className="media-view-segment" role="tablist" aria-label="Media view mode">
             <button
               className={`btn btn-sm btn-icon media-view-toggle ${viewMode === 'classic' ? 'active' : ''}`}
-              onClick={() => {
-                setViewMode('classic');
-                setGridFolderId(null);
-              }}
+              onClick={() => handleViewModeChange('classic')}
               title="Classic list view"
               aria-label="Classic list view"
             >
@@ -2399,7 +3531,7 @@ export function MediaPanel() {
             </button>
             <button
               className={`btn btn-sm btn-icon media-view-toggle ${viewMode === 'icons' ? 'active' : ''}`}
-              onClick={() => setViewMode('icons')}
+              onClick={() => handleViewModeChange('icons')}
               title="Large icon view"
               aria-label="Large icon view"
             >
@@ -2407,10 +3539,7 @@ export function MediaPanel() {
             </button>
             <button
               className={`btn btn-sm btn-icon media-view-toggle ${viewMode === 'board' ? 'active' : ''}`}
-              onClick={() => {
-                setViewMode('board');
-                setGridFolderId(null);
-              }}
+              onClick={() => handleViewModeChange('board')}
               title="Board view"
               aria-label="Board view"
             >
@@ -2507,7 +3636,7 @@ export function MediaPanel() {
       />
 
       {/* Item list with column headers */}
-      <div className="media-panel-content">
+      <div className="media-panel-content" ref={mediaPanelContentRef}>
         {totalItems === 0 ? (
           <div className="media-panel-empty" onContextMenu={(e) => handleContextMenu(e)}>
             <div className="drop-icon">

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -152,6 +152,7 @@ export function Preview({ panelId, source, showTransparencyGrid }: PreviewProps)
   const sourceMonitorFile = useMediaStore(state =>
     state.sourceMonitorFileId ? state.files.find(f => f.id === state.sourceMonitorFileId) ?? null : null
   );
+  const previousActiveCompositionIdRef = useRef(activeCompositionId);
   const activeCompositionVideoTracks = useMemo(
     () => tracks.filter((track) => track.type === 'video'),
     [tracks],
@@ -170,8 +171,12 @@ export function Preview({ panelId, source, showTransparencyGrid }: PreviewProps)
 
   // Clear source monitor when active composition changes
   useEffect(() => {
-    if (activeCompositionId && sourceMonitorFileId) {
-      useMediaStore.getState().setSourceMonitorFile(null);
+    const previousActiveCompositionId = previousActiveCompositionIdRef.current;
+    if (previousActiveCompositionId !== activeCompositionId) {
+      previousActiveCompositionIdRef.current = activeCompositionId;
+      if (sourceMonitorFileId) {
+        useMediaStore.getState().setSourceMonitorFile(null);
+      }
     }
   }, [activeCompositionId, sourceMonitorFileId]);
 

--- a/src/components/preview/SceneObjectOverlay.tsx
+++ b/src/components/preview/SceneObjectOverlay.tsx
@@ -11,10 +11,12 @@ import {
 import type { AnimatableProperty, ClipTransform, TimelineClip, TimelineTrack } from '../../types';
 import { engine } from '../../engine/WebGPUEngine';
 import { endBatch, startBatch } from '../../stores/historyStore';
+import { useEngineStore } from '../../stores/engineStore';
 import { useTimelineStore } from '../../stores/timeline';
 import type { SceneViewport } from '../../engine/scene/types';
 import {
   collectPreviewSceneObjects,
+  projectWorldToCanvas,
   resolveAxisScreenHandle,
   type PreviewSceneObject,
   type SceneAxisScreenHandle,
@@ -34,14 +36,24 @@ interface SceneObjectOverlayProps {
   enabled: boolean;
 }
 
+type SceneGizmoDragAxis = SceneGizmoAxis | 'all';
+
 interface DragState {
   clipId: string;
   mode: SceneGizmoMode;
-  axis: SceneGizmoAxis;
+  axis: SceneGizmoDragAxis;
+  kind: PreviewSceneObject['kind'];
   transformSpace: PreviewSceneObject['transformSpace'];
   startTransform: ClipTransform;
   direction: { x: number; y: number };
+  axisVector: { x: number; y: number; z: number };
   pixelsPerUnit: number;
+  freePixelsPerUnit: { x: number; y: number };
+  rotationCenterClient?: { x: number; y: number };
+  rotationStartPointerClient?: { x: number; y: number };
+  rotationRingClientRect?: { left: number; top: number; width: number; height: number };
+  rotationRingPoints?: ProjectedRotateRingPoint[];
+  rotationStartRingAngle?: number;
   viewport: SceneViewport;
 }
 
@@ -59,8 +71,28 @@ interface DisplaySceneObject extends PreviewSceneObject {
   displayY: number;
 }
 
+interface ProjectedRotateRingPoint {
+  x: number;
+  y: number;
+  angleRadians: number;
+}
+
+interface ProjectedRotateRing {
+  axis: SceneGizmoAxis;
+  handle: SceneAxisScreenHandle;
+  path: string;
+  points: ProjectedRotateRingPoint[];
+}
+
 const AXES: SceneGizmoAxis[] = ['x', 'y', 'z'];
 const OVERLAY_REFRESH_MS = 125;
+const CENTER_DRAG_FALLBACK_PIXELS_PER_UNIT = 72;
+const CENTER_SCALE_DIRECTION = { x: Math.SQRT1_2, y: -Math.SQRT1_2 };
+const ROTATE_RING_VIEWBOX_SIZE = 320;
+const ROTATE_RING_CENTER = ROTATE_RING_VIEWBOX_SIZE / 2;
+const ROTATE_RING_SCREEN_RADIUS = 112;
+const ROTATE_RING_SEGMENTS = 96;
+const ROTATE_RING_HIT_THRESHOLD = 28;
 
 const AXIS_LABELS: Record<SceneGizmoAxis, string> = {
   x: 'X',
@@ -72,6 +104,12 @@ const MODE_LABELS: Record<SceneGizmoMode, string> = {
   move: 'Move',
   rotate: 'Rotate',
   scale: 'Scale',
+};
+
+const ROTATE_RING_PLANE_AXES: Record<SceneGizmoAxis, [SceneGizmoAxis, SceneGizmoAxis]> = {
+  x: ['y', 'z'],
+  y: ['z', 'x'],
+  z: ['x', 'y'],
 };
 
 function getObjectBadge(kind: PreviewSceneObject['kind']): string {
@@ -158,6 +196,168 @@ function getAxisStyle(handle: SceneAxisScreenHandle): CSSProperties {
   };
 }
 
+function getCenterHandleLabel(mode: SceneGizmoMode): string {
+  if (mode === 'move') return 'Move freely';
+  if (mode === 'scale') return 'Scale all axes';
+  return 'Selected scene object';
+}
+
+function resolveWorldPerPixel(
+  origin: PreviewSceneObject['worldPosition'],
+  camera: ReturnType<typeof collectPreviewSceneObjects>['camera'],
+): number {
+  const distance = Math.max(
+    0.01,
+    Math.hypot(
+      origin.x - camera.cameraPosition.x,
+      origin.y - camera.cameraPosition.y,
+      origin.z - camera.cameraPosition.z,
+    ),
+  );
+  const fovRadians = (camera.fov * Math.PI) / 180;
+  return (2 * distance * Math.tan(fovRadians * 0.5)) / Math.max(1, camera.viewport.height);
+}
+
+function buildProjectedRotateRing(
+  handle: SceneAxisScreenHandle,
+  object: PreviewSceneObject,
+  camera: ReturnType<typeof collectPreviewSceneObjects>['camera'],
+  canvasSize: { width: number; height: number },
+): ProjectedRotateRing | null {
+  const axis = handle.axis;
+  const [firstAxis, secondAxis] = ROTATE_RING_PLANE_AXES[axis];
+  const first = object.axisBasis[firstAxis];
+  const second = object.axisBasis[secondAxis];
+  const radius = resolveWorldPerPixel(object.worldPosition, camera) * ROTATE_RING_SCREEN_RADIUS;
+  const points: ProjectedRotateRingPoint[] = [];
+
+  for (let i = 0; i < ROTATE_RING_SEGMENTS; i += 1) {
+    const angle = (i / ROTATE_RING_SEGMENTS) * Math.PI * 2;
+    const worldPoint = {
+      x: object.worldPosition.x + first.x * Math.cos(angle) * radius + second.x * Math.sin(angle) * radius,
+      y: object.worldPosition.y + first.y * Math.cos(angle) * radius + second.y * Math.sin(angle) * radius,
+      z: object.worldPosition.z + first.z * Math.cos(angle) * radius + second.z * Math.sin(angle) * radius,
+    };
+    const projected = projectWorldToCanvas(worldPoint, camera, canvasSize);
+    if (projected.depth <= 0 || !Number.isFinite(projected.x) || !Number.isFinite(projected.y)) {
+      continue;
+    }
+    points.push({
+      x: ROTATE_RING_CENTER + projected.x - object.screen.x,
+      y: ROTATE_RING_CENTER + projected.y - object.screen.y,
+      angleRadians: angle,
+    });
+  }
+
+  if (points.length < 4) return null;
+  const [firstPoint, ...remainingPoints] = points;
+  const path = [
+    `M ${firstPoint.x.toFixed(2)} ${firstPoint.y.toFixed(2)}`,
+    ...remainingPoints.map((point) => `L ${point.x.toFixed(2)} ${point.y.toFixed(2)}`),
+    'Z',
+  ].join(' ');
+
+  return { axis, handle, path, points };
+}
+
+function getPointToSegmentProjection(
+  point: { x: number; y: number },
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+): { distance: number; t: number } {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const lengthSq = dx * dx + dy * dy;
+  if (lengthSq <= 0.000001) {
+    return { distance: Math.hypot(point.x - start.x, point.y - start.y), t: 0 };
+  }
+
+  const t = Math.max(0, Math.min(1, ((point.x - start.x) * dx + (point.y - start.y) * dy) / lengthSq));
+  return {
+    distance: Math.hypot(point.x - (start.x + dx * t), point.y - (start.y + dy * t)),
+    t,
+  };
+}
+
+function getPointToRingDistance(point: { x: number; y: number }, ring: ProjectedRotateRing): number {
+  let nearest = Number.POSITIVE_INFINITY;
+  for (let i = 0; i < ring.points.length; i += 1) {
+    const start = ring.points[i];
+    const end = ring.points[(i + 1) % ring.points.length];
+    nearest = Math.min(nearest, getPointToSegmentProjection(point, start, end).distance);
+  }
+  return nearest;
+}
+
+function getPointToProjectedRingPointsAngle(
+  point: { x: number; y: number },
+  points: ProjectedRotateRingPoint[],
+): number | null {
+  let nearestDistance = Number.POSITIVE_INFINITY;
+  let nearestAngle: number | null = null;
+
+  for (let i = 0; i < points.length; i += 1) {
+    const start = points[i];
+    const end = points[(i + 1) % points.length];
+    const projection = getPointToSegmentProjection(point, start, end);
+    if (projection.distance >= nearestDistance) {
+      continue;
+    }
+
+    nearestDistance = projection.distance;
+    const angleDelta = normalizeAngleRadians(end.angleRadians - start.angleRadians);
+    nearestAngle = normalizeAngleRadians(start.angleRadians + angleDelta * projection.t);
+  }
+
+  return nearestAngle;
+}
+
+function getPointToRingAngle(point: { x: number; y: number }, ring: ProjectedRotateRing): number | null {
+  return getPointToProjectedRingPointsAngle(point, ring.points);
+}
+
+function resolveNearestRotateRing(
+  point: { x: number; y: number },
+  rings: ProjectedRotateRing[],
+): ProjectedRotateRing | null {
+  let nearestRing: ProjectedRotateRing | null = null;
+  let nearestDistance = ROTATE_RING_HIT_THRESHOLD;
+
+  for (const ring of rings) {
+    const distance = getPointToRingDistance(point, ring);
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearestRing = ring;
+    }
+  }
+
+  return nearestRing;
+}
+
+function getRotateRingEventPoint(event: ReactMouseEvent<SVGSVGElement>): { x: number; y: number } {
+  const rect = event.currentTarget.getBoundingClientRect();
+  const scaleX = ROTATE_RING_VIEWBOX_SIZE / Math.max(1, rect.width);
+  const scaleY = ROTATE_RING_VIEWBOX_SIZE / Math.max(1, rect.height);
+  return {
+    x: (event.clientX - rect.left) * scaleX,
+    y: (event.clientY - rect.top) * scaleY,
+  };
+}
+
+function resolveCenterFreePixelsPerUnit(axisHandles: SceneAxisScreenHandle[]): { x: number; y: number } {
+  const xHandle = axisHandles.find((handle) => handle.axis === 'x');
+  const yHandle = axisHandles.find((handle) => handle.axis === 'y');
+  const fallback = xHandle?.pixelsPerUnit ?? yHandle?.pixelsPerUnit ?? CENTER_DRAG_FALLBACK_PIXELS_PER_UNIT;
+  return {
+    x: Math.max(24, xHandle?.pixelsPerUnit ?? fallback),
+    y: Math.max(24, yHandle?.pixelsPerUnit ?? fallback),
+  };
+}
+
+function getAveragePixelsPerUnit(pixelsPerUnit: { x: number; y: number }): number {
+  return Math.max(24, (pixelsPerUnit.x + pixelsPerUnit.y) / 2);
+}
+
 function getDragSpeedMultiplier(event: MouseEvent): number {
   if (event.ctrlKey) return 5;
   if (event.altKey || event.shiftKey) return 0.1;
@@ -181,24 +381,289 @@ function applySceneObjectTransform(clipId: string, transform: Partial<ClipTransf
   engine.requestRender();
 }
 
-function applyDragTransform(drag: DragState, screenDistance: number): void {
+function buildScaleUpdate(
+  startScale: ClipTransform['scale'],
+  values: { x: number; y: number; z?: number },
+): ClipTransform['scale'] {
+  const scale: ClipTransform['scale'] = {
+    x: Math.max(0.001, values.x),
+    y: Math.max(0.001, values.y),
+  };
+
+  if (values.z !== undefined || startScale.z !== undefined) {
+    scale.z = Math.max(0.001, values.z ?? startScale.z ?? 1);
+  }
+
+  return scale;
+}
+
+function buildAxisResetTransform(
+  mode: SceneGizmoMode,
+  axis: SceneGizmoAxis,
+  start: ClipTransform,
+): Partial<ClipTransform> {
+  if (mode === 'rotate') {
+    return {
+      rotation: {
+        ...start.rotation,
+        [axis]: 0,
+      },
+    };
+  }
+
+  if (mode === 'scale') {
+    return {
+      scale: buildScaleUpdate(start.scale, {
+        x: axis === 'x' ? 1 : start.scale.x,
+        y: axis === 'y' ? 1 : start.scale.y,
+        ...(axis === 'z'
+          ? { z: 1 }
+          : start.scale.z !== undefined
+            ? { z: start.scale.z }
+            : {}),
+      }),
+    };
+  }
+
+  return {
+    position: {
+      ...start.position,
+      [axis]: 0,
+    },
+  };
+}
+
+function buildCenterResetTransform(
+  mode: SceneGizmoMode,
+  object: PreviewSceneObject,
+  start: ClipTransform,
+): Partial<ClipTransform> {
+  if (mode === 'rotate') {
+    return {
+      rotation: { x: 0, y: 0, z: 0 },
+    };
+  }
+
+  if (mode === 'scale') {
+    return {
+      scale: buildScaleUpdate(start.scale, {
+        x: 1,
+        y: 1,
+        ...(object.kind !== 'plane' || start.scale.z !== undefined ? { z: 1 } : {}),
+      }),
+    };
+  }
+
+  return {
+    position: { x: 0, y: 0, z: 0 },
+  };
+}
+
+function resetSceneObjectTransform(
+  clipId: string,
+  mode: SceneGizmoMode,
+  transform: Partial<ClipTransform>,
+): void {
+  startBatch(`Reset scene ${mode}`);
+  applySceneObjectTransform(clipId, transform);
+  endBatch();
+}
+
+function normalizeAngleRadians(angle: number): number {
+  let normalized = angle;
+  while (normalized > Math.PI) normalized -= Math.PI * 2;
+  while (normalized < -Math.PI) normalized += Math.PI * 2;
+  return normalized;
+}
+
+function buildRotationMatrixFromDegrees(rotation: ClipTransform['rotation']): number[] {
+  const x = (rotation.x * Math.PI) / 180;
+  const y = (rotation.y * Math.PI) / 180;
+  const z = (rotation.z * Math.PI) / 180;
+  const a = Math.cos(x);
+  const b = Math.sin(x);
+  const c = Math.cos(y);
+  const d = Math.sin(y);
+  const e = Math.cos(z);
+  const f = Math.sin(z);
+  const ae = a * e;
+  const af = a * f;
+  const be = b * e;
+  const bf = b * f;
+
+  return [
+    c * e,
+    af + be * d,
+    bf - ae * d,
+    -c * f,
+    ae - bf * d,
+    be + af * d,
+    d,
+    -b * c,
+    a * c,
+  ];
+}
+
+function buildLocalAxisRotationMatrix(axis: SceneGizmoAxis, degrees: number): number[] {
+  const radians = (degrees * Math.PI) / 180;
+  const c = Math.cos(radians);
+  const s = Math.sin(radians);
+
+  if (axis === 'x') {
+    return [
+      1, 0, 0,
+      0, c, s,
+      0, -s, c,
+    ];
+  }
+
+  if (axis === 'y') {
+    return [
+      c, 0, -s,
+      0, 1, 0,
+      s, 0, c,
+    ];
+  }
+
+  return [
+    c, s, 0,
+    -s, c, 0,
+    0, 0, 1,
+  ];
+}
+
+function multiplyMat3(a: number[], b: number[]): number[] {
+  const out = new Array<number>(9);
+  for (let col = 0; col < 3; col += 1) {
+    for (let row = 0; row < 3; row += 1) {
+      let sum = 0;
+      for (let k = 0; k < 3; k += 1) {
+        sum += a[k * 3 + row] * b[col * 3 + k];
+      }
+      out[col * 3 + row] = sum;
+    }
+  }
+  return out;
+}
+
+function matrixToRotationDegrees(matrix: number[]): ClipTransform['rotation'] {
+  const y = Math.asin(Math.max(-1, Math.min(1, matrix[6] ?? 0)));
+  const c = Math.cos(y);
+  let x: number;
+  let z: number;
+
+  if (Math.abs(c) > 0.000001) {
+    x = Math.atan2(-(matrix[7] ?? 0), matrix[8] ?? 1);
+    z = Math.atan2(-(matrix[3] ?? 0), matrix[0] ?? 1);
+  } else {
+    x = 0;
+    z = Math.atan2(matrix[1] ?? 0, matrix[4] ?? 1);
+  }
+
+  return {
+    x: (x * 180) / Math.PI,
+    y: (y * 180) / Math.PI,
+    z: (z * 180) / Math.PI,
+  };
+}
+
+function applyLocalAxisRotation(
+  startRotation: ClipTransform['rotation'],
+  axis: SceneGizmoAxis,
+  degrees: number,
+): ClipTransform['rotation'] {
+  const startMatrix = buildRotationMatrixFromDegrees(startRotation);
+  const localDelta = buildLocalAxisRotationMatrix(axis, degrees);
+  return matrixToRotationDegrees(multiplyMat3(startMatrix, localDelta));
+}
+
+function resolveAngularDragDegrees(
+  drag: DragState,
+  screenDelta: { x: number; y: number },
+): number | null {
+  if (!drag.rotationCenterClient || !drag.rotationStartPointerClient) {
+    return null;
+  }
+
+  const startVector = {
+    x: drag.rotationStartPointerClient.x - drag.rotationCenterClient.x,
+    y: drag.rotationStartPointerClient.y - drag.rotationCenterClient.y,
+  };
+  const currentVector = {
+    x: drag.rotationStartPointerClient.x + screenDelta.x - drag.rotationCenterClient.x,
+    y: drag.rotationStartPointerClient.y + screenDelta.y - drag.rotationCenterClient.y,
+  };
+  if (Math.hypot(startVector.x, startVector.y) < 6 || Math.hypot(currentVector.x, currentVector.y) < 6) {
+    return null;
+  }
+
+  const startAngle = Math.atan2(startVector.y, startVector.x);
+  const currentAngle = Math.atan2(currentVector.y, currentVector.x);
+  return (normalizeAngleRadians(currentAngle - startAngle) * 180) / Math.PI;
+}
+
+function resolveProjectedRingDragDegrees(
+  drag: DragState,
+  screenDelta: { x: number; y: number },
+): number | null {
+  if (
+    !drag.rotationStartPointerClient ||
+    !drag.rotationRingClientRect ||
+    !drag.rotationRingPoints ||
+    drag.rotationStartRingAngle === undefined
+  ) {
+    return null;
+  }
+
+  const currentClient = {
+    x: drag.rotationStartPointerClient.x + screenDelta.x,
+    y: drag.rotationStartPointerClient.y + screenDelta.y,
+  };
+  const point = {
+    x: ((currentClient.x - drag.rotationRingClientRect.left) * ROTATE_RING_VIEWBOX_SIZE) /
+      Math.max(1, drag.rotationRingClientRect.width),
+    y: ((currentClient.y - drag.rotationRingClientRect.top) * ROTATE_RING_VIEWBOX_SIZE) /
+      Math.max(1, drag.rotationRingClientRect.height),
+  };
+  const currentAngle = getPointToProjectedRingPointsAngle(point, drag.rotationRingPoints);
+  if (currentAngle === null) {
+    return null;
+  }
+
+  return (normalizeAngleRadians(currentAngle - drag.rotationStartRingAngle) * 180) / Math.PI;
+}
+
+function applyDragTransform(drag: DragState, screenDistance: number, screenDelta: { x: number; y: number }): void {
   const units = screenDistance / drag.pixelsPerUnit;
   const start = drag.startTransform;
   const axis = drag.axis;
 
   if (drag.mode === 'rotate') {
-    const degrees = screenDistance * 0.6;
+    if (axis === 'all') return;
+    const degrees =
+      resolveProjectedRingDragDegrees(drag, screenDelta) ??
+      resolveAngularDragDegrees(drag, screenDelta) ??
+      screenDistance * 0.6;
     applySceneObjectTransform(drag.clipId, {
-      rotation: {
-        x: start.rotation.x + (axis === 'x' ? degrees : 0),
-        y: start.rotation.y + (axis === 'y' ? degrees : 0),
-        z: start.rotation.z + (axis === 'z' ? degrees : 0),
-      },
+      rotation: applyLocalAxisRotation(start.rotation, axis, degrees),
     });
     return;
   }
 
   if (drag.mode === 'scale') {
+    if (axis === 'all') {
+      const factor = Math.max(0.001, 1 + screenDistance / 160);
+      const includeZ = drag.kind !== 'plane' || start.scale.z !== undefined;
+      applySceneObjectTransform(drag.clipId, {
+        scale: buildScaleUpdate(start.scale, {
+          x: start.scale.x * factor,
+          y: start.scale.y * factor,
+          ...(includeZ ? { z: (start.scale.z ?? 1) * factor } : {}),
+        }),
+      });
+      return;
+    }
+
     const scaleDelta = screenDistance / 90;
     if (drag.transformSpace === 'effector') {
       const next = Math.max(0.001, Math.max(start.scale.x, start.scale.y, start.scale.z ?? 1) + scaleDelta);
@@ -209,29 +674,45 @@ function applyDragTransform(drag: DragState, screenDistance: number): void {
     }
 
     applySceneObjectTransform(drag.clipId, {
-      scale: {
-        x: Math.max(0.001, start.scale.x + (axis === 'x' ? scaleDelta : 0)),
-        y: Math.max(0.001, start.scale.y + (axis === 'y' ? scaleDelta : 0)),
-        z: axis === 'z'
-          ? Math.max(0.001, (start.scale.z ?? 1) + scaleDelta)
-          : start.scale.z,
-      },
+      scale: buildScaleUpdate(start.scale, {
+        x: start.scale.x + (axis === 'x' ? scaleDelta : 0),
+        y: start.scale.y + (axis === 'y' ? scaleDelta : 0),
+        ...(axis === 'z' ? { z: (start.scale.z ?? 1) + scaleDelta } : {}),
+      }),
     });
     return;
   }
 
   const aspect = drag.viewport.width / Math.max(1, drag.viewport.height);
   const position = { ...start.position };
-  if (axis === 'x') {
-    position.x += drag.transformSpace === 'effector'
-      ? units / aspect
-      : units;
+  if (axis === 'all') {
+    const unitsX = screenDelta.x / drag.freePixelsPerUnit.x;
+    const unitsY = screenDelta.y / drag.freePixelsPerUnit.y;
+    if (drag.transformSpace === 'effector') {
+      position.x += unitsX / aspect;
+      position.y += unitsY;
+    } else {
+      position.x += unitsX;
+      position.y -= unitsY;
+    }
+
+    applySceneObjectTransform(drag.clipId, { position });
+    return;
   }
-  if (axis === 'y') {
-    position.y += drag.transformSpace === 'effector' ? -units : units;
-  }
-  if (axis === 'z') {
-    position.z += units;
+
+  const delta = {
+    x: drag.axisVector.x * units,
+    y: drag.axisVector.y * units,
+    z: drag.axisVector.z * units,
+  };
+  if (drag.transformSpace === 'effector') {
+    position.x += delta.x / aspect;
+    position.y -= delta.y;
+    position.z += delta.z;
+  } else {
+    position.x += delta.x;
+    position.y += delta.y;
+    position.z += delta.z;
   }
 
   applySceneObjectTransform(drag.clipId, { position });
@@ -249,9 +730,13 @@ export function SceneObjectOverlay({
   enabled,
 }: SceneObjectOverlayProps) {
   const [mode, setMode] = useState<SceneGizmoMode>('move');
+  const setSceneGizmoMode = useEngineStore((state) => state.setSceneGizmoMode);
+  const setSceneGizmoHoveredAxis = useEngineStore((state) => state.setSceneGizmoHoveredAxis);
+  const [hoveredAxis, setHoveredAxis] = useState<SceneGizmoAxis | null>(null);
   const [dragState, setDragState] = useState<DragState | null>(null);
   const [timelineSnapshotTick, setTimelineSnapshotTick] = useState(0);
   const endedDragRef = useRef(false);
+  const hoveredAxisRef = useRef<SceneGizmoAxis | null>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
   const dragRuntimeRef = useRef<DragRuntime>({
     target: null,
@@ -309,6 +794,27 @@ export function SceneObjectOverlay({
     }
   }, []);
 
+  const updateHoveredAxis = useCallback((axis: SceneGizmoAxis | null) => {
+    if (hoveredAxisRef.current === axis) return;
+    hoveredAxisRef.current = axis;
+    setHoveredAxis(axis);
+    setSceneGizmoHoveredAxis(axis);
+    engine.requestRender();
+  }, [setSceneGizmoHoveredAxis]);
+
+  const handleAxisHover = useCallback((axis: SceneGizmoAxis | null) => {
+    if (axis === null && dragRuntimeRef.current.target) {
+      return;
+    }
+    updateHoveredAxis(axis);
+  }, [updateHoveredAxis]);
+
+  useEffect(() => () => {
+    hoveredAxisRef.current = null;
+    setSceneGizmoHoveredAxis(null);
+    engine.requestRender();
+  }, [setSceneGizmoHoveredAxis]);
+
   useEffect(() => {
     if (!enabled) return;
 
@@ -318,6 +824,13 @@ export function SceneObjectOverlay({
     }, OVERLAY_REFRESH_MS);
     return () => window.clearInterval(intervalId);
   }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    setSceneGizmoMode(mode);
+    updateHoveredAxis(null);
+    engine.requestRender();
+  }, [enabled, mode, setSceneGizmoMode, updateHoveredAxis]);
 
   const { camera, objects } = useMemo(
     () => {
@@ -348,8 +861,20 @@ export function SceneObjectOverlay({
 
   const axisHandles = useMemo<SceneAxisScreenHandle[]>(() => {
     if (!selectedObject || !selectedObject.screen.visible) return [];
-    return AXES.map((axis) => resolveAxisScreenHandle(axis, selectedObject.worldPosition, camera, canvasSize));
+    return AXES.map((axis) => resolveAxisScreenHandle(
+      axis,
+      selectedObject.worldPosition,
+      camera,
+      canvasSize,
+      selectedObject.axisBasis[axis],
+    ));
   }, [camera, canvasSize, selectedObject]);
+  const rotateRings = useMemo<ProjectedRotateRing[]>(() => {
+    if (!selectedObject || !selectedObject.screen.visible) return [];
+    return axisHandles
+      .map((handle) => buildProjectedRotateRing(handle, selectedObject, camera, canvasSize))
+      .filter((ring): ring is ProjectedRotateRing => ring !== null);
+  }, [axisHandles, camera, canvasSize, selectedObject]);
 
   const endDrag = useCallback(() => {
     if (!dragState) return;
@@ -359,7 +884,13 @@ export function SceneObjectOverlay({
       endBatch();
     }
     setDragState(null);
-  }, [dragState, releasePointerLock]);
+    updateHoveredAxis(null);
+  }, [dragState, releasePointerLock, updateHoveredAxis]);
+
+  useEffect(() => {
+    if (enabled && selectedObject?.screen.visible) return;
+    updateHoveredAxis(null);
+  }, [enabled, selectedObject?.clipId, selectedObject?.screen.visible, updateHoveredAxis]);
 
   useEffect(() => {
     if (!dragState) return;
@@ -394,7 +925,10 @@ export function SceneObjectOverlay({
       const screenDistance =
         runtime.accumulatedX * dragState.direction.x +
         runtime.accumulatedY * dragState.direction.y;
-      applyDragTransform(dragState, screenDistance);
+      applyDragTransform(dragState, screenDistance, {
+        x: runtime.accumulatedX,
+        y: runtime.accumulatedY,
+      });
     };
 
     const handleMouseUp = (event: MouseEvent) => {
@@ -446,43 +980,218 @@ export function SceneObjectOverlay({
     selectClip(object.clipId, event.shiftKey);
   }, [selectClip]);
 
-  const handleAxisMouseDown = useCallback((event: ReactMouseEvent<HTMLButtonElement>, handle: SceneAxisScreenHandle) => {
-    if (event.button !== 0) return;
-    if (!selectedObject) return;
-    const clip = clips.find((candidate) => candidate.id === selectedObject.clipId);
+  const startGizmoDrag = useCallback((params: {
+    clientX: number;
+    clientY: number;
+    currentTarget: Element;
+    object: PreviewSceneObject;
+    axis: SceneGizmoDragAxis;
+    direction: { x: number; y: number };
+    axisVector: { x: number; y: number; z: number };
+    pixelsPerUnit: number;
+    freePixelsPerUnit: { x: number; y: number };
+    rotationRingClientRect?: DragState['rotationRingClientRect'];
+    rotationRingPoints?: ProjectedRotateRingPoint[];
+    rotationStartRingAngle?: number;
+  }) => {
+    const clip = clips.find((candidate) => candidate.id === params.object.clipId);
     if (!clip) return;
 
     const lockTarget = overlayRef.current ?? document.body;
-    const fallbackTarget = event.currentTarget;
-
-    event.preventDefault();
-    event.stopPropagation();
+    const overlayRect = overlayRef.current?.getBoundingClientRect();
+    const fallbackTarget = params.currentTarget instanceof HTMLElement ? params.currentTarget : undefined;
     endedDragRef.current = false;
     dragRuntimeRef.current = {
       target: lockTarget,
       hasPointerLock: false,
       accumulatedX: 0,
       accumulatedY: 0,
-      lastClientX: event.clientX,
-      lastClientY: event.clientY,
+      lastClientX: params.clientX,
+      lastClientY: params.clientY,
     };
     requestPointerLock(lockTarget, fallbackTarget);
     startBatch(`Scene ${mode}`);
+    updateHoveredAxis(params.axis === 'all' ? null : params.axis);
     setDragState({
-      clipId: selectedObject.clipId,
+      clipId: params.object.clipId,
       mode,
-      axis: handle.axis,
-      transformSpace: selectedObject.transformSpace,
+      axis: params.axis,
+      kind: params.object.kind,
+      transformSpace: params.object.transformSpace,
       startTransform: cloneTransform(clip.transform),
-      direction: handle.direction,
-      pixelsPerUnit: handle.pixelsPerUnit,
+      direction: params.direction,
+      axisVector: params.axisVector,
+      pixelsPerUnit: params.pixelsPerUnit,
+      freePixelsPerUnit: params.freePixelsPerUnit,
+      ...(params.rotationRingClientRect && params.rotationRingPoints && params.rotationStartRingAngle !== undefined
+        ? {
+            rotationRingClientRect: params.rotationRingClientRect,
+            rotationRingPoints: params.rotationRingPoints,
+            rotationStartRingAngle: params.rotationStartRingAngle,
+          }
+        : {}),
+      ...(overlayRect
+        ? {
+            rotationCenterClient: {
+              x: overlayRect.left + params.object.screen.x,
+              y: overlayRect.top + params.object.screen.y,
+            },
+            rotationStartPointerClient: {
+              x: params.clientX,
+              y: params.clientY,
+            },
+          }
+        : {}),
       viewport,
     });
-  }, [clips, mode, requestPointerLock, selectedObject, viewport]);
+  }, [clips, mode, requestPointerLock, updateHoveredAxis, viewport]);
+
+  const handleAxisMouseDown = useCallback((event: ReactMouseEvent<Element>, handle: SceneAxisScreenHandle) => {
+    if (event.button !== 0) return;
+    if (!selectedObject) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.detail > 1) return;
+
+    startGizmoDrag({
+      clientX: event.clientX,
+      clientY: event.clientY,
+      currentTarget: event.currentTarget,
+      object: selectedObject,
+      axis: handle.axis,
+      direction: handle.direction,
+      axisVector: handle.axisVector,
+      pixelsPerUnit: handle.pixelsPerUnit,
+      freePixelsPerUnit: { x: handle.pixelsPerUnit, y: handle.pixelsPerUnit },
+    });
+  }, [selectedObject, startGizmoDrag]);
+
+  const handleAxisDoubleClick = useCallback((event: ReactMouseEvent<Element>, handle: SceneAxisScreenHandle) => {
+    if (!selectedObject) return;
+    const clip = clips.find((candidate) => candidate.id === selectedObject.clipId);
+    if (!clip) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    resetSceneObjectTransform(
+      selectedObject.clipId,
+      mode,
+      buildAxisResetTransform(mode, handle.axis, clip.transform),
+    );
+  }, [clips, mode, selectedObject]);
+
+  const resolveRotateRingFromEvent = useCallback((event: ReactMouseEvent<SVGSVGElement>) => (
+    resolveNearestRotateRing(getRotateRingEventPoint(event), rotateRings)
+  ), [rotateRings]);
+
+  const handleRotateRingMouseMove = useCallback((event: ReactMouseEvent<SVGSVGElement>) => {
+    const ring = resolveRotateRingFromEvent(event);
+    updateHoveredAxis(ring?.axis ?? null);
+  }, [resolveRotateRingFromEvent, updateHoveredAxis]);
+
+  const handleRotateRingMouseDown = useCallback((event: ReactMouseEvent<SVGSVGElement>) => {
+    if (event.button !== 0) return;
+    if (!selectedObject) return;
+    const ring = resolveRotateRingFromEvent(event);
+    if (!ring) {
+      updateHoveredAxis(null);
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.detail > 1) return;
+
+    const point = getRotateRingEventPoint(event);
+    const startAngle = getPointToRingAngle(point, ring);
+    const rect = event.currentTarget.getBoundingClientRect();
+    updateHoveredAxis(ring.axis);
+    startGizmoDrag({
+      clientX: event.clientX,
+      clientY: event.clientY,
+      currentTarget: event.currentTarget,
+      object: selectedObject,
+      axis: ring.axis,
+      direction: ring.handle.direction,
+      axisVector: ring.handle.axisVector,
+      pixelsPerUnit: ring.handle.pixelsPerUnit,
+      freePixelsPerUnit: { x: ring.handle.pixelsPerUnit, y: ring.handle.pixelsPerUnit },
+      ...(startAngle !== null
+        ? {
+            rotationRingClientRect: {
+              left: rect.left,
+              top: rect.top,
+              width: rect.width,
+              height: rect.height,
+            },
+            rotationRingPoints: ring.points,
+            rotationStartRingAngle: startAngle,
+          }
+        : {}),
+    });
+  }, [resolveRotateRingFromEvent, selectedObject, startGizmoDrag, updateHoveredAxis]);
+
+  const handleRotateRingDoubleClick = useCallback((event: ReactMouseEvent<SVGSVGElement>) => {
+    const ring = resolveRotateRingFromEvent(event);
+    if (!ring) {
+      updateHoveredAxis(null);
+      return;
+    }
+
+    updateHoveredAxis(ring.axis);
+    handleAxisDoubleClick(event, ring.handle);
+  }, [handleAxisDoubleClick, resolveRotateRingFromEvent, updateHoveredAxis]);
+
+  const handleCenterPointerDown = useCallback((event: ReactPointerEvent<HTMLButtonElement>, object: PreviewSceneObject) => {
+    if (event.button !== 0) return;
+
+    if (event.detail > 1) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    if (object.clipId !== selectedClipId || (mode !== 'move' && mode !== 'scale')) {
+      handleObjectPointerDown(event, object);
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    const freePixelsPerUnit = resolveCenterFreePixelsPerUnit(axisHandles);
+    startGizmoDrag({
+      clientX: event.clientX,
+      clientY: event.clientY,
+      currentTarget: event.currentTarget,
+      object,
+      axis: 'all',
+      direction: mode === 'scale' ? CENTER_SCALE_DIRECTION : { x: 1, y: 0 },
+      axisVector: { x: 0, y: 0, z: 0 },
+      pixelsPerUnit: getAveragePixelsPerUnit(freePixelsPerUnit),
+      freePixelsPerUnit,
+    });
+  }, [axisHandles, handleObjectPointerDown, mode, selectedClipId, startGizmoDrag]);
+
+  const handleCenterDoubleClick = useCallback((event: ReactMouseEvent<HTMLButtonElement>, object: PreviewSceneObject) => {
+    if (object.clipId !== selectedClipId) return;
+    const clip = clips.find((candidate) => candidate.id === object.clipId);
+    if (!clip) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    resetSceneObjectTransform(
+      object.clipId,
+      mode,
+      buildCenterResetTransform(mode, object, clip.transform),
+    );
+  }, [clips, mode, selectedClipId]);
 
   if (!enabled || canvasSize.width <= 0 || canvasSize.height <= 0 || objects.length === 0) {
     return null;
   }
+
+  const toolbarOffsetX = mode === 'rotate' ? ROTATE_RING_SCREEN_RADIUS + 28 : 18;
 
   return (
     <div
@@ -492,33 +1201,70 @@ export function SceneObjectOverlay({
     >
       {selectedObject && selectedObject.screen.visible && (
         <>
-          {axisHandles.map((handle) => (
-            <div key={`${mode}-${handle.axis}`} className="preview-scene-gizmo-axis-layer">
-              <button
-                type="button"
-                className={`preview-scene-gizmo-axis axis-${handle.axis} mode-${mode}`}
-                style={getAxisStyle(handle)}
-                aria-label={`${MODE_LABELS[mode]} ${AXIS_LABELS[handle.axis]}`}
-                onMouseDown={(event) => handleAxisMouseDown(event, handle)}
-              >
-                <span className="preview-scene-gizmo-axis-line" />
-                <span className="preview-scene-gizmo-end" />
-              </button>
-              <span
-                className={`preview-scene-gizmo-label axis-${handle.axis}`}
-                style={{
-                  left: handle.end.x + handle.direction.x * 12,
-                  top: handle.end.y + handle.direction.y * 12,
-                }}
-              >
-                {AXIS_LABELS[handle.axis]}
-              </span>
-            </div>
-          ))}
+          {mode === 'rotate' ? (
+            <svg
+              className="preview-scene-gizmo-rotate"
+              style={{
+                left: selectedObject.screen.x,
+                top: selectedObject.screen.y,
+                width: ROTATE_RING_VIEWBOX_SIZE,
+                height: ROTATE_RING_VIEWBOX_SIZE,
+              }}
+              viewBox={`0 0 ${ROTATE_RING_VIEWBOX_SIZE} ${ROTATE_RING_VIEWBOX_SIZE}`}
+              aria-hidden="true"
+              onMouseMove={handleRotateRingMouseMove}
+              onMouseDown={handleRotateRingMouseDown}
+              onDoubleClick={handleRotateRingDoubleClick}
+              onMouseLeave={() => handleAxisHover(null)}
+            >
+              {rotateRings.map((ring) => (
+                <g
+                  key={ring.axis}
+                  className={`preview-scene-gizmo-rotate-ring axis-${ring.axis} ${hoveredAxis === ring.axis ? 'is-hovered' : ''}`}
+                >
+                  <path
+                    className="preview-scene-gizmo-rotate-hit"
+                    d={ring.path}
+                  />
+                  <path
+                    className="preview-scene-gizmo-rotate-stroke"
+                    d={ring.path}
+                  />
+                </g>
+              ))}
+            </svg>
+          ) : (
+            axisHandles.map((handle) => (
+              <div key={`${mode}-${handle.axis}`} className="preview-scene-gizmo-axis-layer">
+                <button
+                  type="button"
+                  className={`preview-scene-gizmo-axis axis-${handle.axis} mode-${mode} ${hoveredAxis === handle.axis ? 'is-hovered' : ''}`}
+                  style={getAxisStyle(handle)}
+                  aria-label={`${MODE_LABELS[mode]} ${AXIS_LABELS[handle.axis]}`}
+                  onMouseEnter={() => handleAxisHover(handle.axis)}
+                  onMouseLeave={() => handleAxisHover(null)}
+                  onMouseDown={(event) => handleAxisMouseDown(event, handle)}
+                  onDoubleClick={(event) => handleAxisDoubleClick(event, handle)}
+                >
+                  <span className="preview-scene-gizmo-axis-line" />
+                  <span className="preview-scene-gizmo-end" />
+                </button>
+                <span
+                  className={`preview-scene-gizmo-label axis-${handle.axis}`}
+                  style={{
+                    left: handle.end.x + handle.direction.x * 12,
+                    top: handle.end.y + handle.direction.y * 12,
+                  }}
+                >
+                  {AXIS_LABELS[handle.axis]}
+                </span>
+              </div>
+            ))
+          )}
           <div
             className="preview-scene-gizmo-toolbar"
             style={{
-              left: Math.min(canvasSize.width - 180, Math.max(8, selectedObject.screen.x + 14)),
+              left: Math.min(canvasSize.width - 180, Math.max(8, selectedObject.screen.x + toolbarOffsetX)),
               top: Math.min(canvasSize.height - 34, Math.max(8, selectedObject.screen.y - 50)),
             }}
           >
@@ -543,17 +1289,21 @@ export function SceneObjectOverlay({
       {displayObjects.map((object) => {
         if (!object.screen.visible) return null;
         const selected = object.clipId === selectedClipId;
+        const centerDraggable = selected && (mode === 'move' || mode === 'scale');
+        const label = centerDraggable ? getCenterHandleLabel(mode) : object.name;
         return (
           <button
             key={object.clipId}
             type="button"
-            className={`preview-scene-object-handle kind-${object.kind} ${selected ? 'selected' : ''}`}
+            className={`preview-scene-object-handle kind-${object.kind} ${selected ? `selected gizmo-center mode-${mode}` : ''} ${centerDraggable ? 'center-draggable' : ''}`}
             style={{
-              left: object.displayX,
-              top: object.displayY,
+              left: selected ? object.screen.x : object.displayX,
+              top: selected ? object.screen.y : object.displayY,
             }}
-            title={object.name}
-            onPointerDown={(event) => handleObjectPointerDown(event, object)}
+            title={label}
+            aria-label={label}
+            onPointerDown={(event) => handleCenterPointerDown(event, object)}
+            onDoubleClick={(event) => handleCenterDoubleClick(event, object)}
           >
             <span>{getObjectBadge(object.kind)}</span>
           </button>

--- a/src/components/preview/sceneObjectOverlayMath.ts
+++ b/src/components/preview/sceneObjectOverlayMath.ts
@@ -1,12 +1,16 @@
 import type { Keyframe, TimelineClip, TimelineTrack } from '../../types';
-import type { SceneCamera, SceneViewport, SceneVector3 } from '../../engine/scene/types';
+import type {
+  SceneCamera,
+  SceneGizmoAxis,
+  SceneVector3,
+  SceneViewport,
+} from '../../engine/scene/types';
 import { resolveRenderableSharedSceneCamera } from '../../engine/scene/SceneCameraUtils';
 import { resolveSceneClipTransform } from '../../engine/scene/SceneTimelineUtils';
 
 export type SceneObjectKind = 'effector' | 'splat' | 'model' | 'plane';
 export type SceneObjectTransformSpace = 'world' | 'effector';
-export type SceneGizmoAxis = 'x' | 'y' | 'z';
-export type SceneGizmoMode = 'move' | 'rotate' | 'scale';
+export type { SceneGizmoAxis, SceneGizmoMode } from '../../engine/scene/types';
 
 export interface PreviewSceneObject {
   clipId: string;
@@ -14,6 +18,7 @@ export interface PreviewSceneObject {
   kind: SceneObjectKind;
   transformSpace: SceneObjectTransformSpace;
   worldPosition: SceneVector3;
+  axisBasis: Record<SceneGizmoAxis, SceneVector3>;
   screen: {
     x: number;
     y: number;
@@ -24,10 +29,12 @@ export interface PreviewSceneObject {
 
 export interface SceneAxisScreenHandle {
   axis: SceneGizmoAxis;
+  axisVector: SceneVector3;
   start: { x: number; y: number };
   end: { x: number; y: number };
   direction: { x: number; y: number };
   pixelsPerUnit: number;
+  projectedLength: number;
 }
 
 interface CollectPreviewSceneObjectsParams {
@@ -109,34 +116,53 @@ function normalizeScreenVector(vector: { x: number; y: number }, fallback: { x: 
   };
 }
 
+function normalizeSceneVector(vector: SceneVector3): SceneVector3 {
+  const length = Math.hypot(vector.x, vector.y, vector.z) || 1;
+  return {
+    x: vector.x / length,
+    y: vector.y / length,
+    z: vector.z / length,
+  };
+}
+
 export function resolveAxisScreenHandle(
   axis: SceneGizmoAxis,
   worldPosition: SceneVector3,
   camera: SceneCamera,
   canvasSize: { width: number; height: number },
+  basisVector?: SceneVector3,
 ): SceneAxisScreenHandle {
   const start = projectWorldToCanvas(worldPosition, camera, canvasSize);
+  const axisVector = normalizeSceneVector(basisVector ?? {
+    x: axis === 'x' ? 1 : 0,
+    y: axis === 'y' ? 1 : 0,
+    z: axis === 'z' ? 1 : 0,
+  });
   const axisEndWorld = {
-    x: worldPosition.x + (axis === 'x' ? 1 : 0),
-    y: worldPosition.y + (axis === 'y' ? 1 : 0),
-    z: worldPosition.z + (axis === 'z' ? 1 : 0),
+    x: worldPosition.x + axisVector.x,
+    y: worldPosition.y + axisVector.y,
+    z: worldPosition.z + axisVector.z,
   };
   const projectedEnd = projectWorldToCanvas(axisEndWorld, camera, canvasSize);
+  const projectedVector = { x: projectedEnd.x - start.x, y: projectedEnd.y - start.y };
+  const projectedLength = Math.hypot(projectedVector.x, projectedVector.y);
   const normalized = normalizeScreenVector(
-    { x: projectedEnd.x - start.x, y: projectedEnd.y - start.y },
+    projectedVector,
     AXIS_FALLBACKS[axis],
   );
-  const visualLength = Math.max(42, Math.min(78, normalized.length));
+  const visualLength = Math.max(66, Math.min(124, normalized.length));
 
   return {
     axis,
+    axisVector,
     start: { x: start.x, y: start.y },
     end: {
       x: start.x + normalized.x * visualLength,
       y: start.y + normalized.y * visualLength,
     },
     direction: { x: normalized.x, y: normalized.y },
-    pixelsPerUnit: Math.max(42, normalized.length),
+    pixelsPerUnit: Math.max(66, normalized.length),
+    projectedLength,
   };
 }
 
@@ -165,6 +191,40 @@ function resolveClipWorldPosition(
       x: transform.position.x,
       y: transform.position.y,
       z: transform.position.z,
+    },
+  };
+}
+
+function resolveClipAxisBasis(transform: TimelineClip['transform']): Record<SceneGizmoAxis, SceneVector3> {
+  const x = (transform.rotation.x * Math.PI) / 180;
+  const y = (transform.rotation.y * Math.PI) / 180;
+  const z = (transform.rotation.z * Math.PI) / 180;
+  const a = Math.cos(x);
+  const b = Math.sin(x);
+  const c = Math.cos(y);
+  const d = Math.sin(y);
+  const e = Math.cos(z);
+  const f = Math.sin(z);
+  const ae = a * e;
+  const af = a * f;
+  const be = b * e;
+  const bf = b * f;
+
+  return {
+    x: {
+      x: c * e,
+      y: af + be * d,
+      z: bf - ae * d,
+    },
+    y: {
+      x: -c * f,
+      y: ae - bf * d,
+      z: be + af * d,
+    },
+    z: {
+      x: d,
+      y: -b * c,
+      z: a * c,
     },
   };
 }
@@ -204,6 +264,7 @@ export function collectPreviewSceneObjects({
         { clips, clipKeyframes },
       );
       const { position, transformSpace } = resolveClipWorldPosition(kind, transform, viewport);
+      const axisBasis = resolveClipAxisBasis(transform);
       const screen = projectWorldToCanvas(position, camera, canvasSize);
 
       return {
@@ -212,6 +273,7 @@ export function collectPreviewSceneObjects({
         kind,
         transformSpace,
         worldPosition: position,
+        axisBasis,
         screen,
       };
     })

--- a/src/engine/native3d/NativeSceneRenderer.ts
+++ b/src/engine/native3d/NativeSceneRenderer.ts
@@ -4,6 +4,7 @@ import { DEFAULT_GAUSSIAN_SPLAT_SETTINGS } from '../gaussian/types';
 import { resolveSharedSplatSceneKey } from '../scene/runtime/SharedSplatRuntimeUtils';
 import type {
   SceneCamera,
+  SceneGizmoRenderOptions,
   SceneLayer3DData,
   SceneModelLayer,
   ScenePlaneLayer,
@@ -12,6 +13,7 @@ import type {
 } from '../scene/types';
 import { ModelRuntimeCache } from './assets/ModelRuntimeCache';
 import { EffectorCompute } from './passes/EffectorCompute';
+import { GizmoPass } from './passes/GizmoPass';
 import { MeshPass, type SceneNativeMeshLayer } from './passes/MeshPass';
 import { PlanePass } from './passes/PlanePass';
 import { SplatPass } from './passes/SplatPass';
@@ -49,6 +51,7 @@ export class NativeSceneRenderer {
   private planeTextures = new Map<string, CachedPlaneTexture>();
   private readonly planePass = new PlanePass();
   private readonly meshPass = new MeshPass();
+  private readonly gizmoPass = new GizmoPass();
   private readonly splatPass = new SplatPass();
   private readonly effectorCompute = new EffectorCompute();
   private readonly modelRuntimeCache = new ModelRuntimeCache();
@@ -84,6 +87,7 @@ export class NativeSceneRenderer {
     camera: SceneCamera,
     effectors: SceneSplatEffectorRuntimeData[],
     realtimePlayback: boolean,
+    gizmo?: SceneGizmoRenderOptions | null,
   ): GPUTextureView | null {
     if (!this.initialized) {
       return null;
@@ -121,6 +125,7 @@ export class NativeSceneRenderer {
       camera,
       effectors,
       realtimePlayback,
+      gizmo,
     );
     if (!nativeSceneView) {
       return null;
@@ -151,6 +156,7 @@ export class NativeSceneRenderer {
     this.planeSampler = null;
     this.initialized = false;
     this.meshPass.dispose();
+    this.gizmoPass.dispose();
     for (const entry of this.planeTextures.values()) {
       entry.texture.destroy();
     }
@@ -208,6 +214,7 @@ export class NativeSceneRenderer {
     camera: SceneCamera,
     effectors: SceneSplatEffectorRuntimeData[],
     realtimePlayback: boolean,
+    gizmo?: SceneGizmoRenderOptions | null,
   ): GPUTextureView | null {
     const renderer = getGaussianSplatGpuRenderer();
     if (layers.length > 0 && !renderer.isInitialized) {
@@ -222,6 +229,7 @@ export class NativeSceneRenderer {
     this.ensureCompositeResources(device);
     this.ensurePlaneResources(device);
     this.meshPass.initialize(device, SCENE_DEPTH_FORMAT);
+    this.gizmoPass.initialize(device, 'rgba8unorm');
     if (
       !this.sceneTexture ||
       !this.sceneView ||
@@ -401,6 +409,21 @@ export class NativeSceneRenderer {
     }
 
     if (!this.renderPlanePass(device, commandEncoder, transparentPlanes, camera, true, temporaryBuffers)) {
+      return null;
+    }
+    const gizmoLayer = gizmo
+      ? [...planeLayers, ...nativeMeshLayers, ...layers].find((layer) => layer.clipId === gizmo.clipId) ?? null
+      : null;
+    if (gizmoLayer && !this.gizmoPass.render(
+      device,
+      commandEncoder,
+      this.sceneView,
+      gizmoLayer,
+      camera,
+      gizmo!.mode,
+      gizmo!.hoveredAxis,
+      temporaryBuffers,
+    )) {
       return null;
     }
     device.queue.submit([commandEncoder.finish()]);

--- a/src/engine/native3d/passes/GizmoPass.ts
+++ b/src/engine/native3d/passes/GizmoPass.ts
@@ -1,0 +1,452 @@
+import type {
+  SceneCamera,
+  SceneGizmoAxis,
+  SceneGizmoMode,
+  SceneLayer3DData,
+  SceneVector3,
+} from '../../scene/types';
+import shaderSource from '../shaders/GizmoPass.wgsl?raw';
+
+type SceneGizmoLayer = Pick<SceneLayer3DData, 'clipId' | 'worldMatrix' | 'worldTransform'>;
+
+type Vec2 = { x: number; y: number };
+type Vec3 = { x: number; y: number; z: number };
+type Vec4 = [number, number, number, number];
+
+const VERTEX_FLOATS = 8;
+const VERTEX_STRIDE_BYTES = VERTEX_FLOATS * 4;
+const GIZMO_AXES: readonly SceneGizmoAxis[] = ['x', 'y', 'z'];
+const AXIS_COLORS: Record<SceneGizmoAxis, readonly [number, number, number, number]> = {
+  x: [1, 0.16, 0.12, 1],
+  y: [0.2, 1, 0.32, 1],
+  z: [0.22, 0.5, 1, 1],
+};
+const OUTLINE_COLOR = [0.015, 0.02, 0.03, 0.78] as const;
+const RING_SEGMENTS = 96;
+const AXIS_SCREEN_LENGTH = 122;
+const RING_SCREEN_RADIUS = 112;
+const AXIS_THICKNESS = 6.4;
+const RING_THICKNESS = 5.1;
+const OUTLINE_EXTRA_THICKNESS = 4.4;
+const HOVER_THICKNESS_BOOST = 3.2;
+const HOVER_OUTLINE_EXTRA_THICKNESS = 6.8;
+
+export class GizmoPass {
+  private pipeline: GPURenderPipeline | null = null;
+
+  initialize(device: GPUDevice, colorFormat: GPUTextureFormat): void {
+    if (this.pipeline) return;
+
+    const shaderModule = device.createShaderModule({
+      code: shaderSource,
+      label: 'native-scene-gizmo-shader',
+    });
+
+    this.pipeline = device.createRenderPipeline({
+      layout: 'auto',
+      vertex: {
+        module: shaderModule,
+        entryPoint: 'vertexMain',
+        buffers: [
+          {
+            arrayStride: VERTEX_STRIDE_BYTES,
+            attributes: [
+              { shaderLocation: 0, offset: 0, format: 'float32x4' },
+              { shaderLocation: 1, offset: 16, format: 'float32x4' },
+            ],
+          },
+        ],
+      },
+      fragment: {
+        module: shaderModule,
+        entryPoint: 'fragmentMain',
+        targets: [
+          {
+            format: colorFormat,
+            blend: {
+              color: {
+                srcFactor: 'src-alpha',
+                dstFactor: 'one-minus-src-alpha',
+                operation: 'add',
+              },
+              alpha: {
+                srcFactor: 'one',
+                dstFactor: 'one-minus-src-alpha',
+                operation: 'add',
+              },
+            },
+          },
+        ],
+      },
+      primitive: {
+        topology: 'triangle-list',
+        cullMode: 'none',
+      },
+      label: 'native-scene-gizmo-pipeline',
+    });
+  }
+
+  render(
+    device: GPUDevice,
+    commandEncoder: GPUCommandEncoder,
+    sceneView: GPUTextureView,
+    layer: SceneGizmoLayer | null,
+    camera: SceneCamera,
+    mode: SceneGizmoMode,
+    hoveredAxis: SceneGizmoAxis | null | undefined,
+    temporaryBuffers: GPUBuffer[],
+  ): boolean {
+    if (!layer?.worldTransform || !this.pipeline) {
+      return true;
+    }
+
+    const vertices: number[] = [];
+    const viewProjection = multiplyMat4(camera.projectionMatrix, camera.viewMatrix);
+    const origin = layer.worldTransform.position;
+    const basis = resolveAxisBasis(layer.worldMatrix);
+    const worldPerPixel = resolveWorldPerPixel(origin, camera);
+
+    if (mode === 'rotate') {
+      this.appendRotationRings(vertices, viewProjection, camera.viewport, origin, basis, worldPerPixel, hoveredAxis ?? null);
+    } else {
+      this.appendAxisHandles(vertices, viewProjection, camera, origin, basis, worldPerPixel, mode, hoveredAxis ?? null);
+    }
+
+    if (vertices.length === 0) {
+      return true;
+    }
+
+    const vertexData = new Float32Array(vertices);
+    const vertexBuffer = device.createBuffer({
+      size: vertexData.byteLength,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+      label: 'native-scene-gizmo-vertex-buffer',
+    });
+    temporaryBuffers.push(vertexBuffer);
+    device.queue.writeBuffer(vertexBuffer, 0, vertexData.buffer, vertexData.byteOffset, vertexData.byteLength);
+
+    const renderPass = commandEncoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: sceneView,
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
+          loadOp: 'load',
+          storeOp: 'store',
+        },
+      ],
+      label: 'native-scene-gizmo-pass',
+    });
+    renderPass.setPipeline(this.pipeline);
+    renderPass.setVertexBuffer(0, vertexBuffer);
+    renderPass.draw(vertexData.length / VERTEX_FLOATS);
+    renderPass.end();
+    return true;
+  }
+
+  dispose(): void {
+    this.pipeline = null;
+  }
+
+  private appendAxisHandles(
+    vertices: number[],
+    viewProjection: Float32Array,
+    camera: SceneCamera,
+    origin: SceneVector3,
+    basis: Record<SceneGizmoAxis, Vec3>,
+    worldPerPixel: number,
+    mode: SceneGizmoMode,
+    hoveredAxis: SceneGizmoAxis | null,
+  ): void {
+    const length = worldPerPixel * AXIS_SCREEN_LENGTH;
+    const arrowLength = worldPerPixel * 24;
+    const arrowSpread = worldPerPixel * 12;
+    const cameraForward = normalize({
+      x: camera.cameraTarget.x - camera.cameraPosition.x,
+      y: camera.cameraTarget.y - camera.cameraPosition.y,
+      z: camera.cameraTarget.z - camera.cameraPosition.z,
+    });
+
+    for (const axis of getAxisDrawOrder(hoveredAxis)) {
+      const axisVector = basis[axis];
+      const end = add(origin, scale(axisVector, length));
+      const thickness = resolveAxisThickness(AXIS_THICKNESS, axis, hoveredAxis);
+      const color = resolveAxisColor(axis, hoveredAxis);
+      const outlineExtra = resolveOutlineExtra(axis, hoveredAxis);
+      addStyledSegment(vertices, viewProjection, camera.viewport, origin, end, thickness, color, outlineExtra);
+
+      if (mode === 'move') {
+        const side = resolveArrowSide(axisVector, cameraForward);
+        const base = add(end, scale(axisVector, -arrowLength));
+        addStyledSegment(vertices, viewProjection, camera.viewport, add(base, scale(side, arrowSpread)), end, thickness, color, outlineExtra);
+        addStyledSegment(vertices, viewProjection, camera.viewport, add(base, scale(side, -arrowSpread)), end, thickness, color, outlineExtra);
+      } else {
+        const sideA = normalize(cross(axisVector, { x: 0, y: 0, z: 1 }));
+        const side = lengthOf(sideA) < 0.001 ? { x: 1, y: 0, z: 0 } : sideA;
+        const sideB = normalize(cross(axisVector, side));
+        const size = worldPerPixel * 13;
+        const p1 = add(end, add(scale(side, -size), scale(sideB, -size)));
+        const p2 = add(end, add(scale(side, size), scale(sideB, -size)));
+        const p3 = add(end, add(scale(side, size), scale(sideB, size)));
+        const p4 = add(end, add(scale(side, -size), scale(sideB, size)));
+        addStyledSegment(vertices, viewProjection, camera.viewport, p1, p2, thickness, color, outlineExtra);
+        addStyledSegment(vertices, viewProjection, camera.viewport, p2, p3, thickness, color, outlineExtra);
+        addStyledSegment(vertices, viewProjection, camera.viewport, p3, p4, thickness, color, outlineExtra);
+        addStyledSegment(vertices, viewProjection, camera.viewport, p4, p1, thickness, color, outlineExtra);
+      }
+    }
+  }
+
+  private appendRotationRings(
+    vertices: number[],
+    viewProjection: Float32Array,
+    viewport: { width: number; height: number },
+    origin: SceneVector3,
+    basis: Record<SceneGizmoAxis, Vec3>,
+    worldPerPixel: number,
+    hoveredAxis: SceneGizmoAxis | null,
+  ): void {
+    const radius = worldPerPixel * RING_SCREEN_RADIUS;
+    const ringPlanes: Record<SceneGizmoAxis, [SceneGizmoAxis, SceneGizmoAxis]> = {
+      x: ['y', 'z'],
+      y: ['z', 'x'],
+      z: ['x', 'y'],
+    };
+
+    for (const axis of getAxisDrawOrder(hoveredAxis)) {
+      const [firstAxis, secondAxis] = ringPlanes[axis];
+      const first = basis[firstAxis];
+      const second = basis[secondAxis];
+      const thickness = resolveAxisThickness(RING_THICKNESS, axis, hoveredAxis);
+      const color = resolveAxisColor(axis, hoveredAxis);
+      const outlineExtra = resolveOutlineExtra(axis, hoveredAxis);
+      let previous: Vec3 | null = null;
+      for (let i = 0; i <= RING_SEGMENTS; i += 1) {
+        const angle = (i / RING_SEGMENTS) * Math.PI * 2;
+        const point = add(origin, add(
+          scale(first, Math.cos(angle) * radius),
+          scale(second, Math.sin(angle) * radius),
+        ));
+        if (previous) {
+          addStyledSegment(vertices, viewProjection, viewport, previous, point, thickness, color, outlineExtra);
+        }
+        previous = point;
+      }
+    }
+  }
+}
+
+function addStyledSegment(
+  vertices: number[],
+  viewProjection: Float32Array,
+  viewport: { width: number; height: number },
+  startWorld: Vec3,
+  endWorld: Vec3,
+  thicknessPx: number,
+  color: readonly [number, number, number, number],
+  outlineExtraThickness = OUTLINE_EXTRA_THICKNESS,
+): void {
+  addThickSegment(
+    vertices,
+    viewProjection,
+    viewport,
+    startWorld,
+    endWorld,
+    thicknessPx + outlineExtraThickness,
+    OUTLINE_COLOR,
+  );
+  addThickSegment(vertices, viewProjection, viewport, startWorld, endWorld, thicknessPx, color);
+}
+
+function getAxisDrawOrder(hoveredAxis: SceneGizmoAxis | null): readonly SceneGizmoAxis[] {
+  if (!hoveredAxis) {
+    return GIZMO_AXES;
+  }
+  return [...GIZMO_AXES.filter((axis) => axis !== hoveredAxis), hoveredAxis];
+}
+
+function resolveAxisThickness(baseThickness: number, axis: SceneGizmoAxis, hoveredAxis: SceneGizmoAxis | null): number {
+  return axis === hoveredAxis ? baseThickness + HOVER_THICKNESS_BOOST : baseThickness;
+}
+
+function resolveOutlineExtra(axis: SceneGizmoAxis, hoveredAxis: SceneGizmoAxis | null): number {
+  return axis === hoveredAxis ? HOVER_OUTLINE_EXTRA_THICKNESS : OUTLINE_EXTRA_THICKNESS;
+}
+
+function resolveAxisColor(
+  axis: SceneGizmoAxis,
+  hoveredAxis: SceneGizmoAxis | null,
+): readonly [number, number, number, number] {
+  const color = AXIS_COLORS[axis];
+  if (axis !== hoveredAxis) {
+    return color;
+  }
+
+  return [
+    color[0] + (1 - color[0]) * 0.48,
+    color[1] + (1 - color[1]) * 0.48,
+    color[2] + (1 - color[2]) * 0.48,
+    1,
+  ];
+}
+
+function addThickSegment(
+  vertices: number[],
+  viewProjection: Float32Array,
+  viewport: { width: number; height: number },
+  startWorld: Vec3,
+  endWorld: Vec3,
+  thicknessPx: number,
+  color: readonly [number, number, number, number],
+): void {
+  const startClip = projectWorld(viewProjection, startWorld);
+  const endClip = projectWorld(viewProjection, endWorld);
+  if (!startClip || !endClip || startClip[3] <= 0 || endClip[3] <= 0) {
+    return;
+  }
+
+  const startNdc = toNdc(startClip);
+  const endNdc = toNdc(endClip);
+  const dxPx = (endNdc.x - startNdc.x) * viewport.width * 0.5;
+  const dyPx = (endNdc.y - startNdc.y) * viewport.height * 0.5;
+  const lengthPx = Math.hypot(dxPx, dyPx);
+  if (lengthPx < 0.5) {
+    return;
+  }
+
+  const normalPx = { x: -dyPx / lengthPx, y: dxPx / lengthPx };
+  const halfThickness = thicknessPx * 0.5;
+  const offsetNdc = {
+    x: (normalPx.x * halfThickness * 2) / Math.max(1, viewport.width),
+    y: (normalPx.y * halfThickness * 2) / Math.max(1, viewport.height),
+  };
+
+  const startLeft = offsetClip(startNdc, startClip[3], offsetNdc);
+  const startRight = offsetClip(startNdc, startClip[3], { x: -offsetNdc.x, y: -offsetNdc.y });
+  const endLeft = offsetClip(endNdc, endClip[3], offsetNdc);
+  const endRight = offsetClip(endNdc, endClip[3], { x: -offsetNdc.x, y: -offsetNdc.y });
+
+  pushVertex(vertices, startLeft, color);
+  pushVertex(vertices, startRight, color);
+  pushVertex(vertices, endRight, color);
+  pushVertex(vertices, startLeft, color);
+  pushVertex(vertices, endRight, color);
+  pushVertex(vertices, endLeft, color);
+}
+
+function pushVertex(
+  vertices: number[],
+  position: Vec4,
+  color: readonly [number, number, number, number],
+): void {
+  vertices.push(position[0], position[1], position[2], position[3], color[0], color[1], color[2], color[3]);
+}
+
+function offsetClip(ndc: Vec3, w: number, offset: Vec2): Vec4 {
+  return [
+    (ndc.x + offset.x) * w,
+    (ndc.y + offset.y) * w,
+    ndc.z * w,
+    w,
+  ];
+}
+
+function toNdc(clip: Vec4): Vec3 {
+  return {
+    x: clip[0] / clip[3],
+    y: clip[1] / clip[3],
+    z: clip[2] / clip[3],
+  };
+}
+
+function projectWorld(viewProjection: Float32Array, point: Vec3): Vec4 | null {
+  const projected = multiplyMat4Vec4(viewProjection, [point.x, point.y, point.z, 1]);
+  if (!projected.every(Number.isFinite) || Math.abs(projected[3]) < 0.000001) {
+    return null;
+  }
+  return projected;
+}
+
+function resolveWorldPerPixel(origin: SceneVector3, camera: SceneCamera): number {
+  const distance = Math.max(
+    0.01,
+    Math.hypot(
+      origin.x - camera.cameraPosition.x,
+      origin.y - camera.cameraPosition.y,
+      origin.z - camera.cameraPosition.z,
+    ),
+  );
+  const fovRadians = (camera.fov * Math.PI) / 180;
+  return (2 * distance * Math.tan(fovRadians * 0.5)) / Math.max(1, camera.viewport.height);
+}
+
+function resolveAxisBasis(worldMatrix: Float32Array): Record<SceneGizmoAxis, Vec3> {
+  return {
+    x: normalize({ x: worldMatrix[0] ?? 1, y: worldMatrix[1] ?? 0, z: worldMatrix[2] ?? 0 }),
+    y: normalize({ x: worldMatrix[4] ?? 0, y: worldMatrix[5] ?? 1, z: worldMatrix[6] ?? 0 }),
+    z: normalize({ x: worldMatrix[8] ?? 0, y: worldMatrix[9] ?? 0, z: worldMatrix[10] ?? 1 }),
+  };
+}
+
+function resolveArrowSide(axis: Vec3, cameraForward: Vec3): Vec3 {
+  const side = normalize(cross(axis, cameraForward));
+  if (lengthOf(side) < 0.001) {
+    return normalize(cross(axis, { x: 0, y: 1, z: 0 }));
+  }
+  return side;
+}
+
+function multiplyMat4(a: Float32Array, b: Float32Array): Float32Array {
+  const out = new Float32Array(16);
+  for (let col = 0; col < 4; col += 1) {
+    for (let row = 0; row < 4; row += 1) {
+      let sum = 0;
+      for (let k = 0; k < 4; k += 1) {
+        sum += a[k * 4 + row] * b[col * 4 + k];
+      }
+      out[col * 4 + row] = sum;
+    }
+  }
+  return out;
+}
+
+function multiplyMat4Vec4(matrix: Float32Array, vector: Vec4): Vec4 {
+  const [x, y, z, w] = vector;
+  return [
+    matrix[0] * x + matrix[4] * y + matrix[8] * z + matrix[12] * w,
+    matrix[1] * x + matrix[5] * y + matrix[9] * z + matrix[13] * w,
+    matrix[2] * x + matrix[6] * y + matrix[10] * z + matrix[14] * w,
+    matrix[3] * x + matrix[7] * y + matrix[11] * z + matrix[15] * w,
+  ];
+}
+
+function add(a: Vec3, b: Vec3): Vec3 {
+  return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
+}
+
+function scale(vector: Vec3, scalar: number): Vec3 {
+  return { x: vector.x * scalar, y: vector.y * scalar, z: vector.z * scalar };
+}
+
+function cross(a: Vec3, b: Vec3): Vec3 {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+function lengthOf(vector: Vec3): number {
+  return Math.hypot(vector.x, vector.y, vector.z);
+}
+
+function normalize(vector: Vec3): Vec3 {
+  const length = lengthOf(vector);
+  if (length < 0.000001) {
+    return { x: 0, y: 0, z: 0 };
+  }
+  return {
+    x: vector.x / length,
+    y: vector.y / length,
+    z: vector.z / length,
+  };
+}

--- a/src/engine/native3d/shaders/GizmoPass.wgsl
+++ b/src/engine/native3d/shaders/GizmoPass.wgsl
@@ -1,0 +1,20 @@
+struct VertexOutput {
+  @builtin(position) position: vec4f,
+  @location(0) color: vec4f,
+}
+
+@vertex
+fn vertexMain(
+  @location(0) position: vec4f,
+  @location(1) color: vec4f,
+) -> VertexOutput {
+  var output: VertexOutput;
+  output.position = position;
+  output.color = color;
+  return output;
+}
+
+@fragment
+fn fragmentMain(input: VertexOutput) -> @location(0) vec4f {
+  return input.color;
+}

--- a/src/engine/render/RenderDispatcher.ts
+++ b/src/engine/render/RenderDispatcher.ts
@@ -1044,7 +1044,21 @@ export class RenderDispatcher {
     );
     const nativeRenderer = getGaussianSplatGpuRenderer();
     const timelineState = useTimelineStore.getState();
+    const engineState = useEngineStore.getState();
     const isDraggingPlayhead = timelineState.isDraggingPlayhead;
+    const primarySelectedClipId = timelineState.primarySelectedClipId && timelineState.selectedClipIds.has(timelineState.primarySelectedClipId)
+      ? timelineState.primarySelectedClipId
+      : timelineState.selectedClipIds.values().next().value as string | undefined;
+    const sceneGizmo = primarySelectedClipId &&
+      timelineState.isExporting !== true &&
+      timelineState.isPlaying !== true &&
+      renderLayers3D.some((layer) => layer.clipId === primarySelectedClipId)
+      ? {
+          clipId: primarySelectedClipId,
+          mode: engineState.sceneGizmoMode,
+          hoveredAxis: engineState.sceneGizmoHoveredAxis,
+        }
+      : null;
     for (const layer of nativeSplatLayers) {
       const previewMaxSplats = preciseSplatSorting ? undefined : this.getSplatSequencePreviewMaxSplats(layer);
       const sceneKey = this.getNativeGaussianSplatSceneKey(layer.clipId, layer.gaussianSplatRuntimeKey);
@@ -1098,6 +1112,7 @@ export class RenderDispatcher {
       camera,
       activeSplatEffectors,
       isRealtimePlayback,
+      sceneGizmo,
     );
     const hasSplatSequence = nativeSplatLayers.some((layer) => layer.gaussianSplatIsSequence === true);
     if (textureView && hasSplatSequence) {

--- a/src/engine/scene/types.ts
+++ b/src/engine/scene/types.ts
@@ -111,6 +111,15 @@ export interface SceneCamera {
   applyDefaultDistance?: boolean;
 }
 
+export type SceneGizmoAxis = 'x' | 'y' | 'z';
+export type SceneGizmoMode = 'move' | 'rotate' | 'scale';
+
+export interface SceneGizmoRenderOptions {
+  clipId: string;
+  mode: SceneGizmoMode;
+  hoveredAxis?: SceneGizmoAxis | null;
+}
+
 export interface SceneSplatEffectorRuntimeData {
   clipId: string;
   position: SceneVector3;

--- a/src/services/project/projectLoad.ts
+++ b/src/services/project/projectLoad.ts
@@ -251,6 +251,10 @@ async function convertProjectMediaToStore(projectMedia: ProjectMediaFile[]): Pro
           absolutePath: frame.absolutePath,
           file: frameFile,
           splatUrl,
+          splatCount: frame.splatCount,
+          fileSize: frame.fileSize,
+          container: frame.container,
+          codec: frame.codec,
         });
       }
 
@@ -390,12 +394,15 @@ async function convertProjectMediaToStore(projectMedia: ProjectMediaFile[]): Pro
       width: pm.width,
       height: pm.height,
       fps: pm.frameRate,
-      codec: pm.codec,
+      codec: pm.codec ?? gaussianSplatSequence?.codec,
       audioCodec: pm.audioCodec,
-      container: pm.container,
+      container: pm.container ?? (gaussianSplatSequence?.container ? `${gaussianSplatSequence.container} Seq` : undefined),
       bitrate: pm.bitrate,
-      fileSize: pm.fileSize,
+      fileSize: pm.fileSize ?? gaussianSplatSequence?.totalFileSize,
       hasAudio: pm.hasAudio,
+      splatCount: pm.splatCount ?? gaussianSplatSequence?.frames[0]?.splatCount,
+      totalSplatCount: pm.totalSplatCount ?? gaussianSplatSequence?.totalSplatCount,
+      splatFrameCount: pm.splatFrameCount ?? gaussianSplatSequence?.frameCount,
       modelSequence,
       gaussianSplatSequence,
       proxyStatus: pm.hasProxy ? 'ready' : 'none',
@@ -764,6 +771,11 @@ export async function loadProjectToStores(): Promise<void> {
     localStorage.setItem('media-panel-board-order', JSON.stringify(projectData.uiState.mediaPanelBoardOrder));
   } else {
     removeLocalStorageKey('media-panel-board-order');
+  }
+  if (projectData.uiState?.mediaPanelBoardGroupOffsets) {
+    localStorage.setItem('media-panel-board-group-offsets', JSON.stringify(projectData.uiState.mediaPanelBoardGroupOffsets));
+  } else {
+    removeLocalStorageKey('media-panel-board-group-offsets');
   }
   removeLocalStorageKey('media-panel-board-layout');
   window.dispatchEvent(new CustomEvent(MEDIA_PANEL_PROJECT_UI_LOADED_EVENT));

--- a/src/services/project/projectSave.ts
+++ b/src/services/project/projectSave.ts
@@ -32,6 +32,7 @@ import type {
   TimelineClip,
 } from '../../types';
 import type {
+  ProjectMediaBoardGroupOffsets,
   ProjectMediaBoardOrder,
   ProjectMediaBoardViewport,
 } from './types/project.types';
@@ -83,6 +84,10 @@ function serializeGaussianSplatSequence(
           projectPath: frame.projectPath,
           sourcePath: frame.sourcePath,
           absolutePath: frame.absolutePath,
+          splatCount: frame.splatCount,
+          fileSize: frame.fileSize,
+          container: frame.container,
+          codec: frame.codec,
         })),
       }
     : undefined;
@@ -102,12 +107,15 @@ function convertMediaFiles(files: MediaFile[]): ProjectMediaFile[] {
     width: file.width,
     height: file.height,
     frameRate: file.fps,
-    codec: file.codec,
+    codec: file.codec ?? file.gaussianSplatSequence?.codec,
     audioCodec: file.audioCodec,
-    container: file.container,
+    container: file.container ?? (file.gaussianSplatSequence?.container ? `${file.gaussianSplatSequence.container} Seq` : undefined),
     bitrate: file.bitrate,
-    fileSize: file.fileSize,
+    fileSize: file.fileSize ?? file.gaussianSplatSequence?.totalFileSize,
     hasAudio: file.hasAudio,
+    splatCount: file.splatCount ?? file.gaussianSplatSequence?.frames[0]?.splatCount,
+    totalSplatCount: file.totalSplatCount ?? file.gaussianSplatSequence?.totalSplatCount,
+    splatFrameCount: file.splatFrameCount ?? file.gaussianSplatSequence?.frameCount,
     hasProxy: file.proxyStatus === 'ready',
     vectorAnimation: file.vectorAnimation,
     modelSequence: serializeModelSequence(file.modelSequence),
@@ -422,6 +430,7 @@ export async function syncStoresToProject(): Promise<void> {
       const mediaPanelViewMode = readMediaPanelViewMode();
       const mediaPanelBoardViewport = parseLocalStorageJson<ProjectMediaBoardViewport>('media-panel-board-viewport');
       const mediaPanelBoardOrder = parseLocalStorageJson<ProjectMediaBoardOrder>('media-panel-board-order');
+      const mediaPanelBoardGroupOffsets = parseLocalStorageJson<ProjectMediaBoardGroupOffsets>('media-panel-board-group-offsets');
       const transcriptLanguage = localStorage.getItem('transcriptLanguage');
       const settingsState = useSettingsStore.getState();
       const midiState = useMIDIStore.getState();
@@ -434,6 +443,7 @@ export async function syncStoresToProject(): Promise<void> {
         mediaPanelViewMode,
         mediaPanelBoardViewport,
         mediaPanelBoardOrder,
+        mediaPanelBoardGroupOffsets,
         transcriptLanguage: transcriptLanguage || undefined,
         thumbnailsEnabled: timelineState.thumbnailsEnabled,
         waveformsEnabled: timelineState.waveformsEnabled,

--- a/src/services/project/types/media.types.ts
+++ b/src/services/project/types/media.types.ts
@@ -25,6 +25,9 @@ export interface ProjectMediaFile {
   bitrate?: number;
   fileSize?: number;
   hasAudio?: boolean;
+  splatCount?: number;
+  totalSplatCount?: number;
+  splatFrameCount?: number;
 
   // Proxy status
   hasProxy: boolean;

--- a/src/services/project/types/project.types.ts
+++ b/src/services/project/types/project.types.ts
@@ -59,6 +59,7 @@ export interface ProjectMediaBoardNodeLayout {
 }
 
 export type ProjectMediaBoardOrder = Record<string, string[]>;
+export type ProjectMediaBoardGroupOffsets = Record<string, { x: number; y: number }>;
 
 // UI state that gets persisted with the project
 export interface ProjectUIState {
@@ -78,6 +79,7 @@ export interface ProjectUIState {
   mediaPanelViewMode?: 'classic' | 'icons' | 'board';
   mediaPanelBoardViewport?: ProjectMediaBoardViewport;
   mediaPanelBoardOrder?: ProjectMediaBoardOrder;
+  mediaPanelBoardGroupOffsets?: ProjectMediaBoardGroupOffsets;
   /** @deprecated Board nodes now snap to folder slot grids; retained only to ignore older project files safely. */
   mediaPanelBoardLayouts?: Record<string, ProjectMediaBoardNodeLayout>;
   // Transcript settings

--- a/src/stores/engineStore.ts
+++ b/src/stores/engineStore.ts
@@ -4,6 +4,7 @@
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
 import type { EngineStats } from '../types';
+import type { SceneGizmoAxis, SceneGizmoMode } from '../engine/scene/types';
 
 export type GaussianSplatLoadPhase =
   | 'fetching'
@@ -44,6 +45,8 @@ interface EngineState {
   sceneNavClipId: string | null;
   sceneNavFpsMode: boolean;
   sceneNavFpsMoveSpeed: number;
+  sceneGizmoMode: SceneGizmoMode;
+  sceneGizmoHoveredAxis: SceneGizmoAxis | null;
   gaussianSplatLoadProgress: Record<string, GaussianSplatLoadProgressEntry>;
 
   // Actions
@@ -56,6 +59,8 @@ interface EngineState {
   setSceneNavClipId: (clipId: string | null) => void;
   setSceneNavFpsMode: (enabled: boolean) => void;
   setSceneNavFpsMoveSpeed: (speed: number) => void;
+  setSceneGizmoMode: (mode: SceneGizmoMode) => void;
+  setSceneGizmoHoveredAxis: (axis: SceneGizmoAxis | null) => void;
   setGaussianSplatLoadProgress: (progress: GaussianSplatLoadProgressUpdate) => void;
   clearGaussianSplatLoadProgress: (sceneKey: string) => void;
 }
@@ -145,6 +150,8 @@ export const useEngineStore = create<EngineState>()(
     sceneNavClipId: null,
     sceneNavFpsMode: false,
     sceneNavFpsMoveSpeed: 1,
+    sceneGizmoMode: 'move',
+    sceneGizmoHoveredAxis: null,
     gaussianSplatLoadProgress: {},
     engineStats: {
       fps: 0,
@@ -199,6 +206,14 @@ export const useEngineStore = create<EngineState>()(
 
     setSceneNavFpsMoveSpeed: (speed: number) => {
       set({ sceneNavFpsMoveSpeed: snapSceneNavFpsMoveSpeed(speed) });
+    },
+
+    setSceneGizmoMode: (mode: SceneGizmoMode) => {
+      set({ sceneGizmoMode: mode });
+    },
+
+    setSceneGizmoHoveredAxis: (axis: SceneGizmoAxis | null) => {
+      set({ sceneGizmoHoveredAxis: axis });
     },
 
     setGaussianSplatLoadProgress: (progress: GaussianSplatLoadProgressUpdate) => {

--- a/src/stores/mediaStore/helpers/gaussianSplatSequenceImport.ts
+++ b/src/stores/mediaStore/helpers/gaussianSplatSequenceImport.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../utils/gaussianSplatSequence';
 import { useSettingsStore } from '../../settingsStore';
 import type { MediaFile } from '../types';
+import { readGaussianSplatFileStats, summarizeGaussianSplatSequenceStats } from './gaussianSplatStats';
 
 const log = Logger.create('GaussianSplatSequenceImport');
 
@@ -142,6 +143,7 @@ export async function processGaussianSplatSequenceImport<T extends GaussianSplat
   const frames: GaussianSplatSequenceFrame[] = [];
   for (let index = 0; index < sequence.entries.length; index += 1) {
     const entry = sequence.entries[index];
+    const frameStats = await readGaussianSplatFileStats(entry.file);
     if (entry.handle) {
       const frameHandleKey = getSequenceFrameHandleCacheKey(id, index);
       fileSystemService.storeFileHandle(frameHandleKey, entry.handle);
@@ -154,17 +156,31 @@ export async function processGaussianSplatSequenceImport<T extends GaussianSplat
       absolutePath: entry.absolutePath,
       file: entry.file,
       splatUrl: URL.createObjectURL(entry.file),
+      splatCount: frameStats.splatCount,
+      fileSize: frameStats.fileSize,
+      container: frameStats.container,
+      codec: frameStats.codec,
     });
     advanceProgress();
   }
 
   const sharedBounds = await resolveSequenceSharedBounds(firstEntry);
-  const gaussianSplatSequence: GaussianSplatSequenceData = buildGaussianSplatSequenceData(frames, {
+  const sequenceStats = summarizeGaussianSplatSequenceStats(frames);
+  const baseGaussianSplatSequence = buildGaussianSplatSequenceData(frames, {
     fps: 30,
     playbackMode: 'clamp',
     sequenceName: sequence.sequenceName,
     sharedBounds,
   });
+  const gaussianSplatSequence: GaussianSplatSequenceData = {
+    ...baseGaussianSplatSequence,
+    totalSplatCount: sequenceStats.totalSplatCount,
+    minSplatCount: sequenceStats.minSplatCount,
+    maxSplatCount: sequenceStats.maxSplatCount,
+    totalFileSize: sequenceStats.fileSize,
+    container: sequenceStats.container,
+    codec: sequenceStats.codec,
+  };
 
   const duration = getGaussianSplatSequenceDuration(gaussianSplatSequence);
   const totalSize = sequence.entries.reduce((sum, entry) => sum + (entry.file.size || 0), 0);
@@ -180,7 +196,12 @@ export async function processGaussianSplatSequenceImport<T extends GaussianSplat
     gaussianSplatSequence,
     duration,
     fps: gaussianSplatSequence.fps,
-    fileSize: totalSize,
+    container: sequenceStats.container ? `${sequenceStats.container} Seq` : undefined,
+    codec: sequenceStats.codec,
+    fileSize: sequenceStats.fileSize || totalSize,
+    splatCount: sequenceStats.splatCount,
+    totalSplatCount: sequenceStats.totalSplatCount,
+    splatFrameCount: gaussianSplatSequence.frameCount,
     hasFileHandle: !!firstEntry.handle || !!firstProjectHandle,
     filePath: firstEntry.absolutePath ?? firstEntry.handle?.name ?? firstEntry.file.name,
     absolutePath: firstEntry.absolutePath,

--- a/src/stores/mediaStore/helpers/gaussianSplatStats.ts
+++ b/src/stores/mediaStore/helpers/gaussianSplatStats.ts
@@ -1,0 +1,103 @@
+import { detectFormat, parseGaussianSplatHeader } from '../../../engine/gaussian/loaders/parseHeader';
+import type { GaussianSplatFormat } from '../../../engine/gaussian/loaders/types';
+import type { GaussianSplatSequenceFrame } from '../../../types';
+
+export interface GaussianSplatFileStats {
+  splatCount?: number;
+  fileSize: number;
+  container: string;
+  codec: string;
+}
+
+export interface GaussianSplatSequenceStats {
+  splatCount?: number;
+  totalSplatCount?: number;
+  minSplatCount?: number;
+  maxSplatCount?: number;
+  fileSize: number;
+  container?: string;
+  codec: string;
+}
+
+const CONTAINER_LABELS: Record<GaussianSplatFormat, string> = {
+  ply: 'PLY',
+  splat: 'SPLAT',
+  ksplat: 'KSPLAT',
+  'gsplat-zip': 'ZIP',
+  spz: 'SPZ',
+  sog: 'SOG',
+  lcc: 'LCC',
+};
+
+function getContainerFromFormat(format: GaussianSplatFormat | null): string {
+  return format ? CONTAINER_LABELS[format] : 'SPLAT';
+}
+
+export function getGaussianSplatContainerLabelFromFileName(fileName: string): string {
+  const lowerName = fileName.toLowerCase();
+  if (lowerName.endsWith('.compressed.ply')) return 'PLY';
+  if (lowerName.endsWith('.ksplat')) return 'KSPLAT';
+  if (lowerName.endsWith('.splat')) return 'SPLAT';
+  if (lowerName.endsWith('.spz')) return 'SPZ';
+  if (lowerName.endsWith('.sog')) return 'SOG';
+  if (lowerName.endsWith('.lcc')) return 'LCC';
+  if (lowerName.endsWith('.zip')) return 'ZIP';
+  if (lowerName.endsWith('.ply')) return 'PLY';
+  return 'SPLAT';
+}
+
+function normalizeSplatCount(count: number | undefined): number | undefined {
+  return typeof count === 'number' && Number.isFinite(count) && count > 0
+    ? Math.floor(count)
+    : undefined;
+}
+
+export async function readGaussianSplatFileStats(file: File): Promise<GaussianSplatFileStats> {
+  const detectedFormat = detectFormat(file);
+  const fallback: GaussianSplatFileStats = {
+    fileSize: file.size,
+    container: detectedFormat
+      ? getContainerFromFormat(detectedFormat)
+      : getGaussianSplatContainerLabelFromFileName(file.name),
+    codec: 'Splat',
+  };
+
+  try {
+    const metadata = await parseGaussianSplatHeader(file, detectedFormat ?? undefined);
+    return {
+      ...fallback,
+      container: getContainerFromFormat(metadata.format),
+      splatCount: normalizeSplatCount(metadata.splatCount),
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+export function summarizeGaussianSplatSequenceStats(
+  frames: GaussianSplatSequenceFrame[],
+): GaussianSplatSequenceStats {
+  const counts = frames
+    .map((frame) => normalizeSplatCount(frame.splatCount))
+    .filter((count): count is number => count !== undefined);
+  const totalSplatCount = counts.length > 0
+    ? counts.reduce((sum, count) => sum + count, 0)
+    : undefined;
+  const containers = frames
+    .map((frame) => frame.container)
+    .filter((container): container is string => !!container);
+  const firstContainer = containers[0];
+  const mixedContainers = firstContainer
+    ? containers.some((container) => container !== firstContainer)
+    : false;
+
+  return {
+    splatCount: counts[0],
+    totalSplatCount,
+    minSplatCount: counts.length > 0 ? Math.min(...counts) : undefined,
+    maxSplatCount: counts.length > 0 ? Math.max(...counts) : undefined,
+    fileSize: frames.reduce((sum, frame) => sum + (frame.fileSize ?? frame.file?.size ?? 0), 0),
+    container: mixedContainers ? 'Mixed' : firstContainer,
+    codec: 'Splat Seq',
+  };
+}

--- a/src/stores/mediaStore/helpers/importPipeline.ts
+++ b/src/stores/mediaStore/helpers/importPipeline.ts
@@ -13,6 +13,7 @@ import { useSettingsStore } from '../../settingsStore';
 import { Logger } from '../../../services/logger';
 import { prewarmGaussianSplatRuntime } from '../../../engine/scene/runtime/SharedSplatRuntimeCache';
 import { prepareLottieAsset } from '../../../services/vectorAnimation/lottieMetadata';
+import { readGaussianSplatFileStats } from './gaussianSplatStats';
 
 const log = Logger.create('Import');
 
@@ -125,6 +126,10 @@ export async function processImport(params: ImportParams): Promise<ImportResult>
     }
   }
 
+  const gaussianSplatStats = type === 'gaussian-splat'
+    ? await readGaussianSplatFileStats(canonicalFile)
+    : undefined;
+
   // Build MediaFile
   const mediaFile: MediaFile = {
     id,
@@ -142,6 +147,7 @@ export async function processImport(params: ImportParams): Promise<ImportResult>
     projectPath: copyResult?.relativePath,
     ...info,
     ...proxyInfo,
+    ...gaussianSplatStats,
   };
 
   if (type === 'gaussian-splat') {

--- a/src/stores/mediaStore/slices/fileImportSlice.ts
+++ b/src/stores/mediaStore/slices/fileImportSlice.ts
@@ -17,6 +17,7 @@ import {
   type GroupedModelSequence,
   type ModelSequenceImportEntry,
 } from '../../../utils/modelSequence';
+import { getGaussianSplatContainerLabelFromFileName } from '../helpers/gaussianSplatStats';
 
 const log = Logger.create('Import');
 
@@ -63,6 +64,12 @@ function createPlaceholder(file: File, id: string, type: ImportableMediaType, pa
     url: '',
     fileSize: file.size,
     isImporting: true,
+    ...(type === 'gaussian-splat'
+      ? {
+          container: getGaussianSplatContainerLabelFromFileName(file.name),
+          codec: 'Splat',
+        }
+      : {}),
   };
 }
 
@@ -83,6 +90,9 @@ function createSequencePlaceholder(
     fileSize: sequence.entries.reduce((sum, entry) => sum + entry.file.size, 0),
     duration: sequence.frameCount / 30,
     fps: 30,
+    container: `${getGaussianSplatContainerLabelFromFileName(sequence.entries[0]?.file.name ?? '')} Seq`,
+    codec: 'Splat Seq',
+    splatFrameCount: sequence.frameCount,
     importProgress: 0,
     isImporting: true,
   };
@@ -514,6 +524,8 @@ export const createFileImportSlice: MediaSliceCreator<FileImportActions> = (set,
       file,
       url: '',
       fileSize: file.size,
+      container: getGaussianSplatContainerLabelFromFileName(file.name),
+      codec: 'Splat',
       isImporting: true,
     };
     set((state) => ({

--- a/src/stores/mediaStore/types.ts
+++ b/src/stores/mediaStore/types.ts
@@ -95,6 +95,9 @@ export interface MediaFile extends MediaItem {
   hasAudio?: boolean;    // Does video have audio tracks?
   fileHash?: string;
   thumbnailUrl?: string;
+  splatCount?: number;
+  totalSplatCount?: number;
+  splatFrameCount?: number;
   // Proxy support
   proxyStatus?: ProxyStatus;
   proxyProgress?: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,6 +44,10 @@ export interface GaussianSplatSequenceFrame {
   absolutePath?: string;
   file?: File;
   splatUrl?: string;
+  splatCount?: number;
+  fileSize?: number;
+  container?: string;
+  codec?: string;
 }
 
 export interface GaussianSplatBounds {
@@ -57,6 +61,12 @@ export interface GaussianSplatSequenceData {
   playbackMode?: ModelSequencePlaybackMode;
   sequenceName?: string;
   sharedBounds?: GaussianSplatBounds;
+  totalSplatCount?: number;
+  minSplatCount?: number;
+  maxSplatCount?: number;
+  totalFileSize?: number;
+  container?: string;
+  codec?: string;
   frames: GaussianSplatSequenceFrame[];
 }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,6 +1,6 @@
 // App version
 // Format: MAJOR.MINOR.PATCH
-export const APP_VERSION = '1.6.1';
+export const APP_VERSION = '1.6.2';
 
 export interface ChangelogNotice {
   type: 'info' | 'warning' | 'success' | 'danger';

--- a/tests/unit/PreviewSourceMonitor.test.tsx
+++ b/tests/unit/PreviewSourceMonitor.test.tsx
@@ -1,0 +1,258 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Preview } from '../../src/components/preview/Preview';
+import { useMediaStore } from '../../src/stores/mediaStore';
+import type { Composition, MediaFile } from '../../src/stores/mediaStore';
+
+vi.mock('../../src/hooks/useEngine', () => ({
+  useEngine: () => ({ isEngineReady: false }),
+}));
+
+vi.mock('../../src/hooks/useShortcut', () => ({
+  useShortcut: vi.fn(),
+}));
+
+vi.mock('../../src/stores/mediaStore', () => ({
+  DEFAULT_SCENE_CAMERA_SETTINGS: { fov: 60, near: 0.1, far: 1000 },
+  useMediaStore: Object.assign(vi.fn(), {
+    getState: vi.fn(),
+  }),
+}));
+
+const timelineState = {
+  clips: [],
+  selectedClipIds: new Set<string>(),
+  primarySelectedClipId: null,
+  selectClip: vi.fn(),
+  updateClipTransform: vi.fn(),
+  maskEditMode: 'none',
+  layers: [],
+  selectedLayerId: null,
+  selectLayer: vi.fn(),
+  updateLayer: vi.fn(),
+  tracks: [],
+  isPlaying: false,
+  setPropertyValue: vi.fn(),
+  hasKeyframes: vi.fn(() => false),
+  isRecording: vi.fn(() => false),
+  playheadPosition: 0,
+  getInterpolatedTransform: vi.fn(() => null),
+};
+
+vi.mock('../../src/stores/timeline', () => ({
+  useTimelineStore: Object.assign(vi.fn((selector: (state: typeof timelineState) => unknown) => selector(timelineState)), {
+    getState: vi.fn(() => timelineState),
+  }),
+}));
+
+const engineState = {
+  engineInitFailed: false,
+  engineInitError: null,
+  engineStats: null,
+  sceneNavClipId: null,
+  sceneNavFpsMode: false,
+  sceneNavFpsMoveSpeed: 1,
+  activeGaussianSplatLoadProgress: null,
+  setSceneNavFpsMoveSpeed: vi.fn(),
+};
+
+vi.mock('../../src/stores/engineStore', () => ({
+  selectActiveGaussianSplatLoadProgress: (state: typeof engineState) => state.activeGaussianSplatLoadProgress,
+  selectSceneNavClipId: (state: typeof engineState) => state.sceneNavClipId,
+  selectSceneNavFpsMode: (state: typeof engineState) => state.sceneNavFpsMode,
+  selectSceneNavFpsMoveSpeed: (state: typeof engineState) => state.sceneNavFpsMoveSpeed,
+  stepSceneNavFpsMoveSpeed: vi.fn((speed: number) => speed),
+  useEngineStore: Object.assign(vi.fn((selector: (state: typeof engineState) => unknown) => selector(engineState)), {
+    getState: vi.fn(() => engineState),
+  }),
+}));
+
+const dockState = {
+  addPreviewPanel: vi.fn(),
+  updatePanelData: vi.fn(),
+  closePanelById: vi.fn(),
+};
+
+vi.mock('../../src/stores/dockStore', () => ({
+  useDockStore: vi.fn((selector: (state: typeof dockState) => unknown) => selector(dockState)),
+}));
+
+const settingsState = {
+  outputResolution: { width: 1920, height: 1080 },
+  previewQuality: 'full',
+  setPreviewQuality: vi.fn(),
+};
+
+vi.mock('../../src/stores/settingsStore', () => ({
+  useSettingsStore: Object.assign(vi.fn((selector: (state: typeof settingsState) => unknown) => selector(settingsState)), {
+    getState: vi.fn(() => settingsState),
+  }),
+}));
+
+vi.mock('../../src/stores/renderTargetStore', () => ({
+  useRenderTargetStore: {
+    getState: vi.fn(() => ({
+      registerTarget: vi.fn(),
+      unregisterTarget: vi.fn(),
+      setTargetTransparencyGrid: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock('../../src/stores/historyStore', () => ({
+  startBatch: vi.fn(),
+  endBatch: vi.fn(),
+}));
+
+vi.mock('../../src/stores/sam2Store', () => ({
+  useSAM2Store: vi.fn((selector: (state: { isActive: boolean }) => unknown) => selector({ isActive: false })),
+}));
+
+vi.mock('../../src/services/renderScheduler', () => ({
+  renderScheduler: {
+    register: vi.fn(),
+    unregister: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/components/preview/SourceMonitor', () => ({
+  SourceMonitor: ({ file }: { file: MediaFile }) => <div data-testid="source-monitor">{file.name}</div>,
+}));
+
+vi.mock('../../src/components/preview/PreviewControls', () => ({
+  PreviewControls: ({ sourceMonitorActive }: { sourceMonitorActive: boolean }) => (
+    <div data-testid="preview-controls">{sourceMonitorActive ? 'source' : 'composition'}</div>
+  ),
+}));
+
+vi.mock('../../src/components/preview/StatsOverlay', () => ({
+  StatsOverlay: () => null,
+}));
+
+vi.mock('../../src/components/preview/PreviewBottomControls', () => ({
+  PreviewBottomControls: () => null,
+}));
+
+vi.mock('../../src/components/preview/MaskOverlay', () => ({
+  MaskOverlay: () => null,
+}));
+
+vi.mock('../../src/components/preview/SAM2Overlay', () => ({
+  SAM2Overlay: () => null,
+}));
+
+vi.mock('../../src/components/preview/SceneObjectOverlay', () => ({
+  SceneObjectOverlay: () => null,
+}));
+
+vi.mock('../../src/components/preview/useEditModeOverlay', () => ({
+  useEditModeOverlay: () => ({
+    calculateLayerBounds: vi.fn(),
+    findLayerAtPosition: vi.fn(),
+    findHandleAtPosition: vi.fn(),
+    getCursorForHandle: vi.fn(() => 'default'),
+  }),
+}));
+
+vi.mock('../../src/components/preview/useLayerDrag', () => ({
+  useLayerDrag: () => ({
+    isDragging: false,
+    dragMode: null,
+    dragHandle: null,
+    hoverHandle: null,
+    handleOverlayMouseDown: vi.fn(),
+    handleOverlayMouseMove: vi.fn(),
+    handleOverlayMouseUp: vi.fn(),
+  }),
+}));
+
+type MockMediaState = {
+  files: MediaFile[];
+  compositions: Composition[];
+  activeCompositionId: string | null;
+  previewCompositionId: string | null;
+  sourceMonitorFileId: string | null;
+  setSourceMonitorFile: ReturnType<typeof vi.fn>;
+};
+
+const mockedUseMediaStore = useMediaStore as unknown as ReturnType<typeof vi.fn> & {
+  getState: ReturnType<typeof vi.fn>;
+};
+
+function createComposition(id: string): Composition {
+  return {
+    id,
+    name: id,
+    type: 'composition',
+    parentId: null,
+    createdAt: 1,
+    width: 1920,
+    height: 1080,
+    frameRate: 30,
+    duration: 10,
+    backgroundColor: '#000000',
+  };
+}
+
+function createVideoFile(): MediaFile {
+  return {
+    id: 'file-1',
+    name: 'Clip.mp4',
+    type: 'video',
+    parentId: null,
+    createdAt: 1,
+    file: new File(['video'], 'Clip.mp4', { type: 'video/mp4' }),
+    url: 'blob:clip',
+    duration: 10,
+  };
+}
+
+describe('Preview source monitor lifecycle', () => {
+  let mediaState: MockMediaState;
+
+  beforeEach(() => {
+    class TestResizeObserver {
+      observe = vi.fn();
+      disconnect = vi.fn();
+    }
+    globalThis.ResizeObserver = TestResizeObserver as unknown as typeof ResizeObserver;
+
+    mediaState = {
+      files: [createVideoFile()],
+      compositions: [createComposition('comp-1'), createComposition('comp-2')],
+      activeCompositionId: 'comp-1',
+      previewCompositionId: null,
+      sourceMonitorFileId: 'file-1',
+      setSourceMonitorFile: vi.fn((id: string | null) => {
+        mediaState.sourceMonitorFileId = id;
+      }),
+    };
+
+    mockedUseMediaStore.mockImplementation((selector: (state: MockMediaState) => unknown) => selector(mediaState));
+    mockedUseMediaStore.getState.mockReturnValue(mediaState);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('does not close the source monitor just because a source file was selected', () => {
+    render(<Preview panelId="preview" source={{ type: 'activeComp' }} showTransparencyGrid={false} />);
+
+    expect(screen.getByTestId('source-monitor')).toHaveTextContent('Clip.mp4');
+    expect(mediaState.setSourceMonitorFile).not.toHaveBeenCalledWith(null);
+  });
+
+  it('still closes the source monitor when the active composition actually changes', () => {
+    const { rerender } = render(
+      <Preview panelId="preview" source={{ type: 'activeComp' }} showTransparencyGrid={false} />,
+    );
+
+    mediaState.activeCompositionId = 'comp-2';
+    rerender(<Preview panelId="preview" source={{ type: 'activeComp' }} showTransparencyGrid={false} />);
+
+    expect(mediaState.setSourceMonitorFile).toHaveBeenCalledWith(null);
+  });
+});

--- a/tests/unit/gaussianSplatStats.test.ts
+++ b/tests/unit/gaussianSplatStats.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getGaussianSplatContainerLabelFromFileName,
+  readGaussianSplatFileStats,
+  summarizeGaussianSplatSequenceStats,
+} from '../../src/stores/mediaStore/helpers/gaussianSplatStats';
+
+function createPlyFile(name: string, vertexCount: number): File {
+  const header = [
+    'ply',
+    'format binary_little_endian 1.0',
+    `element vertex ${vertexCount}`,
+    'property float x',
+    'property float y',
+    'property float z',
+    'end_header',
+    '',
+  ].join('\n');
+  const bytes = new TextEncoder().encode(header);
+  return {
+    name,
+    size: bytes.byteLength,
+    slice: () => ({
+      arrayBuffer: async () => bytes.buffer.slice(0),
+    }),
+  } as File;
+}
+
+describe('gaussian splat stats', () => {
+  it('reads splat count from PLY headers', async () => {
+    const stats = await readGaussianSplatFileStats(createPlyFile('scan000000.ply', 12345));
+
+    expect(stats).toMatchObject({
+      splatCount: 12345,
+      container: 'PLY',
+      codec: 'Splat',
+    });
+  });
+
+  it('derives .splat count from 32-byte records', async () => {
+    const stats = await readGaussianSplatFileStats(new File([new Uint8Array(96)], 'scan.splat'));
+
+    expect(stats.splatCount).toBe(3);
+    expect(stats.container).toBe('SPLAT');
+  });
+
+  it('summarizes sequence counts and total size', () => {
+    const summary = summarizeGaussianSplatSequenceStats([
+      { name: 'scan000000.ply', splatCount: 1000, fileSize: 64, container: 'PLY', codec: 'Splat' },
+      { name: 'scan000001.ply', splatCount: 2500, fileSize: 96, container: 'PLY', codec: 'Splat' },
+    ]);
+
+    expect(summary).toMatchObject({
+      splatCount: 1000,
+      totalSplatCount: 3500,
+      minSplatCount: 1000,
+      maxSplatCount: 2500,
+      fileSize: 160,
+      container: 'PLY',
+      codec: 'Splat Seq',
+    });
+  });
+
+  it('keeps compressed PLY grouped under the PLY container label', () => {
+    expect(getGaussianSplatContainerLabelFromFileName('scan.compressed.ply')).toBe('PLY');
+  });
+});

--- a/tests/unit/mediaPanelSourceMonitor.test.tsx
+++ b/tests/unit/mediaPanelSourceMonitor.test.tsx
@@ -1,0 +1,149 @@
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MediaPanel } from '../../src/components/panels/MediaPanel';
+import { useMediaStore } from '../../src/stores/mediaStore';
+import type { MediaFile } from '../../src/stores/mediaStore';
+
+vi.mock('../../src/stores/dockStore', () => ({
+  useDockStore: Object.assign(vi.fn(), {
+    getState: vi.fn(() => ({
+      activatePanelType: vi.fn(),
+    })),
+  }),
+}));
+
+vi.mock('../../src/stores/timeline', () => ({
+  useTimelineStore: Object.assign(vi.fn(), {
+    getState: vi.fn(() => ({
+      setDuration: vi.fn(),
+      slotGridProgress: 0,
+      clips: [],
+      selectClip: vi.fn(),
+    })),
+  }),
+}));
+
+type MockMediaState = Record<string, unknown> & {
+  files: MediaFile[];
+  selectedIds: string[];
+  setSelection: ReturnType<typeof vi.fn>;
+  setSourceMonitorFile: ReturnType<typeof vi.fn>;
+  getItemsByFolder: (folderId: string | null) => unknown[];
+};
+
+const mockedUseMediaStore = useMediaStore as unknown as ReturnType<typeof vi.fn> & {
+  getState: ReturnType<typeof vi.fn>;
+};
+
+function createVideoFile(): MediaFile {
+  return {
+    id: 'file-1',
+    name: 'Clip.mp4',
+    type: 'video',
+    parentId: null,
+    createdAt: 1,
+    file: new File(['video'], 'Clip.mp4', { type: 'video/mp4' }),
+    url: 'blob:clip',
+    duration: 10,
+    width: 1920,
+    height: 1080,
+    codec: 'H.264',
+  };
+}
+
+function createMediaState(): MockMediaState {
+  const file = createVideoFile();
+  const state: MockMediaState = {
+    files: [file],
+    compositions: [],
+    folders: [],
+    textItems: [],
+    solidItems: [],
+    meshItems: [],
+    cameraItems: [],
+    splatEffectorItems: [],
+    selectedIds: [],
+    expandedFolderIds: [],
+    fileSystemSupported: false,
+    proxyFolderName: null,
+    activeCompositionId: null,
+    sourceMonitorFileId: null,
+    importFiles: vi.fn(),
+    importFilesWithPicker: vi.fn(),
+    createComposition: vi.fn(),
+    createFolder: vi.fn(),
+    removeFile: vi.fn(),
+    removeComposition: vi.fn(),
+    removeFolder: vi.fn(),
+    renameFile: vi.fn(),
+    renameFolder: vi.fn(),
+    reloadFile: vi.fn(),
+    toggleFolderExpanded: vi.fn(),
+    setSelection: vi.fn((ids: string[]) => {
+      state.selectedIds = ids;
+    }),
+    addToSelection: vi.fn(),
+    getItemsByFolder: (folderId: string | null) => state.files.filter((item) => item.parentId === folderId),
+    openCompositionTab: vi.fn(),
+    updateComposition: vi.fn(),
+    generateProxy: vi.fn(),
+    cancelProxyGeneration: vi.fn(),
+    pickProxyFolder: vi.fn(),
+    showInExplorer: vi.fn(),
+    moveToFolder: vi.fn(),
+    createTextItem: vi.fn(),
+    getOrCreateTextFolder: vi.fn(),
+    removeTextItem: vi.fn(),
+    createSolidItem: vi.fn(),
+    getOrCreateSolidFolder: vi.fn(),
+    updateSolidItem: vi.fn(),
+    createMeshItem: vi.fn(),
+    getOrCreateMeshFolder: vi.fn(),
+    removeMeshItem: vi.fn(),
+    createCameraItem: vi.fn(),
+    getOrCreateCameraFolder: vi.fn(),
+    removeCameraItem: vi.fn(),
+    createSplatEffectorItem: vi.fn(),
+    getOrCreateSplatEffectorFolder: vi.fn(),
+    removeSplatEffectorItem: vi.fn(),
+    setLabelColor: vi.fn(),
+    importGaussianSplat: vi.fn(),
+    refreshFileUrls: vi.fn(),
+    setSourceMonitorFile: vi.fn((id: string | null) => {
+      state.sourceMonitorFileId = id;
+    }),
+  };
+  return state;
+}
+
+describe('MediaPanel source monitor opening', () => {
+  let mediaState: MockMediaState;
+
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem('media-panel-view-mode', 'board');
+
+    mediaState = createMediaState();
+    mockedUseMediaStore.mockImplementation((selector: (state: MockMediaState) => unknown) => selector(mediaState));
+    mockedUseMediaStore.getState.mockReturnValue(mediaState);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('keeps board asset clicks eligible for double-click source preview', () => {
+    const { container } = render(<MediaPanel />);
+    const node = container.querySelector('.media-board-node');
+
+    expect(node).toBeInstanceOf(HTMLElement);
+    expect(fireEvent.mouseDown(node!, { button: 0, detail: 1, clientX: 80, clientY: 80 })).toBe(true);
+    fireEvent.mouseUp(window);
+
+    fireEvent.doubleClick(node!, { button: 0, detail: 2 });
+
+    expect(mediaState.setSourceMonitorFile).toHaveBeenCalledWith('file-1');
+  });
+});


### PR DESCRIPTION
## Summary
- render 3D transform gizmos through the native scene path with hover highlighting, local-axis rotation, center-hub actions, and double-click reset
- show gaussian splat and splat-sequence stats in the Media Panel, including container, size, frame count, and compact splat totals
- keep source monitor previews open until the active composition actually changes

## Verification
- npm run build
- npm run test
- npm run lint passed before release metadata; the final lint rerun was interrupted by the user, then merge was explicitly requested without waiting on checks