### PR TITLE
Fix audio waveform vanishing on zoom (Linux/Chromium) (#171)

### DIFF
--- a/src/components/timeline/components/ClipWaveform.tsx
+++ b/src/components/timeline/components/ClipWaveform.tsx
@@ -16,7 +16,6 @@ import {
   type TimelineWaveformPyramid,
   type WaveformColumn,
 } from '../utils/waveformLod';
-
 const MAX_RENDERED_WAVEFORM_CHANNELS = 8;
 
 function drawCenterLine(ctx: CanvasRenderingContext2D, width: number, height: number): void {
@@ -439,9 +438,15 @@ export const ClipWaveform = memo(function ClipWaveform({
 
       const canvas = canvasRef.current;
       const hasLegacyWaveform = Boolean(waveform?.length || waveformChannels?.some(channel => channel.length > 0));
-      if (!canvas || (!pyramid && !hasLegacyWaveform) || width <= 0 || naturalDuration <= 0) return;
+      if (!canvas || (!pyramid && !hasLegacyWaveform) || width <= 0 || naturalDuration <= 0) {
+        return;
+      }
 
-      const ctx = canvas.getContext('2d');
+      // willReadFrequently forces Chromium onto the CPU raster path for this canvas,
+      // which avoids a Linux GPU-accelerated-2D-canvas present bug where the layer
+      // intermittently renders blank after a per-zoom backing-store resize (#171).
+      // These canvases only redraw on zoom/scroll/edit, so CPU raster is negligible.
+      const ctx = canvas.getContext('2d', { willReadFrequently: true });
       if (!ctx) return;
 
       const clipWidth = Math.max(1, width);


### PR DESCRIPTION
Force the waveform canvas onto Chromium's CPU raster path via getContext('2d', { willReadFrequently: true }).

On Linux the GPU-accelerated 2D-canvas path intermittently fails to present the layer after the per-zoom canvas.width/height resize, so the waveform blanked (and oscillated) while zooming even though the bitmap was drawn correctly and the canvas was visible in the DOM. The spectrogram was immune only because its putImageData usage already puts it on the CPU raster path. willReadFrequently does the same for the waveform. Cross-platform, no OS-specific branching; negligible cost since these canvases only redraw on zoom/scroll/edit.