### PR TITLE
Fix React compiler warnings

### DIFF
--- a/src/artifacts/hash.ts
+++ b/src/artifacts/hash.ts
@@ -1,9 +1,26 @@
 import { ARTIFACT_HASH_ALGORITHM, type ArtifactInput } from './types';
 
+type Sha256Input = ArrayBuffer | ArrayBufferView;
+type CryptoDigestBytes = Uint8Array<ArrayBuffer>;
+
 function toHex(bytes: ArrayBuffer): string {
   return [...new Uint8Array(bytes)]
     .map((byte) => byte.toString(16).padStart(2, '0'))
     .join('');
+}
+
+function copyCryptoDigestBytes(source: Uint8Array): CryptoDigestBytes {
+  const copy = new Uint8Array(source.byteLength);
+  copy.set(source);
+  return copy;
+}
+
+function toCryptoDigestBytes(input: Sha256Input): CryptoDigestBytes {
+  const source = ArrayBuffer.isView(input)
+    ? new Uint8Array(input.buffer, input.byteOffset, input.byteLength)
+    : new Uint8Array(input);
+
+  return copyCryptoDigestBytes(source);
 }
 
 export async function artifactInputToBlob(
@@ -37,12 +54,12 @@ export async function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
   });
 }
 
-export async function sha256ArrayBuffer(buffer: ArrayBuffer): Promise<string> {
+export async function sha256ArrayBuffer(buffer: Sha256Input): Promise<string> {
   if (!globalThis.crypto?.subtle) {
     throw new Error('Web Crypto SHA-256 is not available in this runtime');
   }
 
-  const digest = await globalThis.crypto.subtle.digest('SHA-256', buffer);
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', toCryptoDigestBytes(buffer));
   return toHex(digest);
 }
 

--- a/src/components/common/EditableDraggableNumber.tsx
+++ b/src/components/common/EditableDraggableNumber.tsx
@@ -137,12 +137,6 @@ export function EditableDraggableNumber({
   }, [effectiveDefaultValue]);
 
   useEffect(() => {
-    if (!isEditing) {
-      setDraftValue(formatEditableValue(value, decimals));
-    }
-  }, [decimals, isEditing, value]);
-
-  useEffect(() => {
     if (!isEditing) return;
     const rafId = window.requestAnimationFrame(() => {
       inputRef.current?.focus();
@@ -164,16 +158,9 @@ export function EditableDraggableNumber({
   const openBoundsPopover = useCallback(() => {
     setIsEditing(false);
     syncBoundsDraft();
+    setPopoverPlacement((current) => ({ ...current, visibility: 'hidden' }));
     setShowBoundsPopover(true);
   }, [syncBoundsDraft]);
-
-  useEffect(() => {
-    setDraftDefaultValue(
-      effectiveDefaultValue !== undefined
-        ? formatEditableValue(effectiveDefaultValue, decimals)
-        : '',
-    );
-  }, [decimals, effectiveDefaultValue]);
 
   useEffect(() => {
     if (!showBoundsPopover) return;
@@ -232,7 +219,6 @@ export function EditableDraggableNumber({
   useEffect(() => {
     if (!showBoundsPopover) return;
 
-    setPopoverPlacement((current) => ({ ...current, visibility: 'hidden' }));
     const rafId = window.requestAnimationFrame(updatePopoverPlacement);
 
     const handleViewportChange = () => {

--- a/src/components/dock/DockSplitPane.tsx
+++ b/src/components/dock/DockSplitPane.tsx
@@ -49,7 +49,6 @@ export function DockSplitPane({ split }: DockSplitPaneProps) {
     if (isResizing) return;
     liveRatioRef.current = split.ratio;
     pendingLiveRatioRef.current = null;
-    setLiveRatio(split.ratio);
   }, [isResizing, split.ratio]);
 
   useEffect(() => {

--- a/src/components/timeline/hooks/useTimelineSpectrogramTileSet.ts
+++ b/src/components/timeline/hooks/useTimelineSpectrogramTileSet.ts
@@ -40,8 +40,6 @@ export function useTimelineSpectrogramTileSetState(
   useEffect(() => {
     let cancelled = false;
 
-    setLoaded(createInitialState(refId));
-
     if (!refId || cached) {
       return () => {
         cancelled = true;

--- a/src/components/timeline/hooks/useTimelineWaveformPyramid.ts
+++ b/src/components/timeline/hooks/useTimelineWaveformPyramid.ts
@@ -40,8 +40,6 @@ export function useTimelineWaveformPyramidState(
   useEffect(() => {
     let cancelled = false;
 
-    setLoaded(createInitialState(refId));
-
     if (!refId || cached) {
       return () => {
         cancelled = true;

--- a/src/components/timeline/tools/TimelineToolFlyout.tsx
+++ b/src/components/timeline/tools/TimelineToolFlyout.tsx
@@ -94,7 +94,9 @@ export function TimelineToolFlyout({
   useEffect(() => {
     if (!initialHighlightedToolId) return;
     const index = tools.findIndex((tool) => tool.id === initialHighlightedToolId);
-    if (index >= 0) setHighlightedIndex(index);
+    if (index < 0) return;
+    const rafId = window.requestAnimationFrame(() => setHighlightedIndex(index));
+    return () => window.cancelAnimationFrame(rafId);
   }, [initialHighlightedToolId, tools]);
 
   useEffect(() => {

--- a/src/components/timeline/tools/TimelineToolPalette.tsx
+++ b/src/components/timeline/tools/TimelineToolPalette.tsx
@@ -58,7 +58,7 @@ function isPlacementCommandToolId(toolId: TimelineToolId): toolId is TimelinePla
 }
 
 export function TimelineToolPalette() {
-  const ownerIdRef = useRef(createToolFlyoutOwnerId());
+  const [ownerId] = useState(createToolFlyoutOwnerId);
   const {
     activeTimelineToolId,
     lastTimelineToolByGroup,
@@ -98,7 +98,7 @@ export function TimelineToolPalette() {
   const toolButtonRefs = useRef(new Map<TimelineToolGroupId, HTMLButtonElement>());
   const shortcutRegistry = getShortcutRegistry();
   const hasPlacementSource = hasCurrentTimelinePlacementSource();
-  const ownsFlyout = flyoutOwnerId === ownerIdRef.current;
+  const ownsFlyout = flyoutOwnerId === ownerId;
 
   const openGroup = openTimelineToolGroupId
     ? TIMELINE_TOOL_GROUPS.find((group) => group.id === openTimelineToolGroupId) ?? null
@@ -117,21 +117,21 @@ export function TimelineToolPalette() {
   );
 
   const closeFlyout = useCallback(() => {
-    if (getToolFlyoutOwner() === ownerIdRef.current) {
+    if (getToolFlyoutOwner() === ownerId) {
       setToolFlyoutOwner(null);
     }
     setOpenTimelineToolGroup(null);
     setFlyoutAnchorRect(null);
     setGuidedHighlightedToolId(null);
     clearTimelinePlacementCommandPreview();
-  }, [setOpenTimelineToolGroup]);
+  }, [ownerId, setOpenTimelineToolGroup]);
 
   const openFlyout = useCallback((groupId: TimelineToolGroupId, anchor: HTMLButtonElement, highlightedToolId?: TimelineToolId | null) => {
-    setToolFlyoutOwner(ownerIdRef.current);
+    setToolFlyoutOwner(ownerId);
     setFlyoutAnchorRect(anchor.getBoundingClientRect());
     setGuidedHighlightedToolId(highlightedToolId ?? null);
     setOpenTimelineToolGroup(groupId);
-  }, [setOpenTimelineToolGroup]);
+  }, [ownerId, setOpenTimelineToolGroup]);
 
   const registerToolButton = useCallback((groupId: TimelineToolGroupId, button: HTMLButtonElement | null) => {
     if (button) {
@@ -144,9 +144,9 @@ export function TimelineToolPalette() {
   useEffect(() => {
     const handleFlyoutOwnerChange = (event: Event) => {
       const detail = (event as CustomEvent<{ ownerId?: string | null }>).detail;
-      const ownerId = detail?.ownerId ?? null;
-      setFlyoutOwnerId(ownerId);
-      if (ownerId !== ownerIdRef.current) {
+      const nextOwnerId = detail?.ownerId ?? null;
+      setFlyoutOwnerId(nextOwnerId);
+      if (nextOwnerId !== ownerId) {
         setFlyoutAnchorRect(null);
         setGuidedHighlightedToolId(null);
         clearTimelinePlacementCommandPreview();
@@ -156,11 +156,11 @@ export function TimelineToolPalette() {
     window.addEventListener(TOOL_FLYOUT_OWNER_EVENT, handleFlyoutOwnerChange);
     return () => {
       window.removeEventListener(TOOL_FLYOUT_OWNER_EVENT, handleFlyoutOwnerChange);
-      if (getToolFlyoutOwner() === ownerIdRef.current) {
+      if (getToolFlyoutOwner() === ownerId) {
         setToolFlyoutOwner(null);
       }
     };
-  }, []);
+  }, [ownerId]);
 
   useEffect(() => {
     const handleGuidedOpenToolGroup = (event: Event) => {

--- a/src/importers/hash.ts
+++ b/src/importers/hash.ts
@@ -1,14 +1,29 @@
-import { uint8ArrayToArrayBuffer } from './fileIdentity';
-
 export function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
-export async function sha256ArrayBuffer(buffer: ArrayBuffer): Promise<string> {
-  const digest = await globalThis.crypto.subtle.digest('SHA-256', buffer);
+type Sha256Input = ArrayBuffer | ArrayBufferView;
+type CryptoDigestBytes = Uint8Array<ArrayBuffer>;
+
+function copyCryptoDigestBytes(source: Uint8Array): CryptoDigestBytes {
+  const copy = new Uint8Array(source.byteLength);
+  copy.set(source);
+  return copy;
+}
+
+function toCryptoDigestBytes(input: Sha256Input): CryptoDigestBytes {
+  const source = ArrayBuffer.isView(input)
+    ? new Uint8Array(input.buffer, input.byteOffset, input.byteLength)
+    : new Uint8Array(input);
+
+  return copyCryptoDigestBytes(source);
+}
+
+export async function sha256ArrayBuffer(buffer: Sha256Input): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', toCryptoDigestBytes(buffer));
   return `sha256:${bytesToHex(new Uint8Array(digest))}`;
 }
 
 export async function sha256Utf8(value: string): Promise<string> {
-  return sha256ArrayBuffer(uint8ArrayToArrayBuffer(new TextEncoder().encode(value)));
+  return sha256ArrayBuffer(new TextEncoder().encode(value));
 }

--- a/src/services/audio/runtimeAudioMeterHooks.ts
+++ b/src/services/audio/runtimeAudioMeterHooks.ts
@@ -178,7 +178,10 @@ export function useRuntimeAudioMeterSnapshot(
 
   useEffect(() => {
     if (!kind) {
-      setSnapshot(undefined);
+      if (frameRef.current !== null && typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
       latestRef.current = undefined;
       return undefined;
     }
@@ -230,5 +233,5 @@ export function useRuntimeAudioMeterSnapshot(
     };
   }, [kind, trackId, featuresKey, dynamicsKey, intervalMs]);
 
-  return snapshot;
+  return kind ? snapshot : undefined;
 }

--- a/tests/unit/ClipWaveform.test.tsx
+++ b/tests/unit/ClipWaveform.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from '@testing-library/react';
+import { act, cleanup, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ClipWaveform } from '../../src/components/timeline/components/ClipWaveform';
 import type { TimelineWaveformPyramid } from '../../src/components/timeline/utils/waveformLod';
@@ -98,7 +98,9 @@ describe('ClipWaveform', () => {
 
     const pending = Array.from(scheduledFrames.values());
     scheduledFrames.clear();
-    pending.forEach((callback) => callback(0));
+    act(() => {
+      pending.forEach((callback) => callback(0));
+    });
 
     expect(getContextSpy).toHaveBeenCalledTimes(1);
   });
@@ -145,7 +147,9 @@ describe('ClipWaveform', () => {
 
     const pending = Array.from(scheduledFrames.values());
     scheduledFrames.clear();
-    pending.forEach((callback) => callback(0));
+    act(() => {
+      pending.forEach((callback) => callback(0));
+    });
 
     expect(canvasContext.translate).toHaveBeenCalledWith(0, 0);
     expect(canvasContext.translate).toHaveBeenCalledWith(0, 41);


### PR DESCRIPTION
Removes the remaining React compiler lint warnings and wraps ClipWaveform animation-frame test callbacks in act().\n\nLocal checks:\n- npm run lint\n- npm run build\n- npm run test