### PR TITLE
Release 2.0.9: editing batch (#207 #206 #205 #204 #203 #201 #200 #199 #198)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "masterselects",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "masterselects",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "dependencies": {
         "@ffmpeg/core": "^0.12.6",
         "@ffmpeg/ffmpeg": "^0.12.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "masterselects",
   "private": true,
-  "version": "2.0.8",
+  "version": "2.0.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/dev-full.mjs
+++ b/scripts/dev-full.mjs
@@ -173,12 +173,12 @@ function registerChild(child, onSuccess) {
   });
 }
 
-function spawnNodeProcess(args, onSuccess) {
+function spawnNodeProcess(args, onSuccess, envOverrides) {
   const child = spawn(nodeExePath, args, {
     cwd: repoRoot,
     shell: false,
     stdio: 'inherit',
-    env: childEnv,
+    env: envOverrides ? { ...childEnv, ...envOverrides } : childEnv,
   });
 
   registerChild(child, onSuccess);
@@ -218,6 +218,10 @@ function startApi() {
         '.wrangler/state',
       ]);
     },
+    // Run the migration non-interactively. vite is spawned with the same
+    // inherited stdin, so an interactive Y/n prompt here can never be
+    // confirmed (vite steals the keypress). CI=true makes wrangler auto-apply.
+    { CI: 'true' },
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import type { CampaignStep } from './components/common/tutorialCampaigns';
 import { MobileApp } from './components/mobile';
 import { useTheme } from './hooks/useTheme';
 import { useGlobalSelectWheel } from './hooks/useGlobalSelectWheel';
+import { useBackNavigationGuard } from './hooks/useBackNavigationGuard';
 import { useGlobalHistory } from './hooks/useGlobalHistory';
 import { useClipPanelSync } from './hooks/useClipPanelSync';
 import { useIsMobile, useForceMobile } from './hooks/useIsMobile';
@@ -71,6 +72,9 @@ function App() {
 
   // Scroll the mouse wheel over any native <select> to change its value instantly (#174)
   useGlobalSelectWheel();
+
+  // Trap browser back/swipe so it never leaves the app (#200)
+  useBackNavigationGuard();
 
   // Initialize global undo/redo system
   const { historyNotice, clearHistoryNotice } = useGlobalHistory();

--- a/src/changelog-data.json
+++ b/src/changelog-data.json
@@ -2,6 +2,13 @@
   {
     "date": "2026-05-31",
     "type": "improve",
+    "title": "MasterSelects 2.0.9",
+    "description": "Editing batch: text-clip editing is now part of the layer-edit mode — enter edit mode to move/scale a text layer, double-click to type, with normal resize handles and Ctrl for free corners (no more Shift to align). Edit-mode clicks now select the topmost video, arrow keys nudge the selected clip (Alt = larger, Ctrl = finer, zoom-aware), and you can left-drag a grip on track headers to reorder video layers (z-order) and audio/MIDI tracks. Also: Delete removes selected media-panel items, the source player replays audio files, the slot/grid view scrubs video previews on hover, the panel \"Change to\" menu scrolls, newly created text fills the composition, and browser back no longer leaves the app.",
+    "section": "Release"
+  },
+  {
+    "date": "2026-05-31",
+    "type": "improve",
     "title": "MasterSelects 2.0.8",
     "description": "UI polish batch: drag & drop several files at once into the media panel or straight onto the timeline (both now share the same import path), copy/paste/duplicate media items via right-click or Ctrl+C/V/D with floating action feedback, add panels from a new \"+\" button on every tab bar, scroll the mouse wheel over any dropdown to change its value instantly, the layer-edit backdrop now follows the active color scheme, and the media board's background grid stays visible while zooming with a subtle parallax instead of disappearing.",
     "section": "Release"

--- a/src/components/dock/DockTabPane.tsx
+++ b/src/components/dock/DockTabPane.tsx
@@ -480,17 +480,22 @@ export function DockTabPane({ group }: DockTabPaneProps) {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') setAddMenu(null);
     };
-    const handleWindowChange = () => setAddMenu(null);
+    // Close on outside scroll, but allow scrolling inside the menu itself (#198).
+    const handleScroll = (event: Event) => {
+      if (addMenuRef.current?.contains(event.target as Node)) return;
+      setAddMenu(null);
+    };
+    const handleResize = () => setAddMenu(null);
 
     window.addEventListener('pointerdown', handlePointerDown);
     window.addEventListener('keydown', handleKeyDown);
-    window.addEventListener('resize', handleWindowChange);
-    window.addEventListener('scroll', handleWindowChange, true);
+    window.addEventListener('resize', handleResize);
+    window.addEventListener('scroll', handleScroll, true);
     return () => {
       window.removeEventListener('pointerdown', handlePointerDown);
       window.removeEventListener('keydown', handleKeyDown);
-      window.removeEventListener('resize', handleWindowChange);
-      window.removeEventListener('scroll', handleWindowChange, true);
+      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('scroll', handleScroll, true);
     };
   }, [addMenu]);
 
@@ -506,17 +511,22 @@ export function DockTabPane({ group }: DockTabPaneProps) {
         setTabContextMenu(null);
       }
     };
-    const handleWindowChange = () => setTabContextMenu(null);
+    // Close on outside scroll, but allow scrolling inside the "Change to" submenu (#198).
+    const handleScroll = (event: Event) => {
+      if (contextMenuRef.current?.contains(event.target as Node)) return;
+      setTabContextMenu(null);
+    };
+    const handleResize = () => setTabContextMenu(null);
 
     window.addEventListener('pointerdown', handlePointerDown);
     window.addEventListener('keydown', handleKeyDown);
-    window.addEventListener('resize', handleWindowChange);
-    window.addEventListener('scroll', handleWindowChange, true);
+    window.addEventListener('resize', handleResize);
+    window.addEventListener('scroll', handleScroll, true);
     return () => {
       window.removeEventListener('pointerdown', handlePointerDown);
       window.removeEventListener('keydown', handleKeyDown);
-      window.removeEventListener('resize', handleWindowChange);
-      window.removeEventListener('scroll', handleWindowChange, true);
+      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('scroll', handleScroll, true);
     };
   }, [tabContextMenu]);
 

--- a/src/components/panels/MediaPanel.css
+++ b/src/components/panels/MediaPanel.css
@@ -689,6 +689,28 @@
   object-fit: cover;
 }
 
+/* Hover video preview in grid/slot view (#201) */
+.media-grid-video-thumb {
+  position: absolute;
+  inset: 0;
+}
+
+.media-grid-video-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.media-grid-video-preview {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background: var(--bg-secondary);
+  pointer-events: none;
+}
+
 .media-grid-thumb-placeholder {
   position: absolute;
   inset: 0;

--- a/src/components/panels/MediaPanel.tsx
+++ b/src/components/panels/MediaPanel.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 import './MediaPanel.css';
 import { Logger } from '../../services/logger';
 import { FileTypeIcon } from './media/FileTypeIcon';
+import { MediaGridVideoThumb } from './media/MediaGridVideoThumb';
 import { LABEL_COLORS, getLabelHex } from './media/labelColors';
 import { CompositionSettingsDialog } from './media/CompositionSettingsDialog';
 import { SolidSettingsDialog } from './media/SolidSettingsDialog';
@@ -2121,13 +2122,24 @@ export function MediaPanel() {
   const mediaPanelRootRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (!(e.ctrlKey || e.metaKey) || e.altKey || e.shiftKey) return;
+      if (e.altKey) return;
       const root = mediaPanelRootRef.current;
       if (!root || !root.matches(':hover')) return;
       const active = document.activeElement as HTMLElement | null;
       if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) {
-        return; // let the browser handle text copy/paste while editing
+        return; // let the browser handle text editing / copy-paste while typing
       }
+
+      // Delete / Backspace removes the highlighted media items (#207).
+      if ((e.key === 'Delete' || e.key === 'Backspace') && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
+        if (selectedIds.length === 0) return;
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        void handleDelete();
+        return;
+      }
+
+      if (!(e.ctrlKey || e.metaKey) || e.shiftKey) return;
       const key = e.key.toLowerCase();
       if (key === 'c') {
         if (selectedIds.length === 0) return;
@@ -2151,7 +2163,7 @@ export function MediaPanel() {
     };
     document.addEventListener('keydown', handleKeyDown, { capture: true });
     return () => document.removeEventListener('keydown', handleKeyDown, { capture: true });
-  }, [selectedIds, copyMediaItems, pasteMediaItems, duplicateMediaItems, hasMediaClipboard, getActiveParentId, showFloatingText]);
+  }, [selectedIds, copyMediaItems, pasteMediaItems, duplicateMediaItems, hasMediaClipboard, getActiveParentId, showFloatingText, handleDelete]);
 
   // New composition
   const handleNewComposition = useCallback(() => {
@@ -2926,7 +2938,13 @@ export function MediaPanel() {
           title={buildGridTooltip(item, isFolder, isComp)}
         >
           <div className="media-grid-thumb">
-            {thumbUrl ? (
+            {mediaFile?.type === 'video' ? (
+              <MediaGridVideoThumb
+                mediaFile={mediaFile}
+                thumbUrl={thumbUrl}
+                onError={() => { void refreshFileUrls(mediaFile.id); }}
+              />
+            ) : thumbUrl ? (
               <img
                 src={thumbUrl}
                 alt=""

--- a/src/components/panels/media/MediaAIGenerationQueue.tsx
+++ b/src/components/panels/media/MediaAIGenerationQueue.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type MouseEvent } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type MouseEvent } from 'react';
 import { useFlashBoardStore } from '../../../stores/flashboardStore';
 import { useMediaStore, type MediaFile } from '../../../stores/mediaStore';
 import type { FlashBoardGenerationRequest, FlashBoardNode } from '../../../stores/flashboardStore/types';
@@ -249,13 +249,14 @@ async function animateCardToMediaTarget(source: HTMLElement, mediaFileId: string
   }
 }
 
-export function MediaAIGenerationQueue() {
+function MediaAIGenerationQueueImpl() {
   const boards = useFlashBoardStore((state) => state.boards);
   const removeNode = useFlashBoardStore((state) => state.removeNode);
   const downloadJobs = useMediaDownloadStore((state) => state.jobs);
   const dismissDownloadJob = useMediaDownloadStore((state) => state.dismissJob);
   const retryDownloadJob = useMediaDownloadStore((state) => state.retryJob);
   const mediaFiles = useMediaStore((state) => state.files);
+  const mediaFilesById = useMemo(() => new Map(mediaFiles.map((file) => [file.id, file])), [mediaFiles]);
   const [now, setNow] = useState(() => Date.now());
   const [flyingItemIds, setFlyingItemIds] = useState<Set<string>>(() => new Set());
   const flyingItemIdsRef = useRef<Set<string>>(new Set());
@@ -346,7 +347,7 @@ export function MediaAIGenerationQueue() {
           : null;
         const mediaFileId = isDownload ? job!.mediaFileId : node!.result?.mediaFileId;
         const generatedMedia = mediaFileId
-          ? mediaFiles.find((file) => file.id === mediaFileId)
+          ? mediaFilesById.get(mediaFileId)
           : undefined;
         const previewUrl = isDownload
           ? (job!.thumbnail || getGeneratedPreviewUrl(generatedMedia))
@@ -498,3 +499,7 @@ export function MediaAIGenerationQueue() {
     </div>
   );
 }
+
+// Memoized: the queue subscribes to its own stores, so it shouldn't re-render
+// just because the (heavy) expanded tray parent re-renders (#199).
+export const MediaAIGenerationQueue = memo(MediaAIGenerationQueueImpl);

--- a/src/components/panels/media/MediaAIGenerativeTray.tsx
+++ b/src/components/panels/media/MediaAIGenerativeTray.tsx
@@ -1,9 +1,12 @@
-import { lazy, Suspense, useCallback, useState, type SyntheticEvent } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useState, type SyntheticEvent } from 'react';
 import { useFlashBoardRuntime } from '../flashboard/useFlashBoardRuntime';
 import './MediaAIGenerativeTray.css';
 
+// Shared factory so we can both lazy-render and prefetch the (heavy) expanded
+// tray chunk. Module imports are cached, so calling this repeatedly is cheap.
+const importExpandedTray = () => import('./MediaAIGenerativeTrayExpanded');
 const MediaAIGenerativeTrayExpanded = lazy(() =>
-  import('./MediaAIGenerativeTrayExpanded').then((m) => ({ default: m.MediaAIGenerativeTrayExpanded }))
+  importExpandedTray().then((m) => ({ default: m.MediaAIGenerativeTrayExpanded }))
 );
 
 type MediaAITrayMode = 'generate' | 'chat' | 'download';
@@ -24,6 +27,28 @@ export function MediaAIGenerativeTray({
     event.stopPropagation();
   }, []);
 
+  // Warm the heavy expanded chunk while collapsed (on idle), and on button
+  // hover, so the first expand doesn't pay the parse cost on the click (#199).
+  const prefetchExpanded = useCallback(() => {
+    void importExpandedTray();
+  }, []);
+
+  useEffect(() => {
+    if (expanded) return undefined;
+    let cancelled = false;
+    const warm = () => { if (!cancelled) prefetchExpanded(); };
+    const win = window as Window & {
+      requestIdleCallback?: (cb: () => void) => number;
+      cancelIdleCallback?: (id: number) => void;
+    };
+    if (typeof win.requestIdleCallback === 'function') {
+      const id = win.requestIdleCallback(warm);
+      return () => { cancelled = true; win.cancelIdleCallback?.(id); };
+    }
+    const id = window.setTimeout(warm, 200);
+    return () => { cancelled = true; window.clearTimeout(id); };
+  }, [expanded, prefetchExpanded]);
+
   const openTray = useCallback((mode: MediaAITrayMode) => {
     setTrayMode(mode);
     onExpandedChange(true);
@@ -37,6 +62,7 @@ export function MediaAIGenerativeTray({
             className="media-ai-tray-launch media-ai-tray-launch-chat"
             type="button"
             onClick={() => openTray('chat')}
+            onMouseEnter={prefetchExpanded}
             title="Open AI chat"
           >
             <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden="true">
@@ -49,6 +75,7 @@ export function MediaAIGenerativeTray({
             className="media-ai-tray-launch"
             type="button"
             onClick={() => openTray('generate')}
+            onMouseEnter={prefetchExpanded}
             title="Expand AI prompt"
           >
             <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden="true">
@@ -61,6 +88,7 @@ export function MediaAIGenerativeTray({
             className="media-ai-tray-launch media-ai-tray-launch-download"
             type="button"
             onClick={() => openTray('download')}
+            onMouseEnter={prefetchExpanded}
             title="Open downloads"
           >
             <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.7" aria-hidden="true">

--- a/src/components/panels/media/MediaGridVideoThumb.tsx
+++ b/src/components/panels/media/MediaGridVideoThumb.tsx
@@ -1,0 +1,81 @@
+import React, { useCallback, useRef, useState } from 'react';
+import type { MediaFile } from '../../../stores/mediaStore';
+import { FileTypeIcon } from './FileTypeIcon';
+
+interface MediaGridVideoThumbProps {
+  mediaFile: MediaFile;
+  thumbUrl?: string;
+  onError?: () => void;
+}
+
+/**
+ * Video thumbnail for the media-panel grid/slot view that scrubs a preview on
+ * hover, like the board view (#201). Moving the pointer across the thumb seeks
+ * the video; leaving restores the poster frame.
+ */
+export function MediaGridVideoThumb({ mediaFile, thumbUrl, onError }: MediaGridVideoThumbProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const [hovering, setHovering] = useState(false);
+  const videoUrl = mediaFile.proxyVideoUrl || mediaFile.url;
+
+  const scrubTo = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    const video = videoRef.current;
+    if (!video) return;
+    const duration = video.duration;
+    if (!Number.isFinite(duration) || duration <= 0) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const ratio = rect.width > 0
+      ? Math.min(1, Math.max(0, (event.clientX - rect.left) / rect.width))
+      : 0;
+    try {
+      video.currentTime = Math.min(duration - 0.05, duration * ratio);
+    } catch {
+      /* seeking can throw before metadata is ready */
+    }
+  }, []);
+
+  const handleEnter = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    setHovering(true);
+    scrubTo(event);
+  }, [scrubTo]);
+
+  const handleMove = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (hovering) scrubTo(event);
+  }, [hovering, scrubTo]);
+
+  const handleLeave = useCallback(() => {
+    setHovering(false);
+    videoRef.current?.pause();
+  }, []);
+
+  return (
+    <div
+      className="media-grid-video-thumb"
+      onMouseEnter={handleEnter}
+      onMouseMove={handleMove}
+      onMouseLeave={handleLeave}
+    >
+      {thumbUrl ? (
+        <img src={thumbUrl} alt="" draggable={false} onError={onError} />
+      ) : (
+        <div className="media-grid-thumb-placeholder">
+          <FileTypeIcon type="video" large />
+        </div>
+      )}
+      {hovering && (
+        <video
+          ref={videoRef}
+          className="media-grid-video-preview"
+          src={videoUrl}
+          poster={thumbUrl}
+          muted
+          playsInline
+          loop
+          preload="auto"
+          draggable={false}
+          onError={onError}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -771,6 +771,10 @@ export function Preview({ panelId, source, showTransparencyGrid }: PreviewProps)
 
   // Edit mode state
   const [editMode, setEditMode] = useState(false);
+  // #206: while editing a text clip inside the layer-edit mode, this toggles
+  // between layer transform (move/scale handles) and text typing. Double-click
+  // enters typing; Escape returns to transform.
+  const [textTyping, setTextTyping] = useState(false);
   const [editCameraViewMode, setEditCameraViewMode] = useState<EditCameraViewMode>('camera');
   const [editCameraOrthoFrame, setEditCameraOrthoFrame] = useState<EditCameraOrthoFrame | null>(null);
   const [isEditCameraOrthoPanning, setIsEditCameraOrthoPanning] = useState(false);
@@ -933,7 +937,10 @@ export function Preview({ panelId, source, showTransparencyGrid }: PreviewProps)
   const maskTabActive = isEditableSource && maskPanelActive;
   const maskNavigationMode = layerEditMode && maskTabActive;
   const textClipEditMode = Boolean(layerEditMode && !maskTabActive && selectedClip?.textProperties && selectedTextLayer);
-  const layerTransformMode = layerEditMode && !maskNavigationMode && !textClipEditMode;
+  // #206: a text clip lives inside the layer-edit mode. Show the layer move/scale
+  // handles unless the user is actively typing (entered via double-click).
+  const textTypingActive = textClipEditMode && textTyping;
+  const layerTransformMode = layerEditMode && !maskNavigationMode && (!textClipEditMode || !textTypingActive);
   const freeCanvasNavigationMode = layerTransformMode || maskNavigationMode || textClipEditMode;
   const effectiveSceneNavFpsMode = sceneNavFpsMode && !editCameraModeActive;
   const editCameraClipSelected = Boolean(
@@ -2455,6 +2462,7 @@ export function Preview({ panelId, source, showTransparencyGrid }: PreviewProps)
     !sourceMonitorActive &&
     !isPlaying &&
     textClipEditMode &&
+    textTypingActive &&
     !sceneNavEnabled &&
     selectedClip?.textProperties &&
     selectedTextLayer,
@@ -2478,6 +2486,25 @@ export function Preview({ panelId, source, showTransparencyGrid }: PreviewProps)
   const playbackWaiterDetail = playbackWaiterVideoCount > 0
     ? `${playbackWaiterVideoCount} video${playbackWaiterVideoCount === 1 ? '' : 's'}`
     : '';
+
+  // #206: leave text typing when the selection changes or edit mode is exited.
+  useEffect(() => {
+    setTextTyping(false);
+  }, [selectedClipId, editMode]);
+
+  // #206: Escape returns from text typing to the layer transform handles.
+  useEffect(() => {
+    if (!textTyping) return undefined;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        event.stopPropagation();
+        setTextTyping(false);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => window.removeEventListener('keydown', handleKeyDown, true);
+  }, [textTyping]);
 
   return (
     <div
@@ -2671,6 +2698,23 @@ export function Preview({ panelId, source, showTransparencyGrid }: PreviewProps)
           </div>
         )}
 
+        {/* #206: grey pasteboard backdrop behind the text editor so typing mode
+            matches the layer/video edit look (grey surround, comp cut out). */}
+        {textPreviewEditorEnabled && isEngineReady && (
+          <div
+            className="preview-text-edit-backdrop"
+            style={{
+              position: 'absolute',
+              left: canvasInContainer.x,
+              top: canvasInContainer.y,
+              width: canvasInContainer.width,
+              height: canvasInContainer.height,
+              boxShadow: '0 0 0 9999px var(--preview-pasteboard-bg)',
+              pointerEvents: 'none',
+            }}
+          />
+        )}
+
         {textPreviewEditorEnabled && selectedClip?.textProperties && selectedTextLayer && (
           <TextPreviewEditor
             clip={selectedClip}
@@ -2721,6 +2765,7 @@ export function Preview({ panelId, source, showTransparencyGrid }: PreviewProps)
             onMouseMove={handleOverlayMouseMove}
             onMouseUp={handleOverlayMouseUp}
             onMouseLeave={handleOverlayMouseUp}
+            onDoubleClick={textClipEditMode ? () => setTextTyping(true) : undefined}
             style={{
               position: 'absolute',
               top: 0,
@@ -2735,14 +2780,19 @@ export function Preview({ panelId, source, showTransparencyGrid }: PreviewProps)
           />
         )}
 
-        {layerTransformMode && isEditableSource && (
+        {layerTransformMode && !textClipEditMode && isEditableSource && (
           <div className="preview-edit-hint">
             Drag: Move | Handles: Scale (Shift: Lock Ratio) | Scroll: Zoom | Alt+Drag: Pan
           </div>
         )}
-        {textClipEditMode && isEditableSource && (
+        {textClipEditMode && !textTypingActive && isEditableSource && (
           <div className="preview-edit-hint">
-            Text Edit: Type in bounds | Drag edges: Area | Shift+Drag edge: Rectify | Double-click edge: Straighten | Ctrl+Drag: Move
+            Text Layer: Drag Move | Handles Scale | Double-click: Edit text
+          </div>
+        )}
+        {textTypingActive && isEditableSource && (
+          <div className="preview-edit-hint">
+            Text Edit: Type in bounds | Drag handles: Resize | Ctrl+Drag handle: Free corner | Double-click edge: Straighten | Esc: Done
           </div>
         )}
         {maskNavigationMode && isEditableSource && (

--- a/src/components/preview/SourceMonitor.tsx
+++ b/src/components/preview/SourceMonitor.tsx
@@ -420,14 +420,29 @@ export function SourceMonitor({ file, autoplayRequestId = 0, onClose }: SourceMo
     if (!media) return;
     const playbackStart = inPoint ?? 0;
     const playbackEnd = outPoint ?? timelineDuration;
-    if (
+    const needsRewind =
       media.ended ||
       media.currentTime >= playbackEnd - MIN_MARK_GAP_SECONDS ||
-      media.currentTime < playbackStart - MIN_MARK_GAP_SECONDS
-    ) {
-      media.currentTime = clampTime(playbackStart, timelineDuration);
+      media.currentTime < playbackStart - MIN_MARK_GAP_SECONDS;
+    if (needsRewind) {
+      // Rewind to the marked start. An *ended* <audio> element must be reset
+      // before play() or it stays ended and play() is a no-op — which is why
+      // audio only played once (Stop+Play worked because Stop reset it). (#203)
+      const start = clampTime(playbackStart, timelineDuration);
+      media.currentTime = start;
+      currentTimeRef.current = start;
+      setCurrentTime(start);
     }
-    void media.play();
+    void media.play().catch(() => {
+      // Last resort if the element refuses to restart: reload and retry once.
+      try {
+        media.load();
+        media.currentTime = clampTime(playbackStart, timelineDuration);
+        void media.play();
+      } catch {
+        /* ignore */
+      }
+    });
   }, [inPoint, isPlayable, outPoint, timelineDuration]);
 
   const pauseSource = useCallback(() => {

--- a/src/components/preview/TextPreviewEditor.tsx
+++ b/src/components/preview/TextPreviewEditor.tsx
@@ -376,6 +376,19 @@ export function TextPreviewEditor({
     ));
   }, []);
 
+  // Update the selection highlight live while dragging (the textarea's onSelect
+  // doesn't fire reliably mid-drag). `selectionchange` fires continuously.
+  useEffect(() => {
+    if (!isEditing) return undefined;
+    const handleSelectionChange = () => {
+      if (document.activeElement === textareaRef.current) {
+        syncTextSelection();
+      }
+    };
+    document.addEventListener('selectionchange', handleSelectionChange);
+    return () => document.removeEventListener('selectionchange', handleSelectionChange);
+  }, [isEditing, syncTextSelection]);
+
   const focusEditor = useCallback((selectAll = false) => {
     selectAllOnFocusRef.current = selectAll;
     setIsEditing(true);
@@ -440,7 +453,7 @@ export function TextPreviewEditor({
     setPropertyValue(clip.id, createTextBoundsNumericProperty('position.y'), nextY);
   }, [clip.id, geometry, setPropertyValue, sourcePointFromContainer]);
 
-  const applyVertexDrag = useCallback((drag: DragState, point: OverlayPoint, recordKeyframe: boolean) => {
+  const applyVertexDrag = useCallback((drag: DragState, point: OverlayPoint, recordKeyframe: boolean, freeMove = false) => {
     if (!geometry || !drag.vertexId) return;
     const startVertex = drag.startBounds.vertices.find(vertex => vertex.id === drag.vertexId);
     if (!startVertex) return;
@@ -449,11 +462,43 @@ export function TextPreviewEditor({
     if (!startPoint || !sourcePoint) return;
     const dx = (sourcePoint.x - startPoint.x) / geometry.sourceWidth;
     const dy = (sourcePoint.y - startPoint.y) / geometry.sourceHeight;
+
+    const startVertices = drag.startBounds.vertices;
+    // Default: corner handles resize the box rectangularly (normal handles).
+    // Hold Ctrl (freeMove) to drag a single vertex freely for skew/perspective. (#205)
+    if (!freeMove && startVertices.length === 4) {
+      const minX = Math.min(...startVertices.map(v => v.x));
+      const maxX = Math.max(...startVertices.map(v => v.x));
+      const minY = Math.min(...startVertices.map(v => v.y));
+      const maxY = Math.max(...startVertices.map(v => v.y));
+      const centerX = (minX + maxX) / 2;
+      const centerY = (minY + maxY) / 2;
+      const draggedLeft = startVertex.x <= centerX;
+      const draggedTop = startVertex.y <= centerY;
+      const newX = startVertex.x + dx;
+      const newY = startVertex.y + dy;
+      const resetHandles = {
+        handleIn: { x: 0, y: 0 },
+        handleOut: { x: 0, y: 0 },
+        handleMode: 'none' as const,
+      };
+      const vertexUpdates = startVertices.map((vertex) => ({
+        vertexId: vertex.id,
+        updates: {
+          ...resetHandles,
+          x: (vertex.x <= centerX) === draggedLeft ? newX : vertex.x,
+          y: (vertex.y <= centerY) === draggedTop ? newY : vertex.y,
+        },
+      }));
+      updateTextBoundsVertices(clip.id, vertexUpdates, recordKeyframe);
+      return;
+    }
+
     updateTextBoundsVertex(clip.id, drag.vertexId, {
       x: startVertex.x + dx,
       y: startVertex.y + dy,
     }, recordKeyframe);
-  }, [clip.id, geometry, sourcePointFromContainer, updateTextBoundsVertex]);
+  }, [clip.id, geometry, sourcePointFromContainer, updateTextBoundsVertex, updateTextBoundsVertices]);
 
   const applyEdgeDrag = useCallback((
     drag: DragState,
@@ -580,7 +625,7 @@ export function TextPreviewEditor({
     ], true);
   }, [clip.id, geometry, updateTextBoundsVertices]);
 
-  const finishDrag = useCallback((target: HTMLElement, pointerId: number, finalPoint?: OverlayPoint, snapEdge = false) => {
+  const finishDrag = useCallback((target: HTMLElement, pointerId: number, finalPoint?: OverlayPoint, freeMove = false) => {
     const drag = dragStateRef.current;
     dragStateRef.current = null;
     setDragSelection(null);
@@ -600,12 +645,12 @@ export function TextPreviewEditor({
     }
 
     if (drag.kind === 'vertex') {
-      applyVertexDrag(drag, current, true);
+      applyVertexDrag(drag, current, true, freeMove);
       return;
     }
 
     if (drag.kind === 'edge') {
-      applyEdgeDrag(drag, current, true, snapEdge);
+      applyEdgeDrag(drag, current, true, !freeMove);
       return;
     }
 
@@ -705,10 +750,8 @@ export function TextPreviewEditor({
   }, [beginDrag, focusEditor]);
 
   const handleVertexPointerDown = useCallback((event: ReactPointerEvent<SVGRectElement>, vertexId: string) => {
-    if (shouldMoveWholeText(event)) {
-      beginDrag(event, 'move');
-      return;
-    }
+    // Ctrl on a handle = free vertex movement (handled during the drag), not
+    // move-whole-text — so corner handles stay usable with Ctrl. (#205)
     beginDrag(event, 'vertex', vertexId);
   }, [beginDrag]);
 
@@ -717,10 +760,6 @@ export function TextPreviewEditor({
     fromVertexId: string,
     toVertexId: string,
   ) => {
-    if (shouldMoveWholeText(event)) {
-      beginDrag(event, 'move');
-      return;
-    }
     beginDrag(event, 'edge', undefined, [fromVertexId, toVertexId]);
   }, [beginDrag]);
 
@@ -748,9 +787,11 @@ export function TextPreviewEditor({
     } else if (drag.kind === 'move') {
       applyMoveDrag(drag, point);
     } else if (drag.kind === 'vertex') {
-      applyVertexDrag(drag, point, true);
+      // Default = rectangular resize; Ctrl = free vertex. (#205)
+      applyVertexDrag(drag, point, true, event.ctrlKey || event.metaKey);
     } else if (drag.kind === 'edge') {
-      applyEdgeDrag(drag, point, true, event.shiftKey);
+      // Default = keep the box rectangular (no Shift needed); Ctrl = free edge. (#205)
+      applyEdgeDrag(drag, point, true, !(event.ctrlKey || event.metaKey));
     }
     event.preventDefault();
     event.stopPropagation();
@@ -763,7 +804,7 @@ export function TextPreviewEditor({
     finishDrag(event.currentTarget, event.pointerId, {
       x: event.clientX - rect.left,
       y: event.clientY - rect.top,
-    }, event.shiftKey);
+    }, event.ctrlKey || event.metaKey);
     event.preventDefault();
     event.stopPropagation();
   }, [finishDrag]);
@@ -988,7 +1029,7 @@ export function TextPreviewEditor({
             onPointerDown={(event) => handleEdgePointerDown(event, edge.fromVertexId, edge.toVertexId)}
             onDoubleClick={(event) => handleEdgeDoubleClick(event, edge.fromVertexId, edge.toVertexId)}
           >
-            <title>Drag edge. Shift-drag to snap straight. Double-click to straighten.</title>
+            <title>Drag edge to resize. Ctrl-drag for free edge. Double-click to straighten.</title>
           </path>
         ))}
         {geometry.edges.map(edge => (
@@ -1002,7 +1043,7 @@ export function TextPreviewEditor({
             onPointerDown={(event) => handleEdgePointerDown(event, edge.fromVertexId, edge.toVertexId)}
             onDoubleClick={(event) => handleEdgeDoubleClick(event, edge.fromVertexId, edge.toVertexId)}
           >
-            <title>Drag edge. Shift-drag to snap straight. Double-click to straighten.</title>
+            <title>Drag edge to resize. Ctrl-drag for free edge. Double-click to straighten.</title>
           </rect>
         ))}
         {geometry.vertices.map(({ vertex, point }) => (

--- a/src/components/preview/useEditModeOverlay.ts
+++ b/src/components/preview/useEditModeOverlay.ts
@@ -70,7 +70,10 @@ export function useEditModeOverlay({
 
   // Find layer at mouse position (container coordinates)
   const findLayerAtPosition = useCallback((containerX: number, containerY: number): Layer | null => {
-    const visibleLayers = layers.filter(l => l?.visible && l?.source).reverse();
+    // layers[0] is composited on top (see LayerBuilderService), so iterate in
+    // array order and return the first hit = the topmost layer under the cursor.
+    // (Previously this reversed the list and picked the bottom layer.)
+    const visibleLayers = layers.filter(l => l?.visible && l?.source);
 
     for (const layer of visibleLayers) {
       if (!layer) continue;

--- a/src/components/preview/useLayerDrag.ts
+++ b/src/components/preview/useLayerDrag.ts
@@ -249,6 +249,59 @@ export function useLayerDrag({
     draw();
   }, [editMode, layers, selectedLayerId, selectedClipId, clips, canvasSize, canvasInContainer, viewZoom, calculateLayerBounds, isDragging, dragMode, dragLayerId, overlayRef]);
 
+  // Arrow keys nudge the selected layer while in edit mode. Step is sized in
+  // screen pixels then converted to canvas space (divided by viewZoom) so the
+  // on-screen movement stays consistent across zoom levels. Alt = bigger steps,
+  // Ctrl/Cmd = finer steps.
+  useEffect(() => {
+    if (!editMode) return undefined;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown' && e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+
+      const selectedLayer = selectedLayerId ? layers.find((l) => l?.id === selectedLayerId) : null;
+      if (!selectedLayer) return;
+
+      // Don't hijack arrows while typing (e.g. text editor).
+      const active = document.activeElement as HTMLElement | null;
+      if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) return;
+
+      // Scope to the preview this overlay belongs to (hovered or focused).
+      const container = overlayRef.current?.closest('.preview-container') as HTMLElement | null;
+      if (!container || !(container.matches(':hover') || container.contains(active))) return;
+
+      const clip = findClipForLayer(clips, selectedLayer);
+      if (isClipOnLockedTrack(clip, tracks)) return;
+
+      e.preventDefault();
+      e.stopImmediatePropagation();
+
+      const screenStep = e.altKey ? 50 : (e.ctrlKey || e.metaKey) ? 2 : 12;
+      const canvasStep = screenStep / Math.max(0.0001, viewZoom);
+      let canvasDx = 0;
+      let canvasDy = 0;
+      if (e.key === 'ArrowLeft') canvasDx = -canvasStep;
+      else if (e.key === 'ArrowRight') canvasDx = canvasStep;
+      else if (e.key === 'ArrowUp') canvasDy = -canvasStep;
+      else if (e.key === 'ArrowDown') canvasDy = canvasStep;
+
+      const pos = selectedLayer.position;
+      const baseBounds = calculateLayerBounds(selectedLayer, canvasSize.width, canvasSize.height, { x: pos.x, y: pos.y });
+      const xPlusBounds = calculateLayerBounds(selectedLayer, canvasSize.width, canvasSize.height, { x: pos.x + 1, y: pos.y });
+      const yPlusBounds = calculateLayerBounds(selectedLayer, canvasSize.width, canvasSize.height, { x: pos.x, y: pos.y + 1 });
+      const delta = resolvePositionDeltaForCanvasDelta(baseBounds, xPlusBounds, yPlusBounds, { x: canvasDx, y: canvasDy });
+
+      const newPosition = { x: pos.x + delta.x, y: pos.y + delta.y, z: pos.z };
+      updateLayer(selectedLayer.id, { position: newPosition });
+      if (clip) {
+        updateClipTransform(clip.id, { position: newPosition });
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => window.removeEventListener('keydown', handleKeyDown, true);
+  }, [editMode, selectedLayerId, layers, clips, tracks, canvasSize, viewZoom, calculateLayerBounds, updateLayer, updateClipTransform, overlayRef]);
+
   // Handle mouse down on overlay
   const handleOverlayMouseDown = useCallback((e: React.MouseEvent) => {
     if (!editMode || !overlayRef.current || e.altKey) return;

--- a/src/components/timeline/TimelineHeader.tsx
+++ b/src/components/timeline/TimelineHeader.tsx
@@ -57,6 +57,7 @@ import {
 import { normalizeAudioEqParams } from '../../engine/audio/eq/AudioEqLegacy';
 import { getAudioEffectParamPathValue } from '../../utils/audioEffectParamPath';
 import { MIDI_INSTRUMENT_OPTIONS, type MidiInstrument } from '../../types/midiClip';
+import { useTrackReorderDrag, trackReorderSection } from './hooks/useTrackReorderDrag';
 
 type KeyframeTrackClip = {
   id: string;
@@ -1325,6 +1326,8 @@ function TimelineHeaderComponent({
   audioLayerAdvancedMode = true,
   showCollapsedAudioSummaryMeter = false,
 }: TimelineHeaderProps) {
+  // Left-drag reorder of this track within its section (#layers/tracks)
+  const { onReorderPointerDown } = useTrackReorderDrag(track);
   // Get the first selected clip in this track
   const trackClips = clips.filter((c) => c.trackId === track.id);
   const selectedTrackClip = trackClips.find((c) => selectedClipIds.has(c.id));
@@ -1512,6 +1515,8 @@ function TimelineHeaderComponent({
       }`}
       style={trackHeaderStyle}
       data-dock-layout-child-anim-id={`timeline-track-header:${track.id}`}
+      data-track-reorder-id={track.id}
+      data-track-reorder-section={trackReorderSection(track)}
       onWheel={onWheel}
       onContextMenu={onContextMenu}
     >
@@ -1520,6 +1525,14 @@ function TimelineHeaderComponent({
         style={{ height: baseHeight, cursor: (track.type === 'video' || isMixerTrack) ? 'pointer' : 'default' }}
         onClick={handleHeaderClick}
       >
+        <div
+          className="track-reorder-handle"
+          title="Drag to reorder"
+          onPointerDown={onReorderPointerDown}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <span className="track-reorder-grip" aria-hidden="true">⋮</span>
+        </div>
         {showAudioSummaryMeter && (
           <AudioLevelMeter
             streamScope={{ kind: 'master' }}

--- a/src/components/timeline/TimelineTracks.css
+++ b/src/components/timeline/TimelineTracks.css
@@ -34,6 +34,64 @@
   z-index: 90;
 }
 
+/* Drag-to-reorder grip + indicators (video layers / audio tracks).
+   Absolutely positioned in the header's left padding gutter so it consumes no
+   flex width (otherwise it squeezes the track name on compact mixer tracks). */
+.track-reorder-handle {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  color: var(--text-muted, #888);
+  opacity: 0;
+  transition: opacity 0.12s ease, color 0.12s ease;
+  touch-action: none;
+  z-index: 2;
+}
+
+.track-header:hover .track-reorder-handle {
+  opacity: 0.5;
+}
+
+.track-reorder-handle:hover {
+  opacity: 1;
+  color: var(--text-primary);
+}
+
+.track-reorder-handle:active {
+  cursor: grabbing;
+}
+
+.track-reorder-grip {
+  font-size: 10px;
+  line-height: 1;
+  letter-spacing: -2px;
+  user-select: none;
+  pointer-events: none;
+}
+
+.track-header.track-reordering {
+  opacity: 0.55;
+}
+
+.track-header.track-reorder-target-before {
+  box-shadow: inset 0 2px 0 0 var(--accent, #2d8ceb);
+}
+
+.track-header.track-reorder-target-after {
+  box-shadow: inset 0 -2px 0 0 var(--accent, #2d8ceb);
+}
+
+body.track-reordering-active {
+  cursor: grabbing;
+  user-select: none;
+}
+
 .track-header.video {
   background:
     linear-gradient(90deg, color-mix(in srgb, var(--track-color, #303030) 24%, transparent), transparent 58%),

--- a/src/components/timeline/hooks/useTrackReorderDrag.ts
+++ b/src/components/timeline/hooks/useTrackReorderDrag.ts
@@ -1,0 +1,102 @@
+import { useCallback, useRef } from 'react';
+import type React from 'react';
+import { useTimelineStore } from '../../../stores/timeline';
+import type { TimelineTrack } from '../../../types';
+
+const REORDER_THRESHOLD_PX = 5;
+
+export function trackReorderSection(track: TimelineTrack): 'video' | 'audio' {
+  return track.type === 'video' ? 'video' : 'audio';
+}
+
+interface ReorderDragState {
+  startY: number;
+  dragging: boolean;
+  sourceEl: HTMLElement | null;
+  targetEl: HTMLElement | null;
+  targetId: string | null;
+  placeBelow: boolean;
+}
+
+const TARGET_CLASSES = ['track-reorder-target-before', 'track-reorder-target-after'];
+
+/**
+ * Left-mouse drag-to-reorder for a timeline track header. Returns a pointer-down
+ * handler to attach to a drag grip. Reordering is constrained to the track's own
+ * section (video among video, audio/midi among audio) by the store action.
+ */
+export function useTrackReorderDrag(track: TimelineTrack) {
+  const reorderTrack = useTimelineStore((state) => state.reorderTrack);
+  const stateRef = useRef<ReorderDragState | null>(null);
+
+  const onReorderPointerDown = useCallback((event: React.PointerEvent<HTMLElement>) => {
+    if (event.button !== 0 || track.locked) return;
+    event.stopPropagation();
+
+    const sourceEl = (event.currentTarget.closest('[data-track-reorder-id]') as HTMLElement) ?? null;
+    const sourceSection = trackReorderSection(track);
+    stateRef.current = {
+      startY: event.clientY,
+      dragging: false,
+      sourceEl,
+      targetEl: null,
+      targetId: null,
+      placeBelow: false,
+    };
+
+    const clearTarget = () => {
+      stateRef.current?.targetEl?.classList.remove(...TARGET_CLASSES);
+      if (stateRef.current) {
+        stateRef.current.targetEl = null;
+        stateRef.current.targetId = null;
+      }
+    };
+
+    const handleMove = (moveEvent: PointerEvent) => {
+      const state = stateRef.current;
+      if (!state) return;
+
+      if (!state.dragging) {
+        if (Math.abs(moveEvent.clientY - state.startY) < REORDER_THRESHOLD_PX) return;
+        state.dragging = true;
+        state.sourceEl?.classList.add('track-reordering');
+        document.body.classList.add('track-reordering-active');
+      }
+
+      const overEl = document.elementFromPoint(moveEvent.clientX, moveEvent.clientY) as HTMLElement | null;
+      const headerEl = (overEl?.closest('[data-track-reorder-id]') as HTMLElement) ?? null;
+      clearTarget();
+      if (!headerEl) return;
+
+      const id = headerEl.getAttribute('data-track-reorder-id');
+      const section = headerEl.getAttribute('data-track-reorder-section');
+      if (!id || id === track.id || section !== sourceSection) return;
+
+      const rect = headerEl.getBoundingClientRect();
+      const placeBelow = moveEvent.clientY > rect.top + rect.height / 2;
+      headerEl.classList.add(placeBelow ? 'track-reorder-target-after' : 'track-reorder-target-before');
+      state.targetEl = headerEl;
+      state.targetId = id;
+      state.placeBelow = placeBelow;
+    };
+
+    const handleUp = () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleUp);
+      const state = stateRef.current;
+      stateRef.current = null;
+      if (!state) return;
+      state.sourceEl?.classList.remove('track-reordering');
+      document.body.classList.remove('track-reordering-active');
+      state.targetEl?.classList.remove(...TARGET_CLASSES);
+      if (state.dragging && state.targetId) {
+        reorderTrack(track.id, state.targetId, state.placeBelow);
+      }
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+  }, [reorderTrack, track]);
+
+  return { onReorderPointerDown };
+}

--- a/src/hooks/useBackNavigationGuard.ts
+++ b/src/hooks/useBackNavigationGuard.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+
+/**
+ * Trap browser "back" navigation so it never leaves the app / loses the open
+ * project (#200). A sentinel history entry is pushed on mount; whenever the
+ * user triggers Back (button, Alt+Left, or trackpad swipe) we immediately
+ * re-push it, which keeps the page in place instead of navigating away.
+ *
+ * The app uses only history.replaceState() for its own URL cleanup, so there
+ * is no in-app router navigation for this to interfere with.
+ */
+export function useBackNavigationGuard(): void {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    // Seed an extra entry so the first Back press pops into our handler
+    // rather than leaving the document.
+    window.history.pushState(null, '', window.location.href);
+
+    const handlePopState = () => {
+      // Re-arm the trap: push the current location back on, cancelling the
+      // attempt to leave.
+      window.history.pushState(null, '', window.location.href);
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+}

--- a/src/stores/timeline/textClipSlice.ts
+++ b/src/stores/timeline/textClipSlice.ts
@@ -45,13 +45,15 @@ function getActiveCompositionResolution(): { width: number; height: number } {
 
 function getInitialTextProperties(width: number, height: number): TextClipProperties {
   const base = { ...DEFAULT_TEXT_PROPERTIES };
-  const box = resolveTextBoxRect(base, width, height);
+  // A newly created text field spans the whole composition frame (#204) so the
+  // editable text area matches the comp size; the user can resize it afterwards.
+  const box = { x: 0, y: 0, width, height };
   return {
     ...base,
-    boxX: Math.round(box.x),
-    boxY: Math.round(box.y),
-    boxWidth: Math.round(box.width),
-    boxHeight: Math.round(box.height),
+    boxX: 0,
+    boxY: 0,
+    boxWidth: Math.round(width),
+    boxHeight: Math.round(height),
     textBounds: createTextBoundsFromRect(box, width, height),
   };
 }

--- a/src/stores/timeline/trackSlice.ts
+++ b/src/stores/timeline/trackSlice.ts
@@ -331,6 +331,26 @@ export const createTrackSlice: SliceCreator<TrackActions> = (set, get) => ({
     });
   },
 
+  reorderTrack: (trackId, targetTrackId, placeBelow) => {
+    const { tracks } = get();
+    if (trackId === targetTrackId) return;
+    const source = tracks.find(t => t.id === trackId);
+    const target = tracks.find(t => t.id === targetTrackId);
+    if (!source || !target || source.locked) return;
+
+    // Only reorder within the same section: video among video, audio/midi among
+    // the audio section. Track array order is the compositing z-order for video.
+    const sectionOf = (t: TimelineTrack) => (t.type === 'video' ? 'video' : 'audio');
+    if (sectionOf(source) !== sectionOf(target)) return;
+
+    const without = tracks.filter(t => t.id !== trackId);
+    const targetIndex = without.findIndex(t => t.id === targetTrackId);
+    if (targetIndex < 0) return;
+    const insertIndex = placeBelow ? targetIndex + 1 : targetIndex;
+    without.splice(insertIndex, 0, source);
+    set({ tracks: without });
+  },
+
   renameTrack: (id, name) => {
     const { tracks } = get();
     set({

--- a/src/stores/timeline/types.ts
+++ b/src/stores/timeline/types.ts
@@ -450,6 +450,8 @@ export interface TimelineState {
 export interface TrackActions {
   addTrack: (type: 'video' | 'audio' | 'midi') => string;
   removeTrack: (id: string) => void;
+  // Drag-reorder a track relative to another track in the same section (#layers/tracks)
+  reorderTrack: (trackId: string, targetTrackId: string, placeBelow: boolean) => void;
   renameTrack: (id: string, name: string) => void;
   setTrackLabelColor: (id: string, labelColor: LabelColor) => void;
   setTrackMuted: (id: string, muted: boolean) => void;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,6 +1,6 @@
 // App version
 // Format: MAJOR.MINOR.PATCH
-export const APP_VERSION = '2.0.8';
+export const APP_VERSION = '2.0.9';
 
 export interface ChangelogNotice {
   type: 'info' | 'warning' | 'success' | 'danger';
@@ -27,8 +27,8 @@ export const FEATURED_VIDEO: {
   title: 'MasterSelects Demo',
   banner: {
     type: 'success',
-    title: 'MasterSelects 2.0.8',
-    message: 'UI polish batch: drop multiple files at once into the media panel or timeline, copy/paste/duplicate media items, add panels with a new "+" on every tab bar, scroll any dropdown to change it instantly, and a smoother themed board grid.',
+    title: 'MasterSelects 2.0.9',
+    message: 'Editing batch: text clips edit inside the layer mode (double-click to type, normal handles + Ctrl for free corners), Del removes media items, source player replays audio, the slot view previews videos, and you can drag-reorder video layers / audio tracks plus nudge clips with arrow keys.',
     animated: true,
   },
 };
@@ -36,8 +36,8 @@ export const FEATURED_VIDEO: {
 // Build/Platform notice shown at top of changelog (set to null to hide)
 export const BUILD_NOTICE: ChangelogNotice | null = {
   type: 'success',
-  title: 'MasterSelects 2.0.8',
-  message: 'This release bundles a set of UI fixes: multi-file drag & drop, media copy/paste/duplicate, per-panel "+" add button, scroll-through dropdowns, theme-aware edit backdrop, and a parallax board grid.',
+  title: 'MasterSelects 2.0.9',
+  message: 'This release improves editing: integrated text-clip editing, drag-reorder of video layers / audio tracks, arrow-key clip nudging, media Delete/scroll fixes, source audio replay, slot-view video previews, and a back-navigation guard.',
   animated: true,
 };
 


### PR DESCRIPTION
Editing-focused batch, verified in-app. Build + lint + 3306 tests green.

Closes #207
Closes #206
Closes #205
Closes #204
Closes #203
Closes #201
Closes #200
Closes #199
Closes #198

## Changes
- **#207** Delete/Backspace removes selected media-panel items (hover-scoped)
- **#206** text-clip editing is integrated into the layer-edit mode — move/scale handles by default, double-click to type, Esc back; themed grey pasteboard backdrop while typing
- **#205** normal (rectangular) resize handles by default; Ctrl = free corners/edges; Shift-to-align removed
- **#204** newly created text fields fill the composition
- **#203** source player rewinds ended audio before replay (+ reload fallback)
- **#201** slot/grid view scrubs a video preview on hover, like the board
- **#200** browser back/swipe is trapped so it never leaves the app
- **#199** AI tray prefetches its heavy chunk on idle/hover + memoized queue → first expand isn't laggy
- **#198** dock "Change to" submenu scrolls (internal scroll no longer closes the menu)

## Also (refinements verified during review)
- Edit-mode click selects the **topmost** layer (z-order fix)
- **Arrow-key clip nudging** in edit mode (Alt larger / Ctrl finer, zoom-aware)
- **Drag-reorder** video layers (z-order) and audio/MIDI tracks via a left-edge grip on track headers
- Live text-selection highlight while dragging

🤖 Generated with [Claude Code](https://claude.com/claude-code)