### PR TITLE
Release 2.1.0: media & preview polish (#215 #214 #213 #210 #209 #202 #195)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "masterselects",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "masterselects",
-      "version": "2.0.9",
+      "version": "2.1.0",
       "dependencies": {
         "@ffmpeg/core": "^0.12.6",
         "@ffmpeg/ffmpeg": "^0.12.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "masterselects",
   "private": true,
-  "version": "2.0.9",
+  "version": "2.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import { MobileApp } from './components/mobile';
 import { useTheme } from './hooks/useTheme';
 import { useGlobalSelectWheel } from './hooks/useGlobalSelectWheel';
 import { useBackNavigationGuard } from './hooks/useBackNavigationGuard';
+import { usePageZoom } from './hooks/usePageZoom';
 import { useGlobalHistory } from './hooks/useGlobalHistory';
 import { useClipPanelSync } from './hooks/useClipPanelSync';
 import { useIsMobile, useForceMobile } from './hooks/useIsMobile';
@@ -75,6 +76,9 @@ function App() {
 
   // Trap browser back/swipe so it never leaves the app (#200)
   useBackNavigationGuard();
+
+  // Overall UI zoom slider + block browser Ctrl+wheel page zoom (#209)
+  usePageZoom();
 
   // Initialize global undo/redo system
   const { historyNotice, clearHistoryNotice } = useGlobalHistory();
@@ -290,6 +294,10 @@ function App() {
   const shouldShowChangelogOnStartup = SHOW_CHANGELOG
     && shouldAutoShowChangelog(showChangelogOnStartup, lastSeenChangelogVersion, APP_VERSION);
 
+  // Arm the issue-credit banner only once the startup overlays (splash/welcome/
+  // changelog) are gone — it then appears after a delay and auto-hides (#195).
+  const creditBannerArmed = !isChecking && !showWelcome && !showSplash && !showChangelog;
+
   // Show Splash screen after initial check (when no welcome overlay)
   // This effect intentionally sets state based on derived conditions
   useEffect(() => {
@@ -438,7 +446,7 @@ function App() {
     <div className="app">
       <LinuxVulkanWarning />
       <Toolbar onOpenChangelog={() => setShowChangelog(true)} onOpenSplash={() => setShowSplash(true)} />
-      <IssueCreditCampaignBanner />
+      <IssueCreditCampaignBanner armed={creditBannerArmed} />
       <DockContainer />
       <GuidedActionOverlay />
       <ShortcutDisplayOverlay />

--- a/src/changelog-data.json
+++ b/src/changelog-data.json
@@ -2,6 +2,13 @@
   {
     "date": "2026-05-31",
     "type": "improve",
+    "title": "MasterSelects 2.1.0",
+    "description": "Media & preview polish: audio files now show a detailed waveform preview in the slot and board views (reusing the source-monitor renderer). The source monitor opens in only one preview and reliably replays consecutive same-type files (audio→audio, video→video). On a fullscreen timeline the video/audio divider now hugs its content instead of jumping to the centre. Dragging media-panel list columns no longer starts a marquee selection, badges hide only on horizontal scroll, and audio scrubbing no longer repeats a fragment while the pointer is held still. Appearance gains an interface-zoom area (Ctrl+scroll uses real browser zoom there) while Ctrl+scroll zoom is blocked elsewhere, and the credit banner now appears 10s after the splash and auto-hides.",
+    "section": "Release"
+  },
+  {
+    "date": "2026-05-31",
+    "type": "improve",
     "title": "MasterSelects 2.0.9",
     "description": "Editing batch: text-clip editing is now part of the layer-edit mode — enter edit mode to move/scale a text layer, double-click to type, with normal resize handles and Ctrl for free corners (no more Shift to align). Edit-mode clicks now select the topmost video, arrow keys nudge the selected clip (Alt = larger, Ctrl = finer, zoom-aware), and you can left-drag a grip on track headers to reorder video layers (z-order) and audio/MIDI tracks. Also: Delete removes selected media-panel items, the source player replays audio files, the slot/grid view scrubs video previews on hover, the panel \"Change to\" menu scrolls, newly created text fills the composition, and browser back no longer leaves the app.",
     "section": "Release"

--- a/src/components/common/IssueCreditCampaignBanner.tsx
+++ b/src/components/common/IssueCreditCampaignBanner.tsx
@@ -1,10 +1,19 @@
-import { useEffect, useState, type CSSProperties } from 'react';
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
 import { IconExternalLink, IconX } from '@tabler/icons-react';
 import './IssueCreditCampaignBanner.css';
 
 const ISSUE_CAMPAIGN_URL = 'https://github.com/Sportinger/MasterSelects/issues/new';
 const CONFETTI_VISIBLE_MS = 3600;
 const CONFETTI_IDLE_TIMEOUT_MS = 1400;
+// Show the banner 10s after the splash screen closes, then auto-dismiss after
+// 10s so it isn't intrusive (#195).
+const APPEAR_DELAY_MS = 10000;
+const AUTO_HIDE_MS = 10000;
+
+interface IssueCreditCampaignBannerProps {
+  /** Becomes true once the splash screen is gone; starts the appear delay. */
+  armed: boolean;
+}
 
 const CONFETTI_COLORS = [
   '#ffcc33',
@@ -33,9 +42,27 @@ type IdleWindow = typeof window & {
   cancelIdleCallback?: (handle: number) => void;
 };
 
-export function IssueCreditCampaignBanner() {
-  const [isVisible, setIsVisible] = useState(true);
+export function IssueCreditCampaignBanner({ armed }: IssueCreditCampaignBannerProps) {
+  const [isVisible, setIsVisible] = useState(false);
   const [showConfetti, setShowConfetti] = useState(false);
+  const hasShownRef = useRef(false);
+
+  // Appear once, 10s after the splash is gone.
+  useEffect(() => {
+    if (!armed || hasShownRef.current) return undefined;
+    const timer = window.setTimeout(() => {
+      hasShownRef.current = true;
+      setIsVisible(true);
+    }, APPEAR_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [armed]);
+
+  // Auto-dismiss 10s after appearing.
+  useEffect(() => {
+    if (!isVisible) return undefined;
+    const timer = window.setTimeout(() => setIsVisible(false), AUTO_HIDE_MS);
+    return () => window.clearTimeout(timer);
+  }, [isVisible]);
 
   useEffect(() => {
     if (!isVisible) return undefined;

--- a/src/components/common/settings/AppearanceSettings.tsx
+++ b/src/components/common/settings/AppearanceSettings.tsx
@@ -29,6 +29,34 @@ export function AppearanceSettings() {
       <h2>Appearance</h2>
 
       <div className="settings-group">
+        <div className="settings-group-title">Interface Zoom</div>
+        <p className="settings-group-hint" style={{ color: 'var(--text-secondary)', fontSize: 12, margin: '0 0 8px' }}>
+          Ctrl + Scroll zoom is disabled across the app to avoid accidental zoom. To scale the whole
+          interface, hold <strong>Ctrl</strong> and scroll inside the box below — it uses your browser's
+          native page zoom.
+        </p>
+        <div
+          data-browser-zoom-area
+          tabIndex={0}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: 84,
+            borderRadius: 8,
+            border: '1px dashed var(--border-strong, #555)',
+            background: 'var(--bg-secondary)',
+            color: 'var(--text-secondary)',
+            fontSize: 13,
+            userSelect: 'none',
+            cursor: 'ns-resize',
+          }}
+        >
+          Ctrl + Scroll here to zoom the interface
+        </div>
+      </div>
+
+      <div className="settings-group">
         <div className="settings-group-title">Theme</div>
         <div className="theme-selector">
           {themeOptions.map((opt) => {

--- a/src/components/common/settings/useDraggableDialog.ts
+++ b/src/components/common/settings/useDraggableDialog.ts
@@ -16,6 +16,28 @@ export function useDraggableDialog(dialogRef: React.RefObject<HTMLDivElement | n
     }
   }, [dialogRef]);
 
+  // Keep the dialog at the same on-screen position when the viewport (CSS) size
+  // changes. Browser page zoom changes innerWidth/innerHeight, so scaling the
+  // position by the ratio keeps the dialog visually anchored while zooming via
+  // the Appearance zoom area (#209), rather than drifting across the screen.
+  const viewportRef = useRef({ width: window.innerWidth, height: window.innerHeight });
+  useEffect(() => {
+    const handleResize = () => {
+      const prev = viewportRef.current;
+      const nextWidth = window.innerWidth;
+      const nextHeight = window.innerHeight;
+      if (prev.width > 0 && prev.height > 0 && (nextWidth !== prev.width || nextHeight !== prev.height)) {
+        setPosition((current) => ({
+          x: current.x * (nextWidth / prev.width),
+          y: current.y * (nextHeight / prev.height),
+        }));
+      }
+      viewportRef.current = { width: nextWidth, height: nextHeight };
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (dialogRef.current) {
       const rect = dialogRef.current.getBoundingClientRect();

--- a/src/components/panels/MediaPanel.css
+++ b/src/components/panels/MediaPanel.css
@@ -711,6 +711,21 @@
   pointer-events: none;
 }
 
+/* Detailed waveform preview for audio files (#202) */
+.media-waveform-thumb {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.media-waveform-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 .media-grid-thumb-placeholder {
   position: absolute;
   inset: 0;
@@ -1705,7 +1720,7 @@
   will-change: opacity, transform, max-width;
 }
 
-.media-panel-table-wrapper.is-vertical-scrolling .media-col-badges :is(
+.media-panel-table-wrapper.is-horizontal-scrolled .media-col-badges :is(
   .media-item-import-progress,
   .media-item-waveform-badge,
   .media-item-waveform-generating,

--- a/src/components/panels/MediaPanel.tsx
+++ b/src/components/panels/MediaPanel.tsx
@@ -6,6 +6,7 @@ import './MediaPanel.css';
 import { Logger } from '../../services/logger';
 import { FileTypeIcon } from './media/FileTypeIcon';
 import { MediaGridVideoThumb } from './media/MediaGridVideoThumb';
+import { MediaWaveformThumb } from './media/MediaWaveformThumb';
 import { LABEL_COLORS, getLabelHex } from './media/labelColors';
 import { CompositionSettingsDialog } from './media/CompositionSettingsDialog';
 import { SolidSettingsDialog } from './media/SolidSettingsDialog';
@@ -1730,8 +1731,9 @@ export function MediaPanel() {
   const handleMarqueeMouseDown = useCallback((e: React.MouseEvent) => {
     if (e.button !== 0) return;
     const target = e.target as HTMLElement;
-    // Ignore clicks on buttons, inputs, context menus
-    if (target.closest('button, input, .context-menu')) return;
+    // Ignore clicks on buttons, inputs, context menus, and the list column
+    // headers / resize handles (dragging a column must not start a marquee, #214)
+    if (target.closest('button, input, .context-menu, .media-column-headers, .media-col-resize-handle')) return;
 
     // Don't start marquee when clicking on an item — let item drag handle it
     const clickedOnItem = !!target.closest('.media-item, .media-grid-item');
@@ -2944,6 +2946,8 @@ export function MediaPanel() {
                 thumbUrl={thumbUrl}
                 onError={() => { void refreshFileUrls(mediaFile.id); }}
               />
+            ) : mediaFile?.type === 'audio' ? (
+              <MediaWaveformThumb mediaFile={mediaFile} />
             ) : thumbUrl ? (
               <img
                 src={thumbUrl}

--- a/src/components/panels/media/MediaWaveformThumb.tsx
+++ b/src/components/panels/media/MediaWaveformThumb.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from 'react';
+import { useMediaStore, type MediaFile } from '../../../stores/mediaStore';
+import { FileTypeIcon } from './FileTypeIcon';
+import {
+  drawSourceAudioWaveformCanvas,
+  getAudioWaveformStatus,
+  getSourceWaveformChannels,
+} from '../../preview/sourceAudioWaveform';
+
+interface MediaWaveformThumbProps {
+  mediaFile: MediaFile;
+}
+
+// Light fill so the (otherwise near-black) waveform is visible on the dark thumb.
+const THUMB_WAVEFORM_FILL = 'rgba(255, 255, 255, 0.62)';
+
+/**
+ * Detailed waveform preview for audio files in the grid/slot and board views
+ * (#202 — visual only, no audio playback). Reuses the same waveform renderer as
+ * the Source Monitor so it matches the already-rendered waveforms elsewhere.
+ */
+export function MediaWaveformThumb({ mediaFile }: MediaWaveformThumbProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const generateMediaWaveform = useMediaStore((s) => s.generateMediaWaveform);
+
+  const channels = getSourceWaveformChannels(mediaFile);
+  const hasWaveform = channels.length > 0;
+  const status = getAudioWaveformStatus(mediaFile, true);
+
+  // Kick off waveform generation once if we have nothing to draw yet, but defer
+  // it to idle and CANCEL on unmount. This keeps view switches snappy: rapidly
+  // switching views unmounts these thumbs before generation ever starts, so we
+  // never fire a burst of audio-decodes mid-transition (#202 perf follow-up).
+  useEffect(() => {
+    if (hasWaveform || status === 'generating' || status === 'error') return undefined;
+    let cancelled = false;
+    const run = () => { if (!cancelled) void generateMediaWaveform(mediaFile.id); };
+    const idleWin = window as Window & {
+      requestIdleCallback?: (cb: () => void, opts?: { timeout?: number }) => number;
+      cancelIdleCallback?: (id: number) => void;
+    };
+    const idleId = typeof idleWin.requestIdleCallback === 'function'
+      ? idleWin.requestIdleCallback(run, { timeout: 2000 })
+      : window.setTimeout(run, 500);
+    return () => {
+      cancelled = true;
+      if (typeof idleWin.cancelIdleCallback === 'function') idleWin.cancelIdleCallback(idleId);
+      window.clearTimeout(idleId);
+    };
+  }, [hasWaveform, status, mediaFile.id, generateMediaWaveform]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !hasWaveform) return undefined;
+
+    const draw = () => drawSourceAudioWaveformCanvas(canvas, channels, status, THUMB_WAVEFORM_FILL);
+    draw();
+    // Debounce resize redraws so view-switch animations stay smooth (the canvas
+    // stretches in the meantime, then crisp-redraws once settled).
+    let debounceTimer = 0;
+    const scheduleDraw = () => {
+      if (debounceTimer) window.clearTimeout(debounceTimer);
+      debounceTimer = window.setTimeout(draw, 140);
+    };
+    const observer = new ResizeObserver(scheduleDraw);
+    if (canvas.parentElement) observer.observe(canvas.parentElement);
+    return () => {
+      if (debounceTimer) window.clearTimeout(debounceTimer);
+      observer.disconnect();
+    };
+  }, [channels, hasWaveform, status]);
+
+  if (!hasWaveform) {
+    return (
+      <div className="media-waveform-thumb">
+        <div className="media-grid-thumb-placeholder">
+          <FileTypeIcon type="audio" large />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="media-waveform-thumb">
+      <canvas ref={canvasRef} className="media-waveform-canvas" />
+    </div>
+  );
+}

--- a/src/components/panels/media/board/MediaBoardView.tsx
+++ b/src/components/panels/media/board/MediaBoardView.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { Composition, MediaFile, MediaFolder, ProjectItem, SolidItem, TextItem } from '../../../../stores/mediaStore';
 import { mediaNeedsRelink } from '../../../../services/project/relinkMedia';
 import { FileTypeIcon } from '../FileTypeIcon';
+import { MediaWaveformThumb } from '../MediaWaveformThumb';
 import { getItemImportProgress, getItemWaveformProgress, isImportedMediaFileItem } from '../itemTypeGuards';
 import { getLabelHex } from '../labelColors';
 import { MEDIA_BOARD_GRID_PARALLAX, getMediaBoardGridSize, getMediaBoardUiScale } from './constants';
@@ -456,6 +457,8 @@ function MediaBoardNode({
               />
             ) : null}
           </>
+        ) : mediaFile?.type === 'audio' ? (
+          <MediaWaveformThumb mediaFile={mediaFile} />
         ) : (
           <div className="media-board-node-placeholder">
             <FileTypeIcon type={isComp ? 'composition' : getProjectItemIconType(item)} large />

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -583,8 +583,11 @@ export function Preview({ panelId, source, showTransparencyGrid }: PreviewProps)
     [source, compositions, activeCompositionId, activeCompositionVideoTracks],
   );
 
-  // Source monitor: show raw media file instead of composition
-  const sourceMonitorActive = source.type === 'activeComp' && sourceMonitorFile !== null;
+  // Source monitor: show raw media file instead of composition. Only the first
+  // editable preview hosts it, so it never opens in multiple previews at once.
+  const sourceMonitorActive = source.type === 'activeComp'
+    && sourceMonitorFile !== null
+    && getFirstEditablePreviewPanelId() === panelId;
 
   const closeSourceMonitor = useCallback(() => {
     useMediaStore.getState().setSourceMonitorFile(null);

--- a/src/components/preview/SourceMonitor.tsx
+++ b/src/components/preview/SourceMonitor.tsx
@@ -10,6 +10,7 @@ import {
   IconX,
 } from '@tabler/icons-react';
 import { getShortcutRegistry } from '../../services/shortcutRegistry';
+import { getAudioWaveformStatus, getSourceWaveformChannels, drawSourceAudioWaveformCanvas } from './sourceAudioWaveform';
 import {
   clearTimelinePlacementCommandPreview,
   runTimelinePlacementCommand,
@@ -42,10 +43,8 @@ const SOURCE_MONITOR_PLACEMENT_COMMANDS: Array<{
 
 const DEFAULT_STILL_DURATION = 5;
 const MIN_MARK_GAP_SECONDS = 0.001;
-const SOURCE_WAVEFORM_FILL = '#020403';
 
 type SourceTimelineDragKind = 'playhead' | 'in' | 'out';
-type AudioWaveformStatus = NonNullable<MediaFile['waveformStatus']>;
 
 function normalizeDuration(value: number | undefined, fallback = 0): number {
   return Number.isFinite(value) && value !== undefined && value > 0 ? value : fallback;
@@ -101,21 +100,6 @@ function createTimelineTicks(duration: number, fps: number): Array<{ time: numbe
   return ticks;
 }
 
-function getAudioWaveformStatus(file: MediaFile, isAudio: boolean): AudioWaveformStatus {
-  if (!isAudio) return 'idle';
-  if ((file.waveform?.length ?? 0) > 0) {
-    return file.waveformStatus ?? 'ready';
-  }
-  return file.waveformStatus ?? 'idle';
-}
-
-function getSourceWaveformChannels(file: MediaFile): readonly (readonly number[])[] {
-  const channels = file.waveformChannels?.filter((channel) => channel.length > 0) ?? [];
-  if (channels.length > 0) return channels;
-  if (file.waveform?.length) return [file.waveform, file.waveform];
-  return [];
-}
-
 function updateMediaFileWaveformCache(
   id: string,
   updates: Partial<Pick<MediaFile, 'audioAnalysisRefs' | 'waveform' | 'waveformChannels' | 'waveformProgress' | 'waveformStatus'>>,
@@ -127,83 +111,6 @@ function updateMediaFileWaveformCache(
         : entry
     )),
   }));
-}
-
-function drawSourceAudioWaveformCanvas(
-  canvas: HTMLCanvasElement,
-  channels: readonly (readonly number[])[],
-  status: AudioWaveformStatus,
-): void {
-  const container = canvas.parentElement;
-  const rect = container?.getBoundingClientRect();
-  const cssWidth = Math.round(rect?.width || container?.clientWidth || canvas.clientWidth || 0);
-  const cssHeight = Math.round(rect?.height || container?.clientHeight || canvas.clientHeight || 0);
-  if (cssWidth <= 1 || cssHeight <= 1) return;
-
-  const dpr = Math.max(1, Math.min(3, window.devicePixelRatio || 1));
-  const pixelWidth = Math.max(1, Math.round(cssWidth * dpr));
-  const pixelHeight = Math.max(1, Math.round(cssHeight * dpr));
-
-  if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
-    canvas.width = pixelWidth;
-    canvas.height = pixelHeight;
-  }
-
-  const context = canvas.getContext('2d');
-  if (!context) return;
-
-  context.setTransform(dpr, 0, 0, dpr, 0, 0);
-  context.clearRect(0, 0, cssWidth, cssHeight);
-
-  const renderChannels = channels.length > 0 ? channels.slice(0, 2) : [];
-  if (renderChannels.length === 0) {
-    if (status === 'generating') {
-      context.fillStyle = 'rgba(2, 4, 3, 0.22)';
-      for (let channelIndex = 0; channelIndex < 2; channelIndex += 1) {
-        const laneTop = (cssHeight / 2) * channelIndex;
-        const laneHeight = cssHeight / 2;
-        const centerY = laneTop + laneHeight / 2;
-        for (let x = 0; x < cssWidth; x += 4) {
-          const amplitude = 0.08 + ((x / 4) % 7) * 0.015;
-          const halfHeight = Math.max(1, laneHeight * amplitude);
-          context.fillRect(x, centerY - halfHeight, 2, halfHeight * 2);
-        }
-      }
-    }
-    return;
-  }
-
-  context.fillStyle = SOURCE_WAVEFORM_FILL;
-  context.globalAlpha = status === 'skipped' || status === 'error'
-    ? 0.32
-    : status === 'generating'
-      ? 0.74
-      : 0.98;
-
-  for (let channelIndex = 0; channelIndex < 2; channelIndex += 1) {
-    const channel = renderChannels[channelIndex] ?? renderChannels[0];
-    if (!channel || channel.length === 0) continue;
-
-    const laneTop = (cssHeight / 2) * channelIndex;
-    const laneHeight = cssHeight / 2;
-    const centerY = laneTop + laneHeight / 2;
-    const maxHalfHeight = Math.max(1, laneHeight * 0.46);
-
-    for (let x = 0; x < cssWidth; x += 1) {
-      const start = Math.floor((x / cssWidth) * channel.length);
-      const end = Math.max(start + 1, Math.ceil(((x + 1) / cssWidth) * channel.length));
-      let peak = 0;
-
-      for (let sampleIndex = start; sampleIndex < end && sampleIndex < channel.length; sampleIndex += 1) {
-        peak = Math.max(peak, Math.abs(channel[sampleIndex] ?? 0));
-      }
-
-      const halfHeight = Math.max(0.6, Math.min(1, peak) * maxHalfHeight);
-      context.fillRect(x, centerY - halfHeight, 1, halfHeight * 2);
-    }
-  }
-
-  context.globalAlpha = 1;
 }
 
 export function SourceMonitor({ file, autoplayRequestId = 0, onClose }: SourceMonitorProps) {
@@ -271,6 +178,7 @@ export function SourceMonitor({ file, autoplayRequestId = 0, onClose }: SourceMo
     if (!canvas || !container) return undefined;
 
     let frameId = 0;
+    let debounceTimer = 0;
     const render = () => {
       frameId = 0;
       drawSourceAudioWaveformCanvas(canvas, audioWaveformChannels, audioWaveformStatus);
@@ -283,22 +191,31 @@ export function SourceMonitor({ file, autoplayRequestId = 0, onClose }: SourceMo
         render();
       }
     };
+    // Resize fires every frame of a view-switch animation; debounce so the
+    // expensive waveform repaints once after the transition settles instead of
+    // stuttering through it (the canvas just stretches smoothly meanwhile).
+    const scheduleDebouncedRender = () => {
+      if (debounceTimer) window.clearTimeout(debounceTimer);
+      debounceTimer = window.setTimeout(scheduleRender, 140);
+    };
 
     scheduleRender();
 
     if (typeof ResizeObserver !== 'undefined') {
-      const observer = new ResizeObserver(scheduleRender);
+      const observer = new ResizeObserver(scheduleDebouncedRender);
       observer.observe(container);
       return () => {
         if (frameId) window.cancelAnimationFrame(frameId);
+        if (debounceTimer) window.clearTimeout(debounceTimer);
         observer.disconnect();
       };
     }
 
-    window.addEventListener('resize', scheduleRender);
+    window.addEventListener('resize', scheduleDebouncedRender);
     return () => {
       if (frameId) window.cancelAnimationFrame(frameId);
-      window.removeEventListener('resize', scheduleRender);
+      if (debounceTimer) window.clearTimeout(debounceTimer);
+      window.removeEventListener('resize', scheduleDebouncedRender);
     };
   }, [audioWaveformChannels, audioWaveformStatus, isAudio]);
 
@@ -395,6 +312,18 @@ export function SourceMonitor({ file, autoplayRequestId = 0, onClose }: SourceMo
     return () => window.cancelAnimationFrame(frameId);
   }, [isPlayable, isPlaying, isScrubbing, outPoint]);
 
+  // On a same-type switch (audio→audio / video→video) the same media element is
+  // reused, so changing `src` alone doesn't reload it — explicitly reload the new
+  // source. (Must NOT strip the src here, or the freshly selected file can't play
+  // until the monitor is reopened.)
+  useEffect(() => {
+    const media = mediaRef.current;
+    if (!media) return;
+    media.pause();
+    media.load();
+  }, [file.id]);
+
+  // Release the media element only when the source monitor actually closes.
   useEffect(() => {
     const media = mediaRef.current;
     return () => {
@@ -403,7 +332,7 @@ export function SourceMonitor({ file, autoplayRequestId = 0, onClose }: SourceMo
       media.removeAttribute('src');
       media.load();
     };
-  }, [file.id]);
+  }, []);
 
   const seekSourceMonitor = useCallback((time: number) => {
     const clampedTime = clampTime(time, timelineDuration || time);

--- a/src/components/preview/sourceAudioWaveform.ts
+++ b/src/components/preview/sourceAudioWaveform.ts
@@ -1,0 +1,106 @@
+// Shared audio-waveform rendering used by the Source Monitor and the media
+// panel slot/board waveform previews (#202) so they look identical.
+
+import type { MediaFile } from '../../stores/mediaStore';
+
+export type AudioWaveformStatus = NonNullable<MediaFile['waveformStatus']>;
+
+export const SOURCE_WAVEFORM_FILL = '#020403';
+
+export function getAudioWaveformStatus(file: MediaFile, isAudio: boolean): AudioWaveformStatus {
+  if (!isAudio) return 'idle';
+  if ((file.waveform?.length ?? 0) > 0) {
+    return file.waveformStatus ?? 'ready';
+  }
+  return file.waveformStatus ?? 'idle';
+}
+
+export function getSourceWaveformChannels(file: MediaFile): readonly (readonly number[])[] {
+  const channels = file.waveformChannels?.filter((channel) => channel.length > 0) ?? [];
+  if (channels.length > 0) return channels;
+  if (file.waveform?.length) return [file.waveform, file.waveform];
+  return [];
+}
+
+/**
+ * Draw the already-generated waveform peaks (two stereo lanes) into a canvas,
+ * sized to the canvas's parent. `fillColor` lets callers on dark backgrounds
+ * (the media board thumbnails) override the default near-black fill.
+ */
+export function drawSourceAudioWaveformCanvas(
+  canvas: HTMLCanvasElement,
+  channels: readonly (readonly number[])[],
+  status: AudioWaveformStatus,
+  fillColor: string = SOURCE_WAVEFORM_FILL,
+): void {
+  const container = canvas.parentElement;
+  const rect = container?.getBoundingClientRect();
+  const cssWidth = Math.round(rect?.width || container?.clientWidth || canvas.clientWidth || 0);
+  const cssHeight = Math.round(rect?.height || container?.clientHeight || canvas.clientHeight || 0);
+  if (cssWidth <= 1 || cssHeight <= 1) return;
+
+  const dpr = Math.max(1, Math.min(3, window.devicePixelRatio || 1));
+  const pixelWidth = Math.max(1, Math.round(cssWidth * dpr));
+  const pixelHeight = Math.max(1, Math.round(cssHeight * dpr));
+
+  if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
+    canvas.width = pixelWidth;
+    canvas.height = pixelHeight;
+  }
+
+  const context = canvas.getContext('2d');
+  if (!context) return;
+
+  context.setTransform(dpr, 0, 0, dpr, 0, 0);
+  context.clearRect(0, 0, cssWidth, cssHeight);
+
+  const renderChannels = channels.length > 0 ? channels.slice(0, 2) : [];
+  if (renderChannels.length === 0) {
+    if (status === 'generating') {
+      context.fillStyle = 'rgba(2, 4, 3, 0.22)';
+      for (let channelIndex = 0; channelIndex < 2; channelIndex += 1) {
+        const laneTop = (cssHeight / 2) * channelIndex;
+        const laneHeight = cssHeight / 2;
+        const centerY = laneTop + laneHeight / 2;
+        for (let x = 0; x < cssWidth; x += 4) {
+          const amplitude = 0.08 + ((x / 4) % 7) * 0.015;
+          const halfHeight = Math.max(1, laneHeight * amplitude);
+          context.fillRect(x, centerY - halfHeight, 2, halfHeight * 2);
+        }
+      }
+    }
+    return;
+  }
+
+  context.fillStyle = fillColor;
+  context.globalAlpha = status === 'skipped' || status === 'error'
+    ? 0.32
+    : status === 'generating'
+      ? 0.74
+      : 0.98;
+
+  for (let channelIndex = 0; channelIndex < 2; channelIndex += 1) {
+    const channel = renderChannels[channelIndex] ?? renderChannels[0];
+    if (!channel || channel.length === 0) continue;
+
+    const laneTop = (cssHeight / 2) * channelIndex;
+    const laneHeight = cssHeight / 2;
+    const centerY = laneTop + laneHeight / 2;
+    const maxHalfHeight = Math.max(1, laneHeight * 0.46);
+
+    for (let x = 0; x < cssWidth; x += 1) {
+      const start = Math.floor((x / cssWidth) * channel.length);
+      const end = Math.max(start + 1, Math.ceil(((x + 1) / cssWidth) * channel.length));
+      let peak = 0;
+
+      for (let sampleIndex = start; sampleIndex < end && sampleIndex < channel.length; sampleIndex += 1) {
+        peak = Math.max(peak, Math.abs(channel[sampleIndex] ?? 0));
+      }
+
+      const halfHeight = Math.max(0.6, Math.min(1, peak) * maxHalfHeight);
+      context.fillRect(x, centerY - halfHeight, 1, halfHeight * 2);
+    }
+  }
+
+  context.globalAlpha = 1;
+}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -1748,7 +1748,13 @@ export function Timeline() {
     }
 
     if (trackFocusMode === 'balanced' && timelineSplitRatio !== null) {
-      const videoHeight = clampSplitDragVideoHeight(availableHeight * timelineSplitRatio, availableHeight);
+      const ratioVideoHeight = clampSplitDragVideoHeight(availableHeight * timelineSplitRatio, availableHeight);
+      // Don't let the ratio grow the video section past its actual content — when
+      // the timeline is maximized this would otherwise push the divider to the
+      // middle and leave an empty gap. Hug the content instead (#215).
+      const videoHeight = videoContentHeight > 0
+        ? Math.min(ratioVideoHeight, videoContentHeight)
+        : ratioVideoHeight;
       return {
         videoSectionHeight: videoHeight,
         audioSectionHeight: Math.max(0, availableHeight - videoHeight),

--- a/src/hooks/usePageZoom.ts
+++ b/src/hooks/usePageZoom.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+/**
+ * Browser page-zoom guard (#209). The browser's native Ctrl+scroll zoom is
+ * blocked everywhere so it can't fire accidentally over the app, EXCEPT inside
+ * a dedicated zoom area (marked with `data-browser-zoom-area`) in the Appearance
+ * settings — there Ctrl+scroll is allowed through so the user can deliberately
+ * scale the whole interface using real browser zoom.
+ */
+export function usePageZoom(): void {
+  useEffect(() => {
+    const handleWheel = (event: WheelEvent) => {
+      if (!event.ctrlKey) return;
+      const target = event.target as HTMLElement | null;
+      if (target?.closest?.('[data-browser-zoom-area]')) return; // allow native zoom here
+      event.preventDefault();
+    };
+    // Capture + non-passive so we can preventDefault before the browser zooms.
+    window.addEventListener('wheel', handleWheel, { passive: false, capture: true });
+    return () => window.removeEventListener('wheel', handleWheel, { capture: true } as EventListenerOptions);
+  }, []);
+}

--- a/src/services/layerBuilder/AudioSyncHandler.ts
+++ b/src/services/layerBuilder/AudioSyncHandler.ts
@@ -52,7 +52,7 @@ interface TailMeterPoll {
  */
 export class AudioSyncHandler {
   // Scrub audio state
-  private scrubStates = new WeakMap<HTMLMediaElement, { lastPosition: number; lastTime: number }>();
+  private scrubStates = new WeakMap<HTMLMediaElement, { lastPosition: number; lastTime: number; lastSeenPosition: number }>();
   private scrubAudioTimeouts = new Map<HTMLMediaElement, ReturnType<typeof setTimeout>>();
   private tailMeterPolls = new Map<string, TailMeterPoll>();
 
@@ -129,18 +129,27 @@ export class AudioSyncHandler {
     masterRoute?: AudioSyncTarget['masterRoute'],
     meterTrackId?: string
   ): void {
-    const scrubState = this.scrubStates.get(element) ?? { lastPosition: -1, lastTime: 0 };
+    const scrubState = this.scrubStates.get(element) ?? { lastPosition: -1, lastTime: 0, lastSeenPosition: -1 };
     const timeSinceLastScrub = ctx.now - scrubState.lastTime;
     const positionChanged = Math.abs(ctx.playheadPosition - scrubState.lastPosition) > 0.005;
+    // Only play while the playhead is actually moving frame-to-frame. A held
+    // (stationary) pointer must not keep replaying the same fragment (#213).
+    const movedSinceLastFrame = scrubState.lastSeenPosition < 0
+      || Math.abs(ctx.playheadPosition - scrubState.lastSeenPosition) > 0.0005;
 
-    if (positionChanged && timeSinceLastScrub > LAYER_BUILDER_CONSTANTS.SCRUB_TRIGGER_INTERVAL) {
+    if (movedSinceLastFrame && positionChanged && timeSinceLastScrub > LAYER_BUILDER_CONSTANTS.SCRUB_TRIGGER_INTERVAL) {
       this.scrubStates.set(element, {
         lastPosition: ctx.playheadPosition,
         lastTime: ctx.now,
+        lastSeenPosition: ctx.playheadPosition,
       });
       element.playbackRate = 1;
       this.applyScrubEffects(element, volume, eqGains, pan, processors, masterRoute, meterTrackId);
       this.playScrubAudio(element, clipTime);
+    } else {
+      // Keep tracking position even when we don't trigger, so the next frame can
+      // tell whether the pointer actually moved.
+      this.scrubStates.set(element, { ...scrubState, lastSeenPosition: ctx.playheadPosition });
     }
   }
 
@@ -434,7 +443,7 @@ export class AudioSyncHandler {
    * Reset scrub state (call when not scrubbing)
    */
   resetScrubState(): void {
-    this.scrubStates = new WeakMap<HTMLMediaElement, { lastPosition: number; lastTime: number }>();
+    this.scrubStates = new WeakMap<HTMLMediaElement, { lastPosition: number; lastTime: number; lastSeenPosition: number }>();
   }
 
   /**

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,6 +1,6 @@
 // App version
 // Format: MAJOR.MINOR.PATCH
-export const APP_VERSION = '2.0.9';
+export const APP_VERSION = '2.1.0';
 
 export interface ChangelogNotice {
   type: 'info' | 'warning' | 'success' | 'danger';
@@ -27,8 +27,8 @@ export const FEATURED_VIDEO: {
   title: 'MasterSelects Demo',
   banner: {
     type: 'success',
-    title: 'MasterSelects 2.0.9',
-    message: 'Editing batch: text clips edit inside the layer mode (double-click to type, normal handles + Ctrl for free corners), Del removes media items, source player replays audio, the slot view previews videos, and you can drag-reorder video layers / audio tracks plus nudge clips with arrow keys.',
+    title: 'MasterSelects 2.1.0',
+    message: 'Polish batch: audio waveform previews in the slot & board views, the source monitor opens once and replays consecutive same-type files, the fullscreen timeline divider hugs its content, list-column dragging no longer marquee-selects, badges hide only on horizontal scroll, idle audio scrubbing stays quiet, and Appearance has an interface-zoom area.',
     animated: true,
   },
 };
@@ -36,8 +36,8 @@ export const FEATURED_VIDEO: {
 // Build/Platform notice shown at top of changelog (set to null to hide)
 export const BUILD_NOTICE: ChangelogNotice | null = {
   type: 'success',
-  title: 'MasterSelects 2.0.9',
-  message: 'This release improves editing: integrated text-clip editing, drag-reorder of video layers / audio tracks, arrow-key clip nudging, media Delete/scroll fixes, source audio replay, slot-view video previews, and a back-navigation guard.',
+  title: 'MasterSelects 2.1.0',
+  message: 'Polish batch: audio waveform previews in the slot/board views, source monitor opens once and replays consecutive same-type files, timeline divider hugs content on fullscreen, list-column drag no longer marquee-selects, badges only hide on horizontal scroll, audio scrub no longer repeats when idle, and an interface zoom area in Appearance.',
   animated: true,
 };
 

--- a/tests/unit/IssueCreditCampaignBanner.test.tsx
+++ b/tests/unit/IssueCreditCampaignBanner.test.tsx
@@ -1,14 +1,28 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { IssueCreditCampaignBanner } from '../../src/components/common/IssueCreditCampaignBanner';
 
+// The banner appears 10s after it is armed (splash closed) and auto-hides 10s
+// later (#195), so the tests arm it and advance fake timers past the delay.
 describe('IssueCreditCampaignBanner', () => {
-  afterEach(() => {
-    cleanup();
+  beforeEach(() => {
+    vi.useFakeTimers();
   });
 
-  it('renders the issue credit campaign and GitHub issue action', () => {
-    render(<IssueCreditCampaignBanner />);
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('renders the issue credit campaign and GitHub issue action after the appear delay', () => {
+    render(<IssueCreditCampaignBanner armed />);
+
+    // Hidden until the appear delay elapses.
+    expect(screen.queryByRole('region', { name: 'MasterSelects issue credit campaign' })).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
 
     expect(screen.getByRole('region', { name: 'MasterSelects issue credit campaign' })).toBeInTheDocument();
     expect(screen.getByText('Completed Issue = 1000 AI Credits')).toBeInTheDocument();
@@ -19,7 +33,11 @@ describe('IssueCreditCampaignBanner', () => {
   });
 
   it('can be dismissed for the current session', () => {
-    render(<IssueCreditCampaignBanner />);
+    render(<IssueCreditCampaignBanner armed />);
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
 
     fireEvent.click(screen.getByRole('button', { name: 'Dismiss issue credit campaign' }));
 


### PR DESCRIPTION
Media-panel & preview polish batch, verified in-app. Build + lint + tests green.

Closes #215
Closes #214
Closes #213
Closes #210
Closes #209
Closes #202
Closes #195

## Changes
- **#202** audio files show a detailed waveform preview in the slot/board views (reuses the Source Monitor's waveform renderer via a shared `sourceAudioWaveform.ts`)
- **#215** fullscreen timeline: the video/audio divider hugs its content instead of jumping to the centre
- **#214** dragging media-panel list columns no longer starts a marquee selection
- **#213** audio scrubbing only plays while the playhead actually moves — a held pointer no longer repeats the fragment
- **#210** media-panel badges hide only on horizontal scroll, not vertical
- **#209** the browser's Ctrl+wheel page zoom is blocked app-wide, allowed only inside a dedicated Appearance zoom area (real browser zoom); the settings window stays anchored while zooming
- **#195** the credit banner appears 10s after the splash closes and auto-hides after 10s

## Also
- Source monitor opens in only one preview, and reliably replays consecutive same-type files (the element was being stripped of its src on same-type switches)
- Waveform redraw is debounced + generation deferred/cancellable so view-switch animations stay smooth

**#197** (multiple-timeline tabs + dock grouping) is intentionally **not** in this batch — left open for a dedicated effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)