### PR TITLE
Fix MIDI track resize in audio focus mode

### DIFF
--- a/src/components/timeline/utils/timelineAudioLayout.ts
+++ b/src/components/timeline/utils/timelineAudioLayout.ts
@@ -24,7 +24,10 @@ export function getTimelineTrackBaseHeight(
   audioDisplayMode: TimelineAudioDisplayMode,
   audioFocusMode = false,
 ): number {
-  if (track.type !== 'audio') {
+  // Only video tracks collapse into a thin context strip in audio focus mode.
+  // MIDI tracks are musical content and stay freely resizable like audio tracks
+  // (they fall through to the audio min-height path below).
+  if (track.type === 'video') {
     if (!audioFocusMode) return track.height;
     return Math.max(20, Math.min(normalizeAudioTrackHeight(track.height), AUDIO_FOCUS_VIDEO_CONTEXT_HEIGHT));
   }


### PR DESCRIPTION
In audio focus mode, getTimelineTrackBaseHeight clamped every non-audio track to a 32px context strip. This also caught MIDI tracks, so resize drags (header / blue line) and the scroll-wheel resize had no visible effect — the rendered height was clamped back regardless of the stored height.

Restrict the context-strip clamp to video tracks only. MIDI tracks now fall through to the audio min-height path and stay freely resizable, matching their nature as musical content.

Fixes #255