### PR TITLE
Fix dead click spot in audio/MIDI track headers (#280)

### DIFF
--- a/src/components/timeline/TimelineHeader.tsx
+++ b/src/components/timeline/TimelineHeader.tsx
@@ -152,9 +152,9 @@ function TimelineHeaderComponent({
 
   const handleHeaderClick = (e: React.MouseEvent) => {
     if (isEditing) return;
-    if ((e.target as HTMLElement).closest('.track-controls')) return;
-    if ((e.target as HTMLElement).closest('.audio-track-faders')) return;
-    if ((e.target as HTMLElement).closest('.audio-track-popover')) return;
+    // Bail only on real interactive controls, not the `.track-controls` grid
+    // container whose empty cells/gaps (e.g. right of FX) must still select. #280
+    if ((e.target as HTMLElement).closest('button, input, select, .audio-track-faders, .audio-track-popover')) return;
     setTargetTrack(track.id);
     if (isMixerTrack) {
       useTimelineStore.getState().selectTrackProperties(track.id);


### PR DESCRIPTION
The header click-to-select handler bailed on the entire `.track-controls` container. On mixer (audio/MIDI) strips that container is a CSS grid whose last row leaves empty cells/gaps (notably to the right of the FX button), so clicking that dead space failed to select the track.

Narrow the guard to real interactive controls (button/input/select and the fader/popover regions) instead of the whole container. Every button already stopPropagation, so empty grid space now falls through and selects the track while buttons keep their own behavior.