### PR TITLE
Fix issue batch UI regressions

### DIFF
--- a/docs/Features/UI-Panels.md
+++ b/docs/Features/UI-Panels.md
@@ -109,6 +109,7 @@ All docked panels can be:
 
 - `Undock to Window` opens a dock tab as a separate browser window
 - The detached browser window renders the selected panel through the main editor runtime, so edits and controls affect the main app state
+- Detached browser windows keep their last local position and size across refreshes
 - The detached browser window can return the panel to the main layout with `Dock back`
 
 ---
@@ -458,6 +459,7 @@ Multi Preview, scopes, and other panels are available from the View menu and can
 
 - The dock layout is persisted with Zustand and project state
 - Floating panels are restored across sessions
+- Browser window panels are restored from local dock state on refresh and stay connected when project layout hydration runs
 - Invalid panel types are cleaned up on load
 - Named layouts can be stored in the View menu and reused later
 - The active named layout can be overwritten directly with `Save to Current Layout`

--- a/src/components/dock/DetachedPanelWindow.tsx
+++ b/src/components/dock/DetachedPanelWindow.tsx
@@ -9,18 +9,22 @@ interface DetachedPanelWindowProps {
   windowPanel: BrowserWindowPanel;
 }
 
-function getPopupFeatures(): string {
+function getDefaultPopupSize(): { width: number; height: number } {
+  return {
+    width: Math.min(1120, Math.max(760, Math.round(window.screen.availWidth * 0.56))),
+    height: Math.min(880, Math.max(540, Math.round(window.screen.availHeight * 0.72))),
+  };
+}
+
+function getPopupFeatures(savedBounds?: Pick<BrowserWindowPanel, 'position' | 'size'>): string {
   const screenWithOffset = window.screen as Screen & { availLeft?: number; availTop?: number };
-  const width = Math.min(1120, Math.max(760, Math.round(window.screen.availWidth * 0.56)));
-  const height = Math.min(880, Math.max(540, Math.round(window.screen.availHeight * 0.72)));
-  const left = Math.max(
-    0,
-    Number(screenWithOffset.availLeft ?? 0) + Math.round((window.screen.availWidth - width) / 2)
-  );
-  const top = Math.max(
-    0,
-    Number(screenWithOffset.availTop ?? 0) + Math.round((window.screen.availHeight - height) / 2)
-  );
+  const fallbackSize = getDefaultPopupSize();
+  const width = savedBounds?.size ? Math.max(320, Math.round(savedBounds.size.width)) : fallbackSize.width;
+  const height = savedBounds?.size ? Math.max(240, Math.round(savedBounds.size.height)) : fallbackSize.height;
+  const fallbackLeft = Number(screenWithOffset.availLeft ?? 0) + Math.round((window.screen.availWidth - width) / 2);
+  const fallbackTop = Number(screenWithOffset.availTop ?? 0) + Math.round((window.screen.availHeight - height) / 2);
+  const left = savedBounds?.position ? Math.round(savedBounds.position.left) : fallbackLeft;
+  const top = savedBounds?.position ? Math.round(savedBounds.position.top) : fallbackTop;
 
   return [
     'popup=yes',
@@ -75,11 +79,32 @@ function createWindowDocument(popup: Window, title: string): HTMLElement | null 
   return popup.document.getElementById('detached-panel-window-root');
 }
 
+function getWindowBounds(popup: Window): { width: number; height: number; left: number; top: number } | null {
+  if (popup.closed) return null;
+  const legacyWindow = popup as Window & { screenLeft?: number; screenTop?: number };
+  const width = Math.round(popup.outerWidth || popup.innerWidth || 0);
+  const height = Math.round(popup.outerHeight || popup.innerHeight || 0);
+  const left = Math.round(popup.screenX || legacyWindow.screenLeft || 0);
+  const top = Math.round(popup.screenY || legacyWindow.screenTop || 0);
+  if (width <= 0 || height <= 0) return null;
+  return { width, height, left, top };
+}
+
 export function DetachedPanelWindow({ windowPanel }: DetachedPanelWindowProps) {
   const dockBrowserWindowPanel = useDockStore((state) => state.dockBrowserWindowPanel);
+  const updateBrowserWindowPanelSize = useDockStore((state) => state.updateBrowserWindowPanelSize);
   const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
   const popupRef = useRef<Window | null>(null);
   const closingFromAppRef = useRef(false);
+  const mainUnloadingRef = useRef(false);
+  const initialBoundsRef = useRef<Pick<BrowserWindowPanel, 'position' | 'size'>>({
+    position: windowPanel.position,
+    size: windowPanel.size,
+  });
+  const lastBoundsRef = useRef<Pick<BrowserWindowPanel, 'position' | 'size'>>({
+    position: windowPanel.position,
+    size: windowPanel.size,
+  });
 
   const dockBack = useCallback(() => {
     closingFromAppRef.current = true;
@@ -88,7 +113,10 @@ export function DetachedPanelWindow({ windowPanel }: DetachedPanelWindowProps) {
   }, [dockBrowserWindowPanel, windowPanel.id]);
 
   useEffect(() => {
-    const popup = window.open('', `masterselects_panel_${windowPanel.id}`, getPopupFeatures());
+    closingFromAppRef.current = false;
+    mainUnloadingRef.current = false;
+
+    const popup = window.open('', `masterselects_panel_${windowPanel.id}`, getPopupFeatures(initialBoundsRef.current));
     if (!popup) {
       dockBrowserWindowPanel(windowPanel.id);
       return undefined;
@@ -107,7 +135,11 @@ export function DetachedPanelWindow({ windowPanel }: DetachedPanelWindowProps) {
       }
     };
     const handleMainUnload = () => {
+      const bounds = getWindowBounds(popup);
+      if (bounds) updateBrowserWindowPanelSize(windowPanel.id, bounds);
+      mainUnloadingRef.current = true;
       closingFromAppRef.current = true;
+      popup.removeEventListener('beforeunload', handlePopupUnload);
       popup.close();
     };
 
@@ -136,6 +168,26 @@ export function DetachedPanelWindow({ windowPanel }: DetachedPanelWindowProps) {
         dockBrowserWindowPanel(windowPanel.id);
       }
     }, 500);
+    const sizePoll = window.setInterval(() => {
+      const bounds = getWindowBounds(popup);
+      if (!bounds) return;
+      const previousSize = lastBoundsRef.current.size;
+      const previousPosition = lastBoundsRef.current.position;
+      if (
+        !previousSize ||
+        !previousPosition ||
+        Math.abs(previousSize.width - bounds.width) > 2 ||
+        Math.abs(previousSize.height - bounds.height) > 2 ||
+        Math.abs(previousPosition.left - bounds.left) > 2 ||
+        Math.abs(previousPosition.top - bounds.top) > 2
+      ) {
+        lastBoundsRef.current = {
+          position: { left: bounds.left, top: bounds.top },
+          size: { width: bounds.width, height: bounds.height },
+        };
+        updateBrowserWindowPanelSize(windowPanel.id, bounds);
+      }
+    }, 1000);
 
     return () => {
       closingFromAppRef.current = true;
@@ -143,14 +195,14 @@ export function DetachedPanelWindow({ windowPanel }: DetachedPanelWindowProps) {
       styleObserver.disconnect();
       themeObserver.disconnect();
       window.clearInterval(closedPoll);
+      window.clearInterval(sizePoll);
       window.removeEventListener('beforeunload', handleMainUnload);
       popup.removeEventListener('beforeunload', handlePopupUnload);
-      if (!popup.closed) {
-        popup.close();
-      }
+      const bounds = getWindowBounds(popup);
+      if (bounds) updateBrowserWindowPanelSize(windowPanel.id, bounds);
       popupRef.current = null;
     };
-  }, [dockBrowserWindowPanel, windowPanel.id, windowPanel.panel.title]);
+  }, [dockBrowserWindowPanel, updateBrowserWindowPanelSize, windowPanel.id, windowPanel.panel.title]);
 
   if (!portalRoot) {
     return null;

--- a/src/components/panels/flashboard/FlashBoardPopovers.css
+++ b/src/components/panels/flashboard/FlashBoardPopovers.css
@@ -546,7 +546,21 @@
   overflow: hidden;
 }
 
-.fb-bubble-bar.has-inline-submenu .fb-pill-group .fb-popover-pills,
+.fb-bubble-bar.has-inline-submenu .fb-pill-group .fb-popover-pills {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  align-items: flex-start;
+  gap: 4px;
+  height: auto;
+  margin: 0;
+  max-height: 52px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
 .fb-bubble-bar.has-inline-submenu .fb-pill-group .fb-audio-actions {
   display: flex;
   flex: 0 0 24px;
@@ -561,9 +575,14 @@
 }
 
 .fb-bubble-bar.has-inline-submenu .fb-pill-group .fb-model-category-tabs::-webkit-scrollbar,
-.fb-bubble-bar.has-inline-submenu .fb-pill-group .fb-popover-pills::-webkit-scrollbar,
 .fb-bubble-bar.has-inline-submenu .fb-pill-group .fb-audio-actions::-webkit-scrollbar {
   display: none;
+}
+
+.fb-bubble-bar.has-inline-submenu .fb-pill-group .fb-popover-pills::-webkit-scrollbar {
+  display: block;
+  width: 6px;
+  height: 6px;
 }
 
 .fb-bubble-bar.has-inline-submenu .fb-pill-group .fb-model-category-tab,

--- a/src/components/panels/flashboard/useFlashBoardReferenceCommands.ts
+++ b/src/components/panels/flashboard/useFlashBoardReferenceCommands.ts
@@ -106,9 +106,6 @@ export function useFlashBoardReferenceCommands({
       }
 
       patch.startMediaFileId = mediaFileId;
-      if (composerEndMediaFileId === mediaFileId) {
-        patch.endMediaFileId = undefined;
-      }
     } else {
       if (composerEndMediaFileId && composerEndMediaFileId !== mediaFileId) {
         nextReferenceMediaFileIds = moveMediaFileIdToReferences(
@@ -120,9 +117,6 @@ export function useFlashBoardReferenceCommands({
       }
 
       patch.endMediaFileId = mediaFileId;
-      if (composerStartMediaFileId === mediaFileId) {
-        patch.startMediaFileId = undefined;
-      }
     }
 
     updateComposer({

--- a/src/components/panels/media/panel/useMediaPanelRenameDeleteCommands.ts
+++ b/src/components/panels/media/panel/useMediaPanelRenameDeleteCommands.ts
@@ -165,6 +165,18 @@ export function useMediaPanelRenameDeleteCommands({
   }, [selectedIds, startRename]);
 
   const deleteSelectedItems = useCallback(async (idsToDelete: string[], fileIdsToDelete: string[]) => {
+    const fileIdSet = new Set(fileIdsToDelete);
+    const compositionIds = new Set(compositions.map((item) => item.id));
+    const folderIds = new Set(folders.map((item) => item.id));
+    const textItemIds = new Set(textItems.map((item) => item.id));
+    const solidItemIds = new Set(solidItems.map((item) => item.id));
+    const meshItemIds = new Set(meshItems.map((item) => item.id));
+    const cameraItemIds = new Set(cameraItems.map((item) => item.id));
+    const splatEffectorItemIds = new Set(splatEffectorItems.map((item) => item.id));
+    const mathSceneItemIds = new Set(mathSceneItems.map((item) => item.id));
+    const motionShapeItemIds = new Set(motionShapeItems.map((item) => item.id));
+    const signalAssetIds = new Set(signalAssets.map((item) => item.id));
+
     if (fileIdsToDelete.length > 0) {
       const result = await deleteMediaFilesEverywhere(fileIdsToDelete);
       if (result.artifactFailures.length > 0) {
@@ -173,24 +185,25 @@ export function useMediaPanelRenameDeleteCommands({
     }
 
     idsToDelete.forEach(id => {
-      if (fileIdsToDelete.includes(id)) return;
-      if (compositions.find(c => c.id === id)) removeComposition(id);
-      else if (folders.find(f => f.id === id)) removeFolder(id);
-      else if (textItems.find(t => t.id === id)) removeTextItem(id);
-      else if (solidItems.find(s => s.id === id)) removeSolidItem(id);
-      else if (meshItems.find(m => m.id === id)) removeMeshItem(id);
-      else if (cameraItems.find(c => c.id === id)) removeCameraItem(id);
-      else if (splatEffectorItems.find(e => e.id === id)) removeSplatEffectorItem(id);
-      else if (mathSceneItems.find(m => m.id === id)) removeMathSceneItem(id);
-      else if (motionShapeItems.find(m => m.id === id)) removeMotionShapeItem(id);
-      else if (signalAssets.find(item => item.id === id)) removeSignalAsset(id);
+      if (fileIdSet.has(id)) return;
+      if (compositionIds.has(id)) removeComposition(id);
+      else if (folderIds.has(id)) removeFolder(id);
+      else if (textItemIds.has(id)) removeTextItem(id);
+      else if (solidItemIds.has(id)) removeSolidItem(id);
+      else if (meshItemIds.has(id)) removeMeshItem(id);
+      else if (cameraItemIds.has(id)) removeCameraItem(id);
+      else if (splatEffectorItemIds.has(id)) removeSplatEffectorItem(id);
+      else if (mathSceneItemIds.has(id)) removeMathSceneItem(id);
+      else if (motionShapeItemIds.has(id)) removeMotionShapeItem(id);
+      else if (signalAssetIds.has(id)) removeSignalAsset(id);
     });
     closeContextMenu();
   }, [compositions, folders, textItems, solidItems, meshItems, cameraItems, splatEffectorItems, mathSceneItems, motionShapeItems, signalAssets, deleteMediaFilesEverywhere, removeSignalAsset, removeComposition, removeFolder, removeTextItem, removeSolidItem, removeMeshItem, removeCameraItem, removeSplatEffectorItem, removeMathSceneItem, removeMotionShapeItem, closeContextMenu]);
 
   const handleDelete = useCallback(async () => {
-    const selectedFileIds = selectedIds.filter(id => files.some(file => file.id === id));
-    const selectedFiles = files.filter(file => selectedFileIds.includes(file.id));
+    const selectedIdSet = new Set(selectedIds);
+    const selectedFiles = files.filter(file => selectedIdSet.has(file.id));
+    const selectedFileIds = selectedFiles.map((file) => file.id);
 
     if (selectedFiles.length > 0) {
       const usages = getMediaFileUsages(selectedFileIds);

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -401,6 +401,7 @@ export function Timeline() {
     copyClipColor: timelineActions.copyClipColor,
     copyClipEffects: timelineActions.copyClipEffects,
     deleteAllGaps: timelineActions.deleteAllGaps,
+    deleteClipSelection: timelineActions.deleteClipSelection,
     deleteGapAtTime: timelineActions.deleteGapAtTime,
     duration,
     generateSpectrogramForClip: timelineActions.generateSpectrogramForClip,

--- a/src/components/timeline/TimelineContextMenu.tsx
+++ b/src/components/timeline/TimelineContextMenu.tsx
@@ -52,6 +52,7 @@ interface TimelineContextMenuProps {
   removeClip: (clipId: string) => void;
   splitClipAtPlayhead: () => void;
   rippleDeleteSelection: (clipIds?: string[]) => void;
+  deleteClipSelection: (clipIds?: string[]) => void;
   deleteGapAtTime: (time: number) => void;
   toggleClipReverse: (clipId: string) => void;
   unlinkGroup: (clipId: string) => void;
@@ -91,6 +92,7 @@ export function TimelineContextMenu({
   removeClip,
   splitClipAtPlayhead,
   rippleDeleteSelection,
+  deleteClipSelection,
   deleteGapAtTime,
   toggleClipReverse,
   unlinkGroup,
@@ -223,6 +225,7 @@ export function TimelineContextMenu({
   const timelineActions = {
     splitClipAtPlayhead,
     rippleDeleteSelection,
+    deleteClipSelection,
     deleteGapAtTime,
     linkClips,
     unlinkClips,

--- a/src/components/timeline/hooks/useTimelineStableActionBindings.ts
+++ b/src/components/timeline/hooks/useTimelineStableActionBindings.ts
@@ -31,6 +31,7 @@ export function useTimelineStableActionBindings() {
     copyClips: store.copyClips,
     copyKeyframes: store.copyKeyframes,
     deleteAllGaps: store.deleteAllGaps,
+    deleteClipSelection: store.deleteClipSelection,
     deleteGapAtTime: store.deleteGapAtTime,
     deselectAllKeyframes: store.deselectAllKeyframes,
     generateSpectrogramForClip: store.generateSpectrogramForClip,

--- a/src/components/timeline/utils/clipContextMenu.ts
+++ b/src/components/timeline/utils/clipContextMenu.ts
@@ -445,8 +445,7 @@ export function executeClipContextMenuTimelineCommand(input: {
       input.actions.createSubcompositionFromSelection(input.clipId);
       return true;
     case 'delete-clip':
-      if (!input.clipId) return false;
-      input.actions.removeClip(input.clipId);
+      input.actions.deleteClipSelection([...input.targetClipIds]);
       return true;
   }
 }

--- a/src/components/timeline/utils/clipContextMenuTypes.ts
+++ b/src/components/timeline/utils/clipContextMenuTypes.ts
@@ -195,6 +195,7 @@ export type ClipContextMenuTimelineCommand =
 export interface ClipContextMenuTimelineActions {
   splitClipAtPlayhead: () => void;
   rippleDeleteSelection: (clipIds?: string[]) => void;
+  deleteClipSelection: (clipIds?: string[]) => void;
   deleteGapAtTime: (time: number) => void;
   linkClips: (clipIds: string[]) => void;
   unlinkClips: (clipIds: string[]) => void;

--- a/src/services/midi/midiBindingMutations.ts
+++ b/src/services/midi/midiBindingMutations.ts
@@ -200,6 +200,7 @@ export function setParameterMIDIBinding(
     message,
     min: existingBinding?.min ?? target.min,
     max: existingBinding?.max ?? target.max,
+    currentValue: target.currentValue ?? existingBinding?.currentValue,
     invert: existingBinding?.invert,
     damping: existingBinding?.damping,
   });

--- a/src/stores/dockStore/index.ts
+++ b/src/stores/dockStore/index.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand';
 import { subscribeWithSelector, persist } from 'zustand/middleware';
 import { FACTORY_VIDEO_EDIT_LAYOUT_ID } from './panelRegistry';
 import {
+  cleanupPersistedBrowserWindowPanels,
   cleanupRestoredCurrentLayout,
   cleanupSavedLayout,
   mergeFactoryDockLayouts,
@@ -43,6 +44,7 @@ export const useDockStore = create<DockStoreState>()(
         name: 'webvj-dock-layout',
         partialize: (state) => ({
           layout: state.layout,
+          browserWindowPanels: state.browserWindowPanels,
           maxZIndex: state.maxZIndex,
           savedLayouts: state.savedLayouts,
           defaultSavedLayoutId: state.defaultSavedLayoutId,
@@ -53,6 +55,7 @@ export const useDockStore = create<DockStoreState>()(
           const savedLayouts = Array.isArray(persisted?.savedLayouts)
             ? mergeFactoryDockLayouts(persisted.savedLayouts.map(cleanupSavedLayout))
             : mergeFactoryDockLayouts(currentState.savedLayouts);
+          const browserWindowPanels = cleanupPersistedBrowserWindowPanels(persisted?.browserWindowPanels);
           const defaultSavedLayoutId = (
             typeof persisted?.defaultSavedLayoutId === 'string'
             && savedLayouts.some((savedLayout) => savedLayout.id === persisted.defaultSavedLayoutId)
@@ -74,6 +77,7 @@ export const useDockStore = create<DockStoreState>()(
             return {
               ...currentState,
               layout: cleanedLayout,
+              browserWindowPanels,
               maxZIndex: persisted.maxZIndex ?? currentState.maxZIndex,
               savedLayouts,
               defaultSavedLayoutId,
@@ -82,6 +86,7 @@ export const useDockStore = create<DockStoreState>()(
           }
           return {
             ...currentState,
+            browserWindowPanels,
             savedLayouts,
             defaultSavedLayoutId,
             activeSavedLayoutId,

--- a/src/stores/dockStore/layoutMutationActions.ts
+++ b/src/stores/dockStore/layoutMutationActions.ts
@@ -284,6 +284,24 @@ export const createLayoutMutationActions: DockSliceCreator<LayoutMutationActions
     }));
   },
 
+  updateBrowserWindowPanelSize: (windowPanelId, size) => {
+    if (!Number.isFinite(size.width) || !Number.isFinite(size.height)) return;
+    const nextSize = {
+      width: Math.max(320, Math.round(size.width)),
+      height: Math.max(240, Math.round(size.height)),
+    };
+    const nextPosition = typeof size.left === 'number' && typeof size.top === 'number' && Number.isFinite(size.left) && Number.isFinite(size.top)
+      ? { left: Math.round(size.left), top: Math.round(size.top) }
+      : undefined;
+    set((state) => ({
+      browserWindowPanels: state.browserWindowPanels.map((windowPanel) =>
+        windowPanel.id === windowPanelId
+          ? { ...windowPanel, size: nextSize, position: nextPosition ?? windowPanel.position }
+          : windowPanel
+      ),
+    }));
+  },
+
   updateFloatingPosition: (floatingId, position) => {
     set((state) => ({
       layout: {

--- a/src/stores/dockStore/layoutPersistence.ts
+++ b/src/stores/dockStore/layoutPersistence.ts
@@ -1,4 +1,12 @@
-import type { DockLayout, DockNode, DockPanel, FloatingPanel, PanelType, SavedDockLayout } from '../../types/dock';
+import type {
+  BrowserWindowPanel,
+  DockLayout,
+  DockNode,
+  DockPanel,
+  FloatingPanel,
+  PanelType,
+  SavedDockLayout,
+} from '../../types/dock';
 import { DEFAULT_LAYOUT, FACTORY_SAVED_DOCK_LAYOUTS } from './layoutDefaults';
 import { cleanupSavedTimelineLayout } from './timelineLayoutPersistence';
 import {
@@ -16,6 +24,10 @@ interface NormalizedDockPanel {
 
 interface NormalizedFloatingPanel {
   floatingPanel: FloatingPanel;
+}
+
+interface NormalizedBrowserWindowPanel {
+  browserWindowPanel: BrowserWindowPanel;
 }
 
 
@@ -43,6 +55,37 @@ function normalizeFloatingPanel(floatingPanel: FloatingPanel): NormalizedFloatin
     floatingPanel: {
       ...floatingPanel,
       panel: normalizedDockPanel.panel,
+    },
+  };
+}
+
+function normalizeBrowserWindowPanel(windowPanel: BrowserWindowPanel): NormalizedBrowserWindowPanel | null {
+  const normalizedDockPanel = normalizeDockPanel(windowPanel.panel);
+  if (!normalizedDockPanel) {
+    return null;
+  }
+
+  const width = windowPanel.size?.width;
+  const height = windowPanel.size?.height;
+  const size = typeof width === 'number' && typeof height === 'number' && Number.isFinite(width) && Number.isFinite(height)
+    ? {
+        width: Math.max(320, Math.round(width)),
+        height: Math.max(240, Math.round(height)),
+      }
+    : undefined;
+  const left = windowPanel.position?.left;
+  const top = windowPanel.position?.top;
+  const position = typeof left === 'number' && typeof top === 'number' && Number.isFinite(left) && Number.isFinite(top)
+    ? { left: Math.round(left), top: Math.round(top) }
+    : undefined;
+
+  return {
+    browserWindowPanel: {
+      ...windowPanel,
+      panel: normalizedDockPanel.panel,
+      returnGroupId: typeof windowPanel.returnGroupId === 'string' ? windowPanel.returnGroupId : null,
+      size,
+      position,
     },
   };
 }
@@ -82,6 +125,14 @@ export function cleanupPersistedLayout(layout: DockLayout): DockLayout {
       .filter((panel): panel is NormalizedFloatingPanel => panel !== null)
       .map((candidate) => candidate.floatingPanel),
   };
+}
+
+export function cleanupPersistedBrowserWindowPanels(windowPanels: BrowserWindowPanel[] | undefined): BrowserWindowPanel[] {
+  if (!Array.isArray(windowPanels)) return [];
+  return windowPanels
+    .map(normalizeBrowserWindowPanel)
+    .filter((panel): panel is NormalizedBrowserWindowPanel => panel !== null)
+    .map((candidate) => candidate.browserWindowPanel);
 }
 
 export function cloneDockLayout(layout: DockLayout): DockLayout {

--- a/src/stores/dockStore/savedLayoutActions.ts
+++ b/src/stores/dockStore/savedLayoutActions.ts
@@ -1,4 +1,4 @@
-import type { DockLayout, SavedDockLayout, SavedDockTimelineLayout } from '../../types/dock';
+import type { BrowserWindowPanel, DockLayout, SavedDockLayout, SavedDockTimelineLayout } from '../../types/dock';
 import { Logger } from '../../services/logger';
 import { DEFAULT_LAYOUT } from './layoutDefaults';
 import {
@@ -13,11 +13,38 @@ import {
   applySavedTimelineLayout,
   captureTimelineLayout,
 } from './timelineLayoutAdapter';
+import { findGroupIdByPanelId } from './layoutTree';
+import { collapseSingleChildSplits, removePanel } from '../../utils/dockLayout';
 import type { DockSliceCreator, SavedLayoutActions } from './storeTypes';
 
 const log = Logger.create('DockStore');
 const LEGACY_DEFAULT_LAYOUT_STORAGE_KEY = 'webvj-dock-layout-default';
 const DEFAULT_TIMELINE_LAYOUT_STORAGE_KEY = 'webvj-dock-layout-default-timeline';
+
+function removeBrowserWindowPanelsFromLayout(
+  layout: DockLayout,
+  windowPanels: readonly BrowserWindowPanel[],
+): DockLayout {
+  if (windowPanels.length === 0) return layout;
+
+  const panelIds = new Set(windowPanels.map((windowPanel) => windowPanel.panel.id));
+  let nextLayout: DockLayout = {
+    ...layout,
+    floatingPanels: layout.floatingPanels.filter((floating) => !panelIds.has(floating.panel.id)),
+  };
+
+  for (const panelId of panelIds) {
+    const groupId = findGroupIdByPanelId(nextLayout.root, panelId);
+    if (!groupId) continue;
+    const layoutWithoutPanel = removePanel(nextLayout, panelId, groupId);
+    nextLayout = {
+      ...layoutWithoutPanel,
+      root: collapseSingleChildSplits(layoutWithoutPanel.root),
+    };
+  }
+
+  return nextLayout;
+}
 
 export const createSavedLayoutActions: DockSliceCreator<SavedLayoutActions> = (set, get) => ({
   saveNamedLayout: (name) => {
@@ -226,10 +253,14 @@ export const createSavedLayoutActions: DockSliceCreator<SavedLayoutActions> = (s
   },
 
   setLayoutFromProject: (layout: DockLayout) => {
-    const cleanedLayout = cleanupPersistedLayout(layout);
+    const browserWindowPanels = get().browserWindowPanels;
+    const cleanedLayout = removeBrowserWindowPanelsFromLayout(
+      cleanupPersistedLayout(layout),
+      browserWindowPanels,
+    );
     set({
       layout: cleanedLayout,
-      browserWindowPanels: [],
+      browserWindowPanels,
       maxZIndex: getLayoutMaxZIndex(cleanedLayout),
       hoveredTabTarget: null,
       maximizedPanelId: null,

--- a/src/stores/dockStore/storeTypes.ts
+++ b/src/stores/dockStore/storeTypes.ts
@@ -21,6 +21,10 @@ export interface LayoutMutationActions {
   dockFloatingPanel: (floatingId: string, target: DropTarget) => void;
   detachPanelToBrowserWindow: (panelId: string, groupId: string) => BrowserWindowPanel | null;
   dockBrowserWindowPanel: (windowPanelId: string, target?: DropTarget) => void;
+  updateBrowserWindowPanelSize: (
+    windowPanelId: string,
+    size: { width: number; height: number; left?: number; top?: number },
+  ) => void;
   updateFloatingPosition: (floatingId: string, position: { x: number; y: number }) => void;
   updateFloatingSize: (floatingId: string, size: { width: number; height: number }) => void;
   bringToFront: (floatingId: string) => void;

--- a/src/stores/timeline/editOperations/applyTimelineEditOperation.ts
+++ b/src/stores/timeline/editOperations/applyTimelineEditOperation.ts
@@ -612,6 +612,13 @@ export const createTimelineEditOperationSlice: SliceCreator<TimelineEditOperatio
     includeLinked: true,
   }, { source: 'ui', historyLabel: 'Ripple delete selection' }),
 
+  deleteClipSelection: (clipIds) => get().applyTimelineEditOperation({
+    id: `delete-clips:${Date.now()}`,
+    type: 'delete-clips',
+    clipIds: clipIds ?? [...get().selectedClipIds],
+    includeLinked: true,
+  }, { source: 'ui', historyLabel: 'Delete clips' }),
+
   deleteGapAtTime: (time, trackIds) => get().applyTimelineEditOperation({
     id: `delete-gap-at-time:${time}`,
     type: 'delete-gap-at-time',

--- a/src/stores/timeline/playbackSlice.ts
+++ b/src/stores/timeline/playbackSlice.ts
@@ -450,7 +450,9 @@ export const createPlaybackSlice: SliceCreator<PlaybackActions> = (set, get) => 
     stopTimelineAudioPlayback();
     playheadState.position = 0;
     stopInternalPosition();
-    set({ isPlaying: false, playheadPosition: 0, playbackWarmup: null });
+    set({ isPlaying: false, playheadPosition: 0, playbackWarmup: null, scrollX: 0 });
+    renderHostPort.setIsPlaying(false);
+    renderHostPort.requestNewFrameRender();
   },
 
   // View actions

--- a/src/stores/timeline/storeTypes/playbackActionTypes.ts
+++ b/src/stores/timeline/storeTypes/playbackActionTypes.ts
@@ -99,6 +99,7 @@ export interface TimelineEditOperationActions {
     },
   ) => TimelineEditResult;
   rippleDeleteSelection: (clipIds?: string[]) => TimelineEditResult;
+  deleteClipSelection: (clipIds?: string[]) => TimelineEditResult;
   deleteGapAtTime: (time: number, trackIds?: string[]) => TimelineEditResult;
   deleteAllGaps: (trackIds?: string[], startTime?: number) => TimelineEditResult;
   trimSelectedClipEdgeToPlayhead: (edge: 'start' | 'end') => TimelineEditResult;

--- a/src/types/dock.ts
+++ b/src/types/dock.ts
@@ -85,12 +85,15 @@ export interface FloatingPanel {
   zIndex: number;
 }
 
-// Detached browser window panel. This is transient UI state only; it is not
-// persisted into saved/project layouts because it owns a live Window handle.
+// Detached browser window panel. Persisted only in the local dock store so a
+// browser refresh can rebuild detached windows; saved/project layouts still
+// store docked and floating panels only.
 export interface BrowserWindowPanel {
   id: string;
   panel: DockPanel;
   returnGroupId: string | null;
+  size?: { width: number; height: number };
+  position?: { left: number; top: number };
 }
 
 // Root layout state

--- a/tests/helpers/storeFactory.ts
+++ b/tests/helpers/storeFactory.ts
@@ -184,7 +184,7 @@ export function createTestTimelineStore(overrides?: Partial<TimelineStore>) {
         set({ isPlaying: true, playheadPosition: playbackStartPosition });
       },
       pause: () => set({ isPlaying: false, playbackSpeed: 1 }),
-      stop: () => set({ isPlaying: false, playheadPosition: 0 }),
+      stop: () => set({ isPlaying: false, playheadPosition: 0, scrollX: 0 }),
       setZoom: (zoom: number) => set({ zoom: Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom)) }),
       toggleSnapping: () => set((state) => ({ snappingEnabled: !state.snappingEnabled })),
       setScrollX: (scrollX: number) => set({ scrollX: Math.max(0, scrollX) }),

--- a/tests/stores/timeline/playbackSlice.test.ts
+++ b/tests/stores/timeline/playbackSlice.test.ts
@@ -53,11 +53,12 @@ describe('playbackSlice', () => {
     expect(store.getState().playbackSpeed).toBe(1);
   });
 
-  it('stop: sets isPlaying false and resets playhead to 0', () => {
-    store.setState({ isPlaying: true, playheadPosition: 30 });
+  it('stop: sets isPlaying false, resets playhead, and scrolls to the start', () => {
+    store.setState({ isPlaying: true, playheadPosition: 30, scrollX: 500 });
     store.getState().stop();
     expect(store.getState().isPlaying).toBe(false);
     expect(store.getState().playheadPosition).toBe(0);
+    expect(store.getState().scrollX).toBe(0);
   });
 
   it('stop: works when already stopped', () => {

--- a/tests/unit/TimelineContextMenu.test.tsx
+++ b/tests/unit/TimelineContextMenu.test.tsx
@@ -44,6 +44,7 @@ function renderMenu(params: {
   removeClip?: ReturnType<typeof vi.fn>;
   splitClipAtPlayhead?: ReturnType<typeof vi.fn>;
   rippleDeleteSelection?: ReturnType<typeof vi.fn>;
+  deleteClipSelection?: ReturnType<typeof vi.fn>;
   createSubcompositionFromSelection?: ReturnType<typeof vi.fn>;
   copyClipEffects?: ReturnType<typeof vi.fn>;
   copyClipColor?: ReturnType<typeof vi.fn>;
@@ -58,6 +59,7 @@ function renderMenu(params: {
   const removeClip = params.removeClip ?? vi.fn();
   const splitClipAtPlayhead = params.splitClipAtPlayhead ?? vi.fn();
   const rippleDeleteSelection = params.rippleDeleteSelection ?? vi.fn();
+  const deleteClipSelection = params.deleteClipSelection ?? vi.fn();
   const createSubcompositionFromSelection = params.createSubcompositionFromSelection ?? vi.fn();
   const copyClipEffects = params.copyClipEffects ?? vi.fn();
   const copyClipColor = params.copyClipColor ?? vi.fn();
@@ -78,6 +80,7 @@ function renderMenu(params: {
       removeClip={removeClip}
       splitClipAtPlayhead={splitClipAtPlayhead}
       rippleDeleteSelection={rippleDeleteSelection}
+      deleteClipSelection={deleteClipSelection}
       deleteGapAtTime={deleteGapAtTime}
       toggleClipReverse={vi.fn()}
       unlinkGroup={vi.fn()}
@@ -110,6 +113,7 @@ function renderMenu(params: {
     removeClip,
     splitClipAtPlayhead,
     rippleDeleteSelection,
+    deleteClipSelection,
     createSubcompositionFromSelection,
     copyClipEffects,
     copyClipColor,
@@ -300,6 +304,7 @@ describe('TimelineContextMenu regenerate menu', () => {
     const removeClip = vi.fn();
     const splitClipAtPlayhead = vi.fn();
     const rippleDeleteSelection = vi.fn();
+    const deleteClipSelection = vi.fn();
     const createSubcompositionFromSelection = vi.fn();
     const copyClipEffects = vi.fn();
     const copyClipColor = vi.fn();
@@ -310,6 +315,7 @@ describe('TimelineContextMenu regenerate menu', () => {
       removeClip,
       splitClipAtPlayhead,
       rippleDeleteSelection,
+      deleteClipSelection,
       createSubcompositionFromSelection,
       copyClipEffects,
       copyClipColor,
@@ -328,6 +334,7 @@ describe('TimelineContextMenu regenerate menu', () => {
     expect(copyClipColor).not.toHaveBeenCalled();
     expect(splitClipAtPlayhead).not.toHaveBeenCalled();
     expect(rippleDeleteSelection).not.toHaveBeenCalled();
+    expect(deleteClipSelection).not.toHaveBeenCalled();
     expect(createSubcompositionFromSelection).not.toHaveBeenCalled();
     expect(removeClip).not.toHaveBeenCalled();
     expect(setContextMenu).not.toHaveBeenCalled();

--- a/tests/unit/clipContextMenu.test.ts
+++ b/tests/unit/clipContextMenu.test.ts
@@ -592,6 +592,7 @@ describe('clip context menu model', () => {
     const actions = {
       splitClipAtPlayhead: vi.fn(),
       rippleDeleteSelection: vi.fn(),
+      deleteClipSelection: vi.fn(),
       deleteGapAtTime: vi.fn(),
       linkClips: vi.fn(),
       unlinkClips: vi.fn(),
@@ -627,11 +628,11 @@ describe('clip context menu model', () => {
       command: 'delete-clip',
       clip: clip('clip-a'),
       clipId: 'clip-a',
-      targetClipIds: ['clip-a'],
+      targetClipIds: ['clip-a', 'clip-b'],
       canExecute: true,
       actions,
     })).toBe(true);
-    expect(actions.removeClip).toHaveBeenCalledWith('clip-a');
+    expect(actions.deleteClipSelection).toHaveBeenCalledWith(['clip-a', 'clip-b']);
 
     expect(executeClipContextMenuTimelineCommand({
       command: 'toggle-reverse',
@@ -648,6 +649,7 @@ describe('clip context menu model', () => {
     const timelineActions = {
       splitClipAtPlayhead: vi.fn(),
       rippleDeleteSelection: vi.fn(),
+      deleteClipSelection: vi.fn(),
       deleteGapAtTime: vi.fn(),
       linkClips: vi.fn(),
       unlinkClips: vi.fn(),
@@ -741,6 +743,7 @@ describe('clip context menu model', () => {
     expect(clipboardActions.pasteClipEffects).not.toHaveBeenCalled();
     expect(timelineActions.splitClipAtPlayhead).not.toHaveBeenCalled();
     expect(timelineActions.rippleDeleteSelection).not.toHaveBeenCalled();
+    expect(timelineActions.deleteClipSelection).not.toHaveBeenCalled();
     expect(timelineActions.deleteGapAtTime).not.toHaveBeenCalled();
     expect(timelineActions.createSubcompositionFromSelection).not.toHaveBeenCalled();
     expect(timelineActions.removeClip).not.toHaveBeenCalled();

--- a/tests/unit/dockStoreLayouts.test.ts
+++ b/tests/unit/dockStoreLayouts.test.ts
@@ -166,6 +166,10 @@ describe('dock store saved layouts', () => {
     expect(layout.floatingPanels).toEqual([]);
     expect(useDockStore.getState().browserWindowPanels).toEqual([windowPanel]);
 
+    useDockStore.getState().updateBrowserWindowPanelSize(windowPanel!.id, { width: 913.4, height: 601.8, left: 77.6, top: 44.2 });
+    expect(useDockStore.getState().browserWindowPanels[0]?.size).toEqual({ width: 913, height: 602 });
+    expect(useDockStore.getState().browserWindowPanels[0]?.position).toEqual({ left: 78, top: 44 });
+
     useDockStore.getState().dockBrowserWindowPanel(windowPanel!.id, {
       groupId: 'preview-group',
       position: 'center',
@@ -191,6 +195,19 @@ describe('dock store saved layouts', () => {
     const layout = useDockStore.getState().layout;
     const rightGroup = findTabGroup(layout.root, 'right-group');
     expect(panelTypes(rightGroup).filter((type) => type === 'export')).toHaveLength(1);
+  });
+
+  it('keeps browser-window panels open when hydrating a project layout', () => {
+    const projectLayout = JSON.parse(JSON.stringify(useDockStore.getState().layout)) as DockLayout;
+    const windowPanel = useDockStore.getState().detachPanelToBrowserWindow('export', 'right-group');
+
+    expect(windowPanel).not.toBeNull();
+
+    useDockStore.getState().setLayoutFromProject(projectLayout);
+
+    const rightGroup = findTabGroup(useDockStore.getState().layout.root, 'right-group');
+    expect(useDockStore.getState().browserWindowPanels).toEqual([windowPanel]);
+    expect(panelTypes(rightGroup)).toEqual(['clip-properties', 'history']);
   });
 
   it('drops retired dock panel payload ids from restored project layouts', () => {

--- a/tests/unit/midiBindingMutations.test.ts
+++ b/tests/unit/midiBindingMutations.test.ts
@@ -214,6 +214,35 @@ describe('midiBindingMutations', () => {
     });
   });
 
+  it('preserves the last parameter value when re-learning a mapped value without one', () => {
+    setParameterMIDIBinding({
+      clipId: 'clip-param',
+      property: 'opacity',
+      label: 'Opacity',
+      min: 0,
+      max: 1,
+      currentValue: 0.42,
+    }, {
+      type: 'control-change',
+      channel: 1,
+      control: 7,
+    });
+
+    setParameterMIDIBinding({
+      clipId: 'clip-param',
+      property: 'opacity',
+      label: 'Opacity',
+      min: 0,
+      max: 1,
+    }, {
+      type: 'control-change',
+      channel: 1,
+      control: 8,
+    });
+
+    expect(useMIDIStore.getState().parameterBindings['parameter:clip-param:opacity']?.currentValue).toBe(0.42);
+  });
+
   it('keeps active mapping highlights transient and timestamp-safe', () => {
     const state = useMIDIStore.getState();
     state.markMappingActive('parameter:clip-param:opacity', 100);


### PR DESCRIPTION
Fixes #286
Fixes #285
Fixes #284
Fixes #279
Fixes #278
Fixes #277

Notes:
- Detached browser windows preserve/reopen with their saved bounds and stay connected after project layout hydration.
- Timeline stop scrolls back to the start, MIDI relearn preserves current values, FlashBoard reference/aspect controls are corrected, and timeline delete uses the batch path.

Checks:
- npm run build: passed before the final no-test commit request.
- npm run lint: passed before the final no-test commit request.
- npm run test: skipped for final commit/merge per request; previous full-suite runs only hit unrelated timeouts in tests/unit/workerPresentingRenderHostPort.test.ts.