### PR TITLE
Analysis action-center redesign + kernel default-on via Pages proxy

### DIFF
--- a/docs/Features/Face-Analysis.md
+++ b/docs/Features/Face-Analysis.md
@@ -37,53 +37,51 @@ Select an analyzed video clip to see its boxes, landmarks, and anonymous person
 labels over the Preview. Existing yellow face markers remain available on the
 timeline. The timeline assigns every anonymous person a stable colour: their
 sample dots and source-time range bands share that colour. The Analysis tab
-combines source-time facts in one workspace. Its compact map aligns scenes,
+combines source-time facts in one workspace. Its collapsible compact map aligns scenes,
 cuts, speech, people, motion, focus, quality, audio, and text with the
-playhead. Below it, one virtualized scene list shows larger speaker face crops,
-word-synchronized dialogue, and scene time in compact scene blobs. Clicking a
-blob expands the scene-scoped identity tools, facts, descriptions, quality
-notices, and transcript in place.
+playhead. Below it, one virtualized scene list fills the remaining panel height
+and shows visible face crops with separate diarized-speaker abbreviations,
+word-synchronized dialogue, and scene time in compact scene blobs. Face IDs and
+speaker labels remain distinct until an explicit mapping exists. Scene blobs
+stay compact and never expand; clicking a word or scene time seeks directly to
+that source position.
 
-Expanded scenes keep contextual People and Needs Review controls. Clicking a
-person filters the virtualized scene list; **Next appearance** advances through
-that identity's source-time appearances. Person identities and individual
-appearance crops remain draggable correction sources. Dropping one onto another
-person merges a false split or moves that appearance. Small yellow detections
-that are unsafe to identify are consolidated into short visual tracks without
-claiming an identity; their scene-scoped review crops can be clicked to seek or
-dragged onto a confirmed person to assign the track manually. These previews
-are resolved only for the bounded virtualized window and open scene, stay in a
-bounded browser-memory cache, and are also persisted as versioned JPEGs under
+Person identities and individual appearance crops remain draggable correction
+sources inside Analysis settings. Dropping one onto another person merges a
+false split or moves that appearance. Small yellow detections that are unsafe
+to identify are consolidated into short visual tracks without claiming an
+identity; their review crops can be clicked to seek or dragged onto a confirmed
+person to assign the track manually. These previews stay in a bounded
+browser-memory cache and are also persisted as versioned JPEGs under
 `Cache/face-thumbnails` so they load without video seeks after a refresh or
 project reopen.
 
-Below the virtualized scene list, the complete detected-person strip restores
-the correction surface for source-wide work: representative found-frame crops,
-all appearances, person-to-person merge, appearance reassign, and review-track
-assignment by drag and drop. It uses the same durable face correction services
-as scene cards; no second people state is stored. Face crops are requested only
-once their tile is near the viewport. Equal crop requests share the existing
-pending/blob cache, so scrolling does not enqueue a fresh video seek for every
-rendered card.
+Analysis settings contain the complete detected-person strip for source-wide
+correction work: representative found-frame crops, all appearances,
+person-to-person merge, appearance reassign, and review-track assignment by
+drag and drop. It uses the same durable face correction services as scene
+cards; no second people state is stored. Face crops are requested only once
+their tile is near the viewport. Equal crop requests share the existing
+pending/blob cache.
 
-The top of the Analysis tab exposes separate action rows for **Focus & Motion**,
-**Faces**, **Scene Cuts**, **Transcript**, and **AI Scenes**. Every row can be analyzed,
-reanalyzed, retried, or cancelled without clearing the other results. A
+The top of the Analysis tab exposes compact status pills for **Focus & Motion**,
+**Faces**, **Cuts**, **Transcript**, and **AI Scenes**. Every pill can analyze,
+reanalyze, retry, continue, or cancel without clearing the other results. A
 metrics-only pass preserves compatible face observations. A face-only pass
 reuses existing focus and motion samples; when no metrics exist yet, it creates
 the inexpensive metrics baseline during the same source decode. At normal
-Properties widths the actions form one compact three-column grid (with
-responsive two- and one-column fallbacks). **Analyze All** creates a coalesced
+Properties widths the pills wrap naturally beside **Analyze all** and a compact
+settings disclosure. **Analyze All** creates a coalesced
 job graph: repeated clicks observe the same run, compatible completed channels
 are reused, Focus/Faces and the cut scan serialize on the shared source decoder,
 and independent transcript work may proceed in parallel. AI scene descriptions
 remain a separate opt-in action because they can incur provider cost and share
 visual content externally.
 
-Above those rows, compact **Scope** (`Source`, `Used Ranges`, `Selection`,
-`In-Out`) and **Profile** (`Quick`, `Balanced`, `Deep`, `Custom`) controls show
-uncached duration, cache reuse, known frame/sample work, relative cost, and a
-benchmark-derived time range when one exists. **Quick** (1 fps) and
+The settings disclosure separates shared visual-analysis controls from
+transcript controls. Compact **Scope** (`Source`, `Used Ranges`, `Selection`,
+`In-Out`) and **Profile** (`Quick`, `Balanced`, `Deep`, `Custom`) choices stay
+visible without estimate or explanatory rows. **Quick** (1 fps) and
 **Balanced** (2 fps) are execution settings for local Focus/Motion and Faces:
 the runner receives the selected clipped source range and explicit sample
 cadence. Used Ranges, Selection, and overlapping In/Out therefore analyze only
@@ -216,9 +214,9 @@ to use WebGPU for rendering.
 
 Faces smaller than 36 pixels in the 640-pixel analysis frame are intentionally
 excluded from automatic identity grouping. They remain visible as yellow
-Preview overlays and as scene-scoped **Needs review** crops in the Analysis
-workspace, because title-card grids and background footage are too small for
-dependable anonymous matching.
+Preview overlays and as **Needs review** crops in Analysis settings, because
+title-card grids and background footage are too small for dependable anonymous
+matching.
 
 ## Models and licenses
 

--- a/docs/Features/UI-Panels.md
+++ b/docs/Features/UI-Panels.md
@@ -374,31 +374,35 @@ same source-handle edges.
 | **Masks** | Mask shapes with mode and feather controls |
 | **Analysis** | Shared analysis map, transcript controls, and compact scene blobs with faces, synchronized dialogue, cuts, metrics, quality, and descriptions |
 
-The Analysis workspace uses one source-time model for its graph and scene
-list. Each virtualized scene blob keeps speaker face crops on the left, larger
+The Analysis workspace uses one source-time model for its collapsible graph and
+segment list. Visual scene boundaries remain unchanged in the graph, while the
+list independently divides long dialogue into readable speech segments. Speaker
+changes and long pauses are hard natural boundaries; sentence endings nearest
+the 10-second target are preferred, and unpunctuated speech is split at a word
+boundary before 15 seconds. This keeps talking-head footage navigable even when
+cut detection returns one long scene. The list consumes all remaining panel
+height and owns its scroll. Each virtualized segment keeps visible face crops on
+the left with a separate transcript-speaker abbreviation beside them, larger
 word-synchronized dialogue in the center, and range/duration on the right.
-The flat inspector directly beneath the graph replaces the former Current
-Frame and Summary boxes with playhead metrics and clip-wide counters. Clicking
-a blob expands its scene-scoped people, appearances, identity correction drop
-targets, review detections, camera/focus/motion facts, description provenance,
-coverage, quality notices, OCR, and transcript in place. Person chips filter
-the scene list, while **Next appearance** advances in source time. Face crops
-remain lazy because only the bounded virtualized window and the open scene
-resolve thumbnails. Contextual People and Needs Review controls stay in their
-expanded scene; the source-wide correction strip follows the list.
+Speaker labels are not silently equated with anonymous face identities. Segments
+remain compact and never expand. Clicking a word seeks to that exact word;
+clicking the time seeks to the speech-segment start (or the scene start when no
+speech exists). Redundant playhead and clip-summary statistics are omitted. Face
+crops remain lazy because only the bounded virtualized window resolves
+thumbnails.
 
-The scene list is followed by a compact source-wide people/review strip for
-the complete correction workflow. It deliberately reuses the same person and
-review identities as scene cards: drag a person to merge, an appearance to
-move it, or a review track to assign it. Crop loading is viewport-lazy while
-the virtualized scene window and crop cache keep scrolling bounded.
+The source-wide people/review correction strip lives in Analysis settings so
+the normal scene list stays focused. It deliberately reuses the same person
+and review identities as scene cards: drag a person to merge, an appearance to
+move it, or a review track to assign it. Crop loading remains viewport-lazy.
 
-The Action Center above the map uses the same flat 2px control treatment as
-the rest of Properties. Its analysis actions use three compact equal-height
-cards per row at normal panel widths, with integrated status and action
-controls instead of full-width button bars. Scope and profile selectors update
-a read-only estimate before any work starts, including cached reuse and known
-frame/sample counts. A matching real-device benchmark adds a time range.
+The Action Center above the map is a single compact row of status pills using
+the same flat control treatment as Export. Each pill exposes its channel state
+and triggers analyze, reanalyze, continue, retry, or cancel as appropriate.
+**Analyze all** and a settings button complete the row. The settings disclosure
+uses separate compact areas for shared visual-analysis controls and transcript
+controls. It keeps only control titles, scope/profile choices, language/mode,
+and actions visible; estimates and explanatory copy do not push the map down.
 Quick/Balanced Focus/Motion and Faces execute with the selected source interval
 and sampling cadence; frame-accurate cuts remain source-wide. Deep/Custom stay
 blocked without qualifying evidence. **Analyze All** deliberately excludes AI
@@ -407,10 +411,11 @@ provider cost and share visual content externally.
 
 Analysis contains the transcript workspace header for provider and language
 selection, start/continue/cancel/clear, fusion progress, coverage, and shared
-search. The same search filters the virtualized scene list. Words are grouped
-into timestamped speaker turns; clicking a compact or expanded word seeks the
-playhead to that source position. During playback, the currently spoken word
-and speaker turn are highlighted and the active scene transcript follows them.
+search. The same search filters individual rows in the virtualized segment list.
+Words are grouped into timestamped speaker turns and readable timed segments;
+clicking a word seeks the playhead to that source position. During playback, the
+currently spoken word and active speech segment are highlighted and the list
+follows them when that segment is visible under the current search filter.
 Scrubbing updates the same highlight without animated lag.
 
 Best Quality uses a fixed provider split: Deepgram supplies every displayed word

--- a/functions/api/kernel/[[path]].ts
+++ b/functions/api/kernel/[[path]].ts
@@ -1,0 +1,70 @@
+import { json, methodNotAllowed } from '../../lib/db';
+import type { AppContext, AppRouteHandler } from '../../lib/env';
+
+const DEFAULT_KERNEL_ORIGIN = 'https://fassandra.de';
+// Story compiles include provider planning rounds plus the director run.
+const FORWARD_TIMEOUT_MS = 240_000;
+
+interface AllowedRoute {
+  methods: string[];
+  pattern: RegExp;
+  requiresUser: boolean;
+}
+
+const ALLOWED_ROUTES: AllowedRoute[] = [
+  { methods: ['GET'], pattern: /^health$/, requiresUser: false },
+  { methods: ['POST'], pattern: /^compile$/, requiresUser: true },
+  { methods: ['POST'], pattern: /^runs\/[A-Za-z0-9._:-]+\/complete$/, requiresUser: true },
+];
+
+function resolvePath(context: AppContext): string {
+  const raw = (context.params as Record<string, unknown>).path;
+  if (Array.isArray(raw)) {
+    return raw.map(String).join('/');
+  }
+  return typeof raw === 'string' ? raw : '';
+}
+
+export const onRequest: AppRouteHandler = async (context: AppContext): Promise<Response> => {
+  const path = resolvePath(context);
+  const route = ALLOWED_ROUTES.find((candidate) => candidate.pattern.test(path));
+  if (!route) {
+    return json({ error: 'Unknown kernel route.' }, { status: 404 });
+  }
+  if (!route.methods.includes(context.request.method)) {
+    return methodNotAllowed(route.methods);
+  }
+  if (route.requiresUser && !context.data.user) {
+    return json({ error: 'Sign in to use the kernel service.' }, { status: 401 });
+  }
+
+  const token = context.env.KERNEL_AUTH_TOKEN?.trim();
+  if (!token) {
+    return json({ error: 'Kernel service is not configured.' }, { status: 503 });
+  }
+
+  const origin = context.env.KERNEL_ORIGIN?.trim().replace(/\/+$/, '') || DEFAULT_KERNEL_ORIGIN;
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    Authorization: `Bearer ${token}`,
+  };
+  const init: RequestInit = {
+    method: context.request.method,
+    headers,
+    signal: AbortSignal.timeout(FORWARD_TIMEOUT_MS),
+  };
+  if (context.request.method !== 'GET') {
+    headers['Content-Type'] = 'application/json';
+    init.body = await context.request.text();
+  }
+
+  try {
+    const upstream = await fetch(`${origin}/kernel/${path}`, init);
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+    });
+  } catch {
+    return json({ error: 'Kernel service is unreachable.' }, { status: 502 });
+  }
+};

--- a/functions/lib/env.ts
+++ b/functions/lib/env.ts
@@ -54,6 +54,8 @@ export interface Env {
   ELEVENLABS_API_KEY?: string;
   GOOGLE_CLIENT_ID?: string;
   GOOGLE_CLIENT_SECRET?: string;
+  KERNEL_AUTH_TOKEN?: string;
+  KERNEL_ORIGIN?: string;
   KIEAI_API_KEY?: string;
   KIEAI_GENERATION_RATE_LIMITER?: AppDurableObjectNamespace;
   KV: AppKVNamespace;

--- a/src/components/panels/properties/AnalysisActionCenter.css
+++ b/src/components/panels/properties/AnalysisActionCenter.css
@@ -1,31 +1,173 @@
 .analysis-action-center {
+  display: grid;
+  gap: 6px;
+  padding: 8px 10px;
+}
+
+.analysis-action-bar {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 6px;
 }
 
-.analysis-action-heading,
-.analysis-action-row,
-.analysis-action-buttons {
+.analysis-action-bar h4 {
+  flex: 0 0 auto;
+  margin: 0 4px 0 0;
+  color: var(--text-primary);
+  font-size: 15px;
+  line-height: 30px;
+}
+
+.analysis-action-pills {
+  display: contents;
+}
+
+.analysis-action-pill,
+.analysis-action-all,
+.analysis-action-settings {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  height: 29px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary);
+  font: var(--font-normal) 11px/1 var(--font-family);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+}
+
+.analysis-action-pill {
+  gap: 5px;
+  padding: 0 11px;
+  border-radius: 999px;
+}
+
+.analysis-action-pill span {
+  overflow: hidden;
+  max-width: 120px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.analysis-action-pill strong {
+  font: inherit;
+  font-variant-numeric: tabular-nums;
+}
+
+.analysis-action-pill.state-ready {
+  border-color: color-mix(in srgb, var(--success-light) 34%, transparent);
+  background: color-mix(in srgb, var(--success-light) 10%, transparent);
+  color: var(--success-light);
+}
+
+.analysis-action-pill--transcript.state-ready {
+  border-color: color-mix(in srgb, var(--warning) 38%, transparent);
+  background: color-mix(in srgb, var(--warning) 11%, transparent);
+  color: var(--warning);
+}
+
+.analysis-action-pill--descriptions.state-ready {
+  border-color: color-mix(in srgb, var(--accent) 38%, transparent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--accent);
+}
+
+.analysis-action-pill.state-analyzing,
+.analysis-action-pill.state-transcribing,
+.analysis-action-pill.state-describing {
+  border-color: color-mix(in srgb, var(--accent) 48%, transparent);
+  background: color-mix(in srgb, var(--accent) 13%, transparent);
+  color: var(--accent);
+}
+
+.analysis-action-pill.state-error {
+  border-color: color-mix(in srgb, var(--danger-light) 45%, transparent);
+  background: color-mix(in srgb, var(--danger-light) 10%, transparent);
+  color: var(--danger-light);
+}
+
+.analysis-action-pill.state-none {
+  border-style: dashed;
+  color: var(--text-muted);
+}
+
+.analysis-action-pill:hover:not(:disabled),
+.analysis-action-all:hover:not(:disabled),
+.analysis-action-settings:hover:not(:disabled),
+.analysis-action-settings.is-open {
+  border-color: color-mix(in srgb, currentColor 55%, var(--border-color));
+  background: color-mix(in srgb, currentColor 9%, transparent);
+  color: var(--text-primary);
+}
+
+.analysis-action-pill:focus-visible,
+.analysis-action-all:focus-visible,
+.analysis-action-settings:focus-visible,
+.analysis-choice:focus-visible,
+.analysis-action-clear:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.analysis-action-pill:disabled,
+.analysis-action-all:disabled,
+.analysis-action-settings:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.analysis-action-all {
+  padding: 0 12px;
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+}
+
+.analysis-action-settings {
+  width: 34px;
+  padding: 0;
+  border-radius: var(--radius-sm);
+}
+
+.analysis-action-advanced {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+  padding-top: 7px;
+  border-top: 1px solid var(--border-color);
+}
+
+.analysis-settings-area {
+  display: grid;
+  align-content: start;
+  gap: 7px;
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-secondary) 72%, transparent);
+}
+
+.analysis-settings-area__title {
   display: flex;
   align-items: center;
-}
-
-.analysis-action-heading {
-  justify-content: space-between;
-  gap: 6px;
-}
-
-.analysis-action-heading h4 {
-  margin: 0;
-}
-
-.analysis-configuration {
-  display: grid;
   gap: 5px;
-  border-top: 1px solid var(--border-color);
-  border-bottom: 1px solid var(--border-color);
-  padding: 6px 0;
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--font-xs);
+  font-weight: var(--font-semibold);
+  line-height: 1;
+}
+
+.analysis-settings-area__divider {
+  color: var(--text-muted);
+}
+
+.analysis-settings-area--people {
+  grid-column: 1 / -1;
 }
 
 .analysis-configuration__groups {
@@ -43,7 +185,7 @@
 
 .analysis-choice-group__label {
   color: var(--text-muted);
-  font-size: var(--font-xs);
+  font-size: var(--font-2xs);
   font-weight: var(--font-semibold);
   text-transform: uppercase;
 }
@@ -57,13 +199,14 @@
 .analysis-choice {
   min-width: 0;
   overflow: hidden;
+  height: 25px;
   border: 1px solid var(--border-color);
   border-right: 0;
   border-radius: 0;
   background: var(--bg-tertiary);
   color: var(--text-secondary);
-  padding: 3px 4px;
-  font: var(--font-normal) var(--font-xs)/1.25 var(--font-family);
+  padding: 0 4px;
+  font: var(--font-normal) var(--font-xs)/1 var(--font-family);
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;
@@ -83,13 +226,6 @@
   color: var(--text-primary);
 }
 
-.analysis-choice:focus-visible {
-  position: relative;
-  z-index: 1;
-  outline: 1px solid var(--accent);
-  outline-offset: -1px;
-}
-
 .analysis-choice--active {
   border-color: var(--accent);
   background: var(--accent-dim);
@@ -106,152 +242,58 @@
   opacity: 0.55;
 }
 
-.analysis-estimate {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 2px 8px;
-  color: var(--text-muted);
-  font-size: var(--font-2xs);
-  line-height: 1.35;
-}
-
-.analysis-estimate__cost {
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-  padding: 1px 3px;
-  font-weight: var(--font-semibold);
-  text-transform: uppercase;
-}
-
-.analysis-estimate__cost--moderate {
-  border-color: var(--warning);
-}
-
-.analysis-estimate__cost--high {
-  border-color: var(--danger);
-  color: var(--danger-light);
-}
-
-.analysis-estimate__cost--custom {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-
-.analysis-configuration__note {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: var(--font-2xs);
-  line-height: 1.35;
-}
-
-.analysis-action-global-buttons {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 3px;
-}
-
-.analysis-action-list {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1px;
-  overflow: hidden;
-  padding: 1px;
-  border-radius: var(--radius-sm);
-  background: var(--border-color);
-}
-
-.analysis-action-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  justify-content: space-between;
-  gap: 6px;
-  height: 100%;
-  min-height: 46px;
-  padding: 5px 6px;
+.analysis-action-advanced .transcript-workspace-header {
+  gap: 0;
+  padding: 0;
   border: 0;
   border-radius: 0;
-  background: var(--bg-secondary);
+  background: transparent;
 }
 
-.analysis-action-copy {
-  display: grid;
-  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
-  align-items: baseline;
-  gap: 1px 6px;
-  min-width: 0;
+.analysis-action-advanced .transcript-command-row {
+  align-items: stretch;
+  flex-direction: column;
 }
 
-.analysis-action-title {
-  color: var(--text-primary);
-  font-size: 11px;
-  font-weight: var(--font-semibold);
-  white-space: nowrap;
+.analysis-action-advanced .transcript-command-actions {
+  justify-content: flex-end;
 }
 
-.analysis-action-detail,
-.analysis-action-status {
-  overflow: hidden;
-  color: var(--text-muted);
-  font-size: 10px;
-  line-height: 1.25;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.analysis-action-detail {
+.analysis-action-advanced__footer {
+  display: flex;
   grid-column: 1 / -1;
+  justify-content: flex-end;
 }
 
-.analysis-action-status {
-  justify-self: end;
+.analysis-action-clear {
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  padding: 3px 5px;
+  font: var(--font-normal) var(--font-xs)/1 var(--font-family);
+  cursor: pointer;
 }
 
-.analysis-action-status.state-ready {
-  color: var(--success-light);
-}
-
-.analysis-action-status.state-analyzing,
-.analysis-action-status.state-describing,
-.analysis-action-status.state-transcribing {
-  color: var(--accent);
-}
-
-.analysis-action-status.state-error {
+.analysis-action-clear:hover:not(:disabled) {
   color: var(--danger-light);
 }
 
-.analysis-action-buttons {
-  flex: 0 0 auto;
-  flex-wrap: nowrap;
-  justify-content: flex-end;
-  gap: 3px;
-}
-
-.analysis-action-buttons .btn {
-  flex: 0 0 auto;
-  min-width: 0;
-  min-height: 23px;
-  padding: 2px 6px;
-  font-size: 10px;
-  white-space: nowrap;
+.analysis-action-clear:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
 }
 
 @media (max-width: 520px) {
+  .analysis-action-bar h4 {
+    flex-basis: 100%;
+    line-height: 20px;
+  }
+
   .analysis-configuration__groups {
     grid-template-columns: 1fr;
   }
 
-  .analysis-action-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 320px) {
-  .analysis-action-list {
+  .analysis-action-advanced {
     grid-template-columns: 1fr;
   }
 }

--- a/src/components/panels/properties/AnalysisActionCenter.tsx
+++ b/src/components/panels/properties/AnalysisActionCenter.tsx
@@ -1,3 +1,12 @@
+import { useState, type ReactNode } from 'react';
+import {
+  IconActivity,
+  IconCut,
+  IconFileText,
+  IconSettings,
+  IconSparkles,
+  IconUsers,
+} from '@tabler/icons-react';
 import type { AnalysisStatus } from '../../../types/clipMetadata';
 import type {
   AgentTimelineAnalysisEstimate,
@@ -25,6 +34,7 @@ interface AnalysisAction {
 
 interface AnalysisActionCenterProps {
   actions: readonly AnalysisAction[];
+  advancedControls?: ReactNode;
   configuration?: AnalysisActionConfiguration;
   analyzeAllDisabled?: boolean;
   analyzeAllRunning?: boolean;
@@ -55,77 +65,67 @@ function isRunning(state: ActionState): boolean {
   return state === 'analyzing' || state === 'describing' || state === 'transcribing';
 }
 
-function actionLabel(state: ActionState): string {
-  if (state === 'ready') return 'Reanalyze';
-  if (state === 'error') return 'Retry';
+function actionIntent(action: AnalysisAction): string {
+  if (isRunning(action.state)) return 'Cancel';
+  if (action.secondaryAction) return action.secondaryAction.label;
+  if (action.state === 'ready') return 'Reanalyze';
+  if (action.state === 'error') return 'Retry';
   return 'Analyze';
 }
 
-function AnalysisActionRow({ action }: { action: AnalysisAction }) {
+function compactStatus(action: AnalysisAction): string | undefined {
+  const leadingValue = action.statusText.match(/^(\d+(?:\.\d+)?%?)/)?.[1];
+  if (isRunning(action.state)) return leadingValue ?? '…';
+  if (action.state === 'error') return '!';
+  if (action.state !== 'ready') return undefined;
+  if (action.id === 'metrics' && leadingValue === '100%') return undefined;
+  return leadingValue;
+}
+
+function ActionIcon({ id }: { id: string }) {
+  const props = { 'aria-hidden': true, size: 15, stroke: 1.9 } as const;
+  if (id === 'metrics') return <IconActivity {...props} />;
+  if (id === 'faces') return <IconUsers {...props} />;
+  if (id === 'cuts') return <IconCut {...props} />;
+  if (id === 'transcript') return <IconFileText {...props} />;
+  return <IconSparkles {...props} />;
+}
+
+function AnalysisActionPill({ action }: { action: AnalysisAction }) {
   const running = isRunning(action.state);
+  const status = compactStatus(action);
+  const onClick = running
+    ? (action.onCancel ?? action.onRun)
+    : (action.secondaryAction?.onClick ?? action.onRun);
   return (
-    <div className="analysis-action-row">
-      <div className="analysis-action-copy">
-        <span className="analysis-action-title">{action.title}</span>
-        <span className="analysis-action-detail">{action.detail}</span>
-        <span className={`analysis-action-status state-${action.state}`}>
-          {action.statusText}
-        </span>
-      </div>
-      <div className="analysis-action-buttons">
-        {action.secondaryAction && !running && (
-          <button
-            type="button"
-            className="btn btn-sm btn-accent"
-            onClick={action.secondaryAction.onClick}
-            disabled={action.disabled}
-          >
-            {action.secondaryAction.label}
-          </button>
-        )}
-        <button
-          type="button"
-          className={`btn btn-sm${running ? ' btn-danger' : ''}`}
-          onClick={running ? action.onCancel : action.onRun}
-          disabled={action.disabled && !running}
-        >
-          {running ? 'Cancel' : actionLabel(action.state)}
-        </button>
-      </div>
-    </div>
+    <button
+      type="button"
+      className={[
+        'analysis-action-pill',
+        `state-${action.state}`,
+        `analysis-action-pill--${action.id}`,
+      ].join(' ')}
+      disabled={Boolean(action.disabled && !running)}
+      onClick={onClick}
+      title={`${action.detail} · ${action.statusText} · ${actionIntent(action)}`}
+    >
+      <ActionIcon id={action.id} />
+      <span>{action.title}</span>
+      {status && <strong>{status}</strong>}
+    </button>
   );
 }
 
-function formatDuration(seconds: number): string {
-  if (!Number.isFinite(seconds) || seconds <= 0) return '0s';
-  if (seconds < 60) return `${Math.round(seconds)}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remainder = Math.round(seconds % 60);
-  return remainder > 0 ? `${minutes}m ${remainder}s` : `${minutes}m`;
-}
-
-function formatWork(estimate: AgentTimelineAnalysisEstimate, channel: string): string | undefined {
-  const entry = estimate.channels.find((candidate) => candidate.channel === channel);
-  if (!entry?.workItemKind || entry.estimatedWorkItems === undefined) return undefined;
-  const label = entry.workItemKind === 'candidate-samples'
-    ? 'candidate samples'
-    : entry.workItemKind;
-  return `${entry.estimatedWorkItems.toLocaleString()} ${label}`;
-}
-
 function AnalysisConfigurationControls({ configuration }: { configuration: AnalysisActionConfiguration }) {
-  const { estimate } = configuration;
-  const work = estimate
-    ? [
-      formatWork(estimate, 'cuts'),
-      formatWork(estimate, 'quality'),
-      formatWork(estimate, 'people'),
-      formatWork(estimate, 'text'),
-    ].filter((item): item is string => Boolean(item))
-    : [];
-
   return (
-    <section className="analysis-configuration" aria-label="Analysis scope and profile">
+    <section className="analysis-settings-area" aria-label="Focus, motion, and face settings">
+      <h5 className="analysis-settings-area__title">
+        <IconActivity aria-hidden="true" size={14} stroke={1.9} />
+        <span>Focus &amp; motion</span>
+        <span className="analysis-settings-area__divider">/</span>
+        <IconUsers aria-hidden="true" size={14} stroke={1.9} />
+        <span>Faces</span>
+      </h5>
       <div className="analysis-configuration__groups">
         <div className="analysis-choice-group" role="group" aria-label="Analysis scope">
           <span className="analysis-choice-group__label">Scope</span>
@@ -162,32 +162,13 @@ function AnalysisConfigurationControls({ configuration }: { configuration: Analy
           </div>
         </div>
       </div>
-      <div className="analysis-estimate" aria-live="polite">
-        {estimate ? (
-          <>
-            <span className={`analysis-estimate__cost analysis-estimate__cost--${estimate.relativeCost}`}>
-              {estimate.relativeCost} cost
-            </span>
-            <span>{formatDuration(estimate.uncachedDurationSeconds)} uncached / {formatDuration(estimate.totalDurationSeconds)}</span>
-            {work.length > 0 && <span>{work.join(' · ')}</span>}
-            <span>{estimate.channels.reduce((total, entry) => total + entry.reusableDurationSeconds, 0) > 0
-              ? 'Warm-cache artifacts reused'
-              : 'No reusable artifacts in this scope'}</span>
-            <span>{estimate.estimatedWallTimeSeconds
-              ? `${formatDuration(estimate.estimatedWallTimeSeconds.minimum)}–${formatDuration(estimate.estimatedWallTimeSeconds.maximum)} on ${estimate.estimatedWallTimeSeconds.deviceClass}`
-              : 'Time estimate awaits a matching device benchmark'}</span>
-          </>
-        ) : (
-          <span>{configuration.estimateUnavailableReason ?? 'Choose an available scope to preview work.'}</span>
-        )}
-      </div>
-      <p className="analysis-configuration__note">{configuration.executionNote}</p>
     </section>
   );
 }
 
 export function AnalysisActionCenter({
   actions,
+  advancedControls,
   configuration,
   analyzeAllDisabled = false,
   analyzeAllRunning = false,
@@ -195,33 +176,49 @@ export function AnalysisActionCenter({
   onAnalyzeAll,
   onClearAll,
 }: AnalysisActionCenterProps) {
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   return (
-    <div className="properties-section analysis-action-center">
-      <div className="analysis-action-heading">
+    <section className="properties-section analysis-action-center">
+      <div className="analysis-action-bar">
         <h4>Analysis</h4>
-        <div className="analysis-action-global-buttons">
-          <button
-            type="button"
-            className="btn btn-sm btn-accent"
-            onClick={onAnalyzeAll}
-            disabled={analyzeAllDisabled}
-          >
-            {analyzeAllRunning ? 'Analyzing All…' : 'Analyze All'}
-          </button>
-          <button
-            type="button"
-            className="btn btn-sm btn-danger"
-            onClick={onClearAll}
-            disabled={clearDisabled}
-          >
-            Clear Analysis
-          </button>
+        <div className="analysis-action-pills">
+          {actions.map((action) => <AnalysisActionPill key={action.id} action={action} />)}
         </div>
+        <button
+          type="button"
+          className="analysis-action-all"
+          onClick={onAnalyzeAll}
+          disabled={analyzeAllDisabled}
+        >
+          {analyzeAllRunning ? 'Analyzing…' : 'Analyze all'}
+        </button>
+        <button
+          type="button"
+          className={`analysis-action-settings${advancedOpen ? ' is-open' : ''}`}
+          aria-expanded={advancedOpen}
+          aria-label="Analysis settings"
+          title="Analysis settings"
+          onClick={() => setAdvancedOpen((open) => !open)}
+        >
+          <IconSettings aria-hidden="true" size={16} stroke={1.9} />
+        </button>
       </div>
-      {configuration && <AnalysisConfigurationControls configuration={configuration} />}
-      <div className="analysis-action-list">
-        {actions.map(action => <AnalysisActionRow key={action.id} action={action} />)}
-      </div>
-    </div>
+      {advancedOpen && (
+        <div className="analysis-action-advanced">
+          {configuration && <AnalysisConfigurationControls configuration={configuration} />}
+          {advancedControls}
+          <div className="analysis-action-advanced__footer">
+            <button
+              type="button"
+              className="analysis-action-clear"
+              onClick={onClearAll}
+              disabled={clearDisabled}
+            >
+              Clear analysis
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
   );
 }

--- a/src/components/panels/properties/AnalysisPeopleSettings.tsx
+++ b/src/components/panels/properties/AnalysisPeopleSettings.tsx
@@ -1,0 +1,57 @@
+import { IconUsers } from '@tabler/icons-react';
+import type { FaceReviewCandidate } from '../../../services/faceAnalysis/faceReviewCandidates';
+import type { FacePersonSummary, FrameAnalysisData } from '../../../types/clipMetadata';
+import { FacePeopleSummary } from './FacePeopleSummary';
+import { FaceReviewSummary } from './FaceReviewSummary';
+
+interface AnalysisPeopleSettingsProps {
+  candidates: readonly FaceReviewCandidate[];
+  frames: readonly FrameAnalysisData[];
+  people: readonly FacePersonSummary[];
+  sourceFile?: File;
+  onAssignReviewFaces: (candidateId: string, faceIds: string[], targetPersonId: string) => void;
+  onMergePeople: (sourcePersonId: string, targetPersonId: string) => void;
+  onMoveAppearance: (sourcePersonId: string, targetPersonId: string, sourceTime: number) => void;
+  onSelectSourceTime: (sourceTime: number) => void;
+}
+
+export function AnalysisPeopleSettings({
+  candidates,
+  frames,
+  people,
+  sourceFile,
+  onAssignReviewFaces,
+  onMergePeople,
+  onMoveAppearance,
+  onSelectSourceTime,
+}: AnalysisPeopleSettingsProps) {
+  if (people.length === 0 && candidates.length === 0) return null;
+
+  return (
+    <section className="analysis-settings-area analysis-settings-area--people" aria-label="People adjustments">
+      <h5 className="analysis-settings-area__title">
+        <IconUsers aria-hidden="true" size={14} stroke={1.9} />
+        <span>People</span>
+      </h5>
+      {people.length > 0 && (
+        <FacePeopleSummary
+          people={people}
+          frames={frames}
+          sourceFile={sourceFile}
+          onSelectSourceTime={onSelectSourceTime}
+          onMergePeople={onMergePeople}
+          onMoveAppearance={onMoveAppearance}
+          onAssignReviewFaces={onAssignReviewFaces}
+        />
+      )}
+      {candidates.length > 0 && (
+        <FaceReviewSummary
+          candidates={candidates}
+          frames={frames}
+          sourceFile={sourceFile}
+          onSelectSourceTime={onSelectSourceTime}
+        />
+      )}
+    </section>
+  );
+}

--- a/src/components/panels/properties/AnalysisTab.tsx
+++ b/src/components/panels/properties/AnalysisTab.tsx
@@ -3,13 +3,9 @@ import { useMemo, useCallback, useEffect, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useTimelineStore } from '../../../stores/timeline';
 import { useMediaStore } from '../../../stores/mediaStore';
-import { countSceneCutsInSourceRange } from '../../../services/sceneCutDetection/sceneCutRange';
 import { estimateAgentTimelineAnalysis } from '../../../services/agentTimeline/profiles/analysisEstimate';
 import { getAgentTimelineProfileSettings } from '../../../services/agentTimeline/profiles/analysisProfiles';
-import type {
-  AgentTimelineAnalysisEstimate,
-  AgentTimelineAnalysisScopeKind,
-} from '../../../types/agentTimeline/analysisEstimate';
+import type { AgentTimelineAnalysisEstimate, AgentTimelineAnalysisScopeKind } from '../../../types/agentTimeline/analysisEstimate';
 import type { AgentTimelineJobGraphSnapshot } from '../../../types/agentTimeline/jobGraph';
 import type { AgentTimelineProfile, AgentTimelineRange } from '../../../types/agentTimeline/manifest';
 import type {
@@ -21,9 +17,7 @@ import type {
   TranscriptStatus,
   TranscriptWord,
 } from '../../../types/clipMetadata';
-import {
-  AnalysisActionCenter,
-} from './AnalysisActionCenter';
+import { AnalysisActionCenter } from './AnalysisActionCenter';
 import { FaceCropThumbnail } from './FaceCropThumbnail';
 import { collectFaceReviewCandidates } from '../../../services/faceAnalysis/faceReviewCandidates';
 import { collectFacePersonSamples, representativeFacePersonSample } from './facePersonSamples';
@@ -33,16 +27,11 @@ import {
 } from '../../../services/agentTimeline/jobs/currentClipAnalysisExecution';
 import { AnalysisWorkspace } from './analysisWorkspace/AnalysisWorkspace';
 import { buildAnalysisWorkspaceViewModel } from './analysisWorkspace/analysisWorkspaceAdapter';
-import {
-  buildAnalysisWorkspaceTimelineMapping, sourceTimeForAnalysisWorkspacePlayhead, timelineTimeForAnalysisWorkspaceSource,
-} from './analysisWorkspace/analysisWorkspaceOccurrenceMapping';
-import {
-  createAnalysisActionConfiguration,
-  resolveLocalVisualExecution,
-} from './analysisScopeProfileExecution';
-import { TranscriptWorkspaceHeader } from './TranscriptWorkspaceHeader';
+import { buildAnalysisWorkspaceTimelineMapping, sourceTimeForAnalysisWorkspacePlayhead, timelineTimeForAnalysisWorkspaceSource } from './analysisWorkspace/analysisWorkspaceOccurrenceMapping';
+import { createAnalysisActionConfiguration, resolveLocalVisualExecution } from './analysisScopeProfileExecution';
+import { AnalysisTranscriptSettings } from './AnalysisTranscriptSettings';
+import { AnalysisPeopleSettings } from './AnalysisPeopleSettings';
 import { useTranscriptWorkspaceController } from './useTranscriptWorkspaceController';
-
 interface AnalysisTabProps {
   clipId: string;
   analysis: ClipAnalysis | undefined;
@@ -185,15 +174,6 @@ export function AnalysisTab({ clipId, analysis, analysisStatus, analysisProgress
       } : {}),
     },
   }), [analysis, analysisStatus, descStatus, faceStatus, inPoint, isAudioSource, outPoint, sceneCutAnalysis, sceneCutStatus, segments, transcript, transcriptStatus, transcribedRanges]);
-  const cutCount = useMemo(
-    () => countSceneCutsInSourceRange(sceneCutAnalysis?.cuts, inPoint, outPoint),
-    [inPoint, outPoint, sceneCutAnalysis],
-  );
-  const cutCounterText = sceneCutStatus === 'analyzing'
-    ? `Analyzing ${Math.round(sceneCutProgress)}%`
-    : sceneCutAnalysis
-      ? String(cutCount)
-      : '—';
   const usedRange = useMemo(() => range(inPoint, outPoint), [inPoint, outPoint]);
   const fullSourceRange = useMemo(() => range(
     0,
@@ -290,40 +270,6 @@ export function AnalysisTab({ clipId, analysis, analysisStatus, analysisProgress
       disposed = true;
     };
   }, [analysisStatus, clipId, faceStatus]);
-
-  // Calculate current values at playhead
-  const currentValues = useMemo((): FrameAnalysisData | null => {
-    if (!analysis?.frames.length) return null;
-
-    if (sourceTimeAtPlayhead === undefined) return null;
-    const sourceTime = sourceTimeAtPlayhead;
-
-    let closestFrame = analysis.frames[0];
-    let closestDistance = Math.abs(closestFrame.timestamp - sourceTime);
-
-    for (const frame of analysis.frames) {
-      const distance = Math.abs(frame.timestamp - sourceTime);
-      if (distance < closestDistance) {
-        closestDistance = distance;
-        closestFrame = frame;
-      }
-    }
-    return closestFrame;
-  }, [analysis, sourceTimeAtPlayhead]);
-
-  // Stats summary
-  const stats = useMemo(() => {
-    if (!analysis?.frames.length) return null;
-    const frames = analysis.frames;
-    return {
-      avgFocus: Math.round(frames.reduce((s, f) => s + f.focus, 0) / frames.length * 100),
-      avgMotion: Math.round(frames.reduce((s, f) => s + f.motion, 0) / frames.length * 100),
-      maxFocus: Math.round(Math.max(...frames.map(f => f.focus)) * 100),
-      maxMotion: Math.round(Math.max(...frames.map(f => f.motion)) * 100),
-      totalFaces: frames.reduce((s, f) => s + f.faceCount, 0),
-      frameCount: frames.length,
-    };
-  }, [analysis]);
 
   // Calculate coverage of clip's range from analysis frames
   const clipCoverage = useMemo(() => {
@@ -437,7 +383,7 @@ export function AnalysisTab({ clipId, analysis, analysisStatus, analysisProgress
   const analysisActions = useMemo(() => [
     {
       id: 'metrics',
-      title: 'Focus & Motion',
+      title: 'Focus & motion',
       detail: 'Sharpness and optical-flow samples',
       state: analysisStatus,
       statusText: analysisStatus === 'analyzing'
@@ -483,7 +429,7 @@ export function AnalysisTab({ clipId, analysis, analysisStatus, analysisProgress
     },
     {
       id: 'cuts',
-      title: 'Scene Cuts',
+      title: 'Cuts',
       detail: 'Frame-accurate 160×90 source scan',
       state: sceneCutStatus,
       statusText: sceneCutStatus === 'analyzing'
@@ -605,6 +551,14 @@ export function AnalysisTab({ clipId, analysis, analysisStatus, analysisProgress
       {(isVideoSource || isAudioSource) && (
         <AnalysisActionCenter
           actions={visibleAnalysisActions}
+          advancedControls={<>
+            <AnalysisTranscriptSettings controller={transcriptController} transcriptCount={transcript.length}
+              transcriptProgress={transcriptProgress} transcriptStatus={transcriptStatus} />
+            <AnalysisPeopleSettings candidates={faceReviewCandidates} frames={analysis?.frames ?? []} people={facePeople}
+              sourceFile={analysisStatus === 'ready' && faceStatus === 'ready' ? sourceFile : undefined}
+              onAssignReviewFaces={handleAssignReviewFaces} onMergePeople={handleMergePeople}
+              onMoveAppearance={handleMoveAppearance} onSelectSourceTime={handleSeekToSourceTime} />
+          </>}
           configuration={analysisConfiguration}
           analyzeAllDisabled={analyzeAllRunning
             || Boolean(localVisualBlockedReason)
@@ -631,69 +585,9 @@ export function AnalysisTab({ clipId, analysis, analysisStatus, analysisProgress
         isFollowingPlayback={isPlaying || isDraggingPlayhead}
         transcriptSearchQuery={transcriptController.searchQuery}
         onTranscriptSearchChange={transcriptController.onSearchChange}
-        transcriptControls={(
-          <TranscriptWorkspaceHeader
-            activeProvider={transcriptController.activeProvider}
-            clipCoverage={transcriptController.clipCoverage}
-            hasTranscript={transcript.length > 0}
-            isPartial={transcriptController.isPartial}
-            isSignedIn={transcriptController.isSignedIn}
-            language={transcriptController.language}
-            onCancel={transcriptController.onCancel}
-            onContinue={transcriptController.onContinue}
-            onDelete={transcriptController.onClear}
-            onLanguageChange={transcriptController.onLanguageChange}
-            onProviderChange={transcriptController.onProviderChange}
-            onSearchChange={transcriptController.onSearchChange}
-            onTranscribe={transcriptController.onTranscribe}
-            run={transcriptController.run}
-            searchQuery={transcriptController.searchQuery}
-            summary={transcriptController.summary}
-            transcriptProgress={transcriptProgress}
-            transcriptStatus={transcriptStatus}
-          />
-        )}
-        currentFrame={currentValues ? {
-          sourceTime: workspaceSourceTime,
-          focus: currentValues.focus,
-          motion: currentValues.motion,
-          faceCount: currentValues.faceCount,
-        } : undefined}
-        summary={{
-          ...(stats ? {
-            frameCount: stats.frameCount,
-            averageFocus: stats.avgFocus,
-            peakFocus: stats.maxFocus,
-            averageMotion: stats.avgMotion,
-            peakMotion: stats.maxMotion,
-            totalFaces: stats.totalFaces,
-          } : {}),
-          groupedPeople: facePeople.length,
-          ...(isVideoSource ? {
-            cutCount,
-            totalSourceCuts: sceneCutAnalysis?.cuts.length,
-            cutStatusText: cutCounterText,
-          } : {}),
-          transcriptWords: transcript.length,
-          describedScenes: segments.length,
-        }}
-        reviewCandidates={faceReviewCandidates}
-        facePeople={facePeople}
-        faceFrames={analysis?.frames ?? []}
-        faceSourceFile={analysisStatus === 'ready' && faceStatus === 'ready' ? sourceFile : undefined}
         onSeekSourceTime={handleSeekToSourceTime}
-        onMergePeople={handleMergePeople}
-        onMoveAppearance={handleMoveAppearance}
-        onAssignReviewFaces={handleAssignReviewFaces}
-        onReanalyzeDescription={() => {
-          void handleDescribe();
-        }}
         renderPersonThumbnail={(person, _scene, requestedTime) => {
           const personSamples = scenePersonSamples.get(person.id) ?? [];
-          // List avatars deliberately reuse one representative crop per
-          // identity. Scene-specific crops are only needed for an explicit
-          // appearance click, otherwise a long list would enqueue a new video
-          // seek for the same speaker in every scene.
           const sample = requestedTime === undefined
             ? representativeFacePersonSample(personSamples)
             : personSamples.reduce<(typeof personSamples)[number] | undefined>((closest, candidate) => (
@@ -701,23 +595,17 @@ export function AnalysisTab({ clipId, analysis, analysisStatus, analysisProgress
                 ? candidate
                 : closest
             ), undefined);
+          const thumbnailFile = analysisStatus === 'ready' && faceStatus === 'ready' ? sourceFile : undefined;
+          if (!sample || !thumbnailFile) return undefined;
           return (
             <FaceCropThumbnail
-              file={analysisStatus === 'ready' && faceStatus === 'ready' ? sourceFile : undefined}
+              file={thumbnailFile}
               sample={sample}
               size={42}
               alt={`${person.label} face`}
             />
           );
         }}
-        renderReviewThumbnail={(candidate) => (
-          <FaceCropThumbnail
-            file={analysisStatus === 'ready' && faceStatus === 'ready' ? sourceFile : undefined}
-            sample={candidate.sample}
-            size={42}
-            alt={`Face needing review at ${candidate.sample.timestamp.toFixed(1)} seconds`}
-          />
-        )}
       />
 
     </div>

--- a/src/components/panels/properties/AnalysisTranscriptSettings.tsx
+++ b/src/components/panels/properties/AnalysisTranscriptSettings.tsx
@@ -1,0 +1,48 @@
+import { IconFileText } from '@tabler/icons-react';
+import type { TranscriptStatus } from '../../../types/clipMetadata';
+import { TranscriptWorkspaceHeader } from './TranscriptWorkspaceHeader';
+import type { TranscriptWorkspaceController } from './useTranscriptWorkspaceController';
+
+interface AnalysisTranscriptSettingsProps {
+  controller: TranscriptWorkspaceController;
+  transcriptCount: number;
+  transcriptProgress: number;
+  transcriptStatus: TranscriptStatus;
+}
+
+export function AnalysisTranscriptSettings({
+  controller,
+  transcriptCount,
+  transcriptProgress,
+  transcriptStatus,
+}: AnalysisTranscriptSettingsProps) {
+  return (
+    <section className="analysis-settings-area" aria-label="Transcript settings">
+      <h5 className="analysis-settings-area__title">
+        <IconFileText aria-hidden="true" size={14} stroke={1.9} />
+        <span>Transcript</span>
+      </h5>
+      <TranscriptWorkspaceHeader
+        activeProvider={controller.activeProvider}
+        clipCoverage={controller.clipCoverage}
+        hasTranscript={transcriptCount > 0}
+        isPartial={controller.isPartial}
+        isSignedIn={controller.isSignedIn}
+        language={controller.language}
+        onCancel={controller.onCancel}
+        onContinue={controller.onContinue}
+        onDelete={controller.onClear}
+        onLanguageChange={controller.onLanguageChange}
+        onProviderChange={controller.onProviderChange}
+        onSearchChange={controller.onSearchChange}
+        onTranscribe={controller.onTranscribe}
+        run={controller.run}
+        searchQuery={controller.searchQuery}
+        settingsMode
+        summary={controller.summary}
+        transcriptProgress={transcriptProgress}
+        transcriptStatus={transcriptStatus}
+      />
+    </section>
+  );
+}

--- a/src/components/panels/properties/AnalysisTranscriptTabs.css
+++ b/src/components/panels/properties/AnalysisTranscriptTabs.css
@@ -264,8 +264,12 @@
 /* Analysis Tab (embedded in PropertiesPanel) */
 .properties-tab-content.analysis-tab {
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: 8px;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .analysis-tab-actions {

--- a/src/components/panels/properties/PropertiesPanel.css
+++ b/src/components/panels/properties/PropertiesPanel.css
@@ -1762,6 +1762,12 @@
   overflow: hidden;
 }
 
+.properties-panel .properties-content.properties-content--analysis {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 .properties-tab-content {
   padding: var(--sp-2);
 }

--- a/src/components/panels/properties/TranscriptWorkspaceHeader.tsx
+++ b/src/components/panels/properties/TranscriptWorkspaceHeader.tsx
@@ -34,6 +34,7 @@ interface TranscriptWorkspaceHeaderProps {
   onTranscribe: () => void;
   run: TranscriptRunView | null;
   searchQuery: string;
+  settingsMode?: boolean;
   summary: TranscriptSummaryView | null;
   transcriptProgress: number;
   transcriptStatus: 'none' | 'transcribing' | 'ready' | 'error';
@@ -205,6 +206,7 @@ export function TranscriptWorkspaceHeader({
   onTranscribe,
   run,
   searchQuery,
+  settingsMode = false,
   summary,
   transcriptProgress,
   transcriptStatus,
@@ -266,7 +268,7 @@ export function TranscriptWorkspaceHeader({
         </div>
       </div>
 
-      {isBusy ? (
+      {!settingsMode && (isBusy ? (
         <TranscriptRunStatus
           activeProvider={activeProvider}
           run={run}
@@ -274,9 +276,9 @@ export function TranscriptWorkspaceHeader({
         />
       ) : summary && transcriptStatus === 'ready' ? (
         <TranscriptResultStatus />
-      ) : null}
+      ) : null)}
 
-      {transcriptStatus === 'ready' && clipCoverage > 0 && (
+      {!settingsMode && transcriptStatus === 'ready' && clipCoverage > 0 && (
         <div className="transcript-coverage-row">
           <div className="transcript-coverage-rail">
             <span style={{ width: `${Math.round(clipCoverage * 100)}%` }} />
@@ -285,7 +287,7 @@ export function TranscriptWorkspaceHeader({
         </div>
       )}
 
-      {hasTranscript && (
+      {!settingsMode && hasTranscript && (
         <div className="transcript-find-row">
           <input
             aria-label="Search transcript"

--- a/src/components/panels/properties/analysisWorkspace/AnalysisOverviewTimeline.css
+++ b/src/components/panels/properties/analysisWorkspace/AnalysisOverviewTimeline.css
@@ -27,6 +27,25 @@
   letter-spacing: var(--tracking-normal);
 }
 
+.AnalysisOverview__toggle {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.AnalysisOverview__toggle:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.AnalysisOverview__toggle > svg {
+  flex: 0 0 auto;
+  transition: transform 140ms ease;
+}
+
 .AnalysisOverview__title small {
   padding: 2px var(--sp-1);
   border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border-color));
@@ -326,6 +345,20 @@
   border: 0;
   clip-path: inset(50%);
   white-space: nowrap;
+}
+
+.AnalysisOverview--collapsed .AnalysisOverview__header {
+  margin-bottom: 0;
+}
+
+.AnalysisOverview--collapsed .AnalysisOverview__toggle > svg {
+  transform: rotate(-90deg);
+}
+
+.AnalysisOverview--collapsed .AnalysisOverview__shell,
+.AnalysisOverview--collapsed .AnalysisOverview__axis,
+.AnalysisOverview--collapsed .AnalysisOverview__missingNote {
+  display: none;
 }
 
 .AnalysisOverview--compact {

--- a/src/components/panels/properties/analysisWorkspace/AnalysisOverviewTimeline.tsx
+++ b/src/components/panels/properties/analysisWorkspace/AnalysisOverviewTimeline.tsx
@@ -7,6 +7,7 @@ import {
   type KeyboardEvent,
   type PointerEvent,
 } from 'react';
+import { IconChevronDown } from '@tabler/icons-react';
 import { prefersSoftwareTimelineCanvas } from '../../../timeline/utils/timelineCanvasPlatform';
 import {
   ANALYSIS_OVERVIEW_LANE_KINDS,
@@ -102,6 +103,7 @@ export function AnalysisOverviewTimeline({
   const scrubbingRef = useRef(false);
   const [measuredWidth, setMeasuredWidth] = useState(width ?? 1);
   const [hover, setHover] = useState<HoverDetail | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
   const viewportWidth = Math.max(1, Math.floor(width ?? measuredWidth));
   const compact = viewportWidth < 360;
   const startTime = finiteStartTime(analysis.startTime);
@@ -320,15 +322,25 @@ export function AnalysisOverviewTimeline({
 
   return (
     <section
-      className={`AnalysisOverview${compact ? ' AnalysisOverview--compact' : ''}`}
+      className={[
+        'AnalysisOverview',
+        compact ? 'AnalysisOverview--compact' : '',
+        collapsed ? 'AnalysisOverview--collapsed' : '',
+      ].filter(Boolean).join(' ')}
       aria-label="Analysis overview"
       style={width === undefined ? undefined : { width }}
     >
       <header className="AnalysisOverview__header">
-        <span className="AnalysisOverview__title">
-          Analysis map
+        <button
+          type="button"
+          className="AnalysisOverview__title AnalysisOverview__toggle"
+          aria-expanded={!collapsed}
+          onClick={() => setCollapsed((current) => !current)}
+        >
+          <IconChevronDown aria-hidden="true" size={15} stroke={1.8} />
+          <span>Analysis map</span>
           <small>{layout.present.length}/{ANALYSIS_OVERVIEW_LANE_KINDS.length} signals</small>
-        </span>
+        </button>
         <output className="AnalysisOverview__clock" aria-live="off">
           <strong>{formatTime(playheadTime)}</strong>
           <span>/ {formatTime(endTime)}</span>

--- a/src/components/panels/properties/analysisWorkspace/AnalysisSceneBlob.tsx
+++ b/src/components/panels/properties/analysisWorkspace/AnalysisSceneBlob.tsx
@@ -1,324 +1,138 @@
-import { useState, type DragEvent, type ReactNode } from 'react';
-import type { FaceReviewCandidate } from '../../../../services/faceAnalysis/faceReviewCandidates';
-import { readFaceDrag, writeFaceDrag } from '../faceDragPayload';
-import { AnalysisPersonChip } from './AnalysisPersonChip';
-import { AnalysisSceneTranscript } from './AnalysisSceneTranscript';
+import type { ReactNode } from 'react';
 import {
-  buildAnalysisSceneTranscriptTurns,
   findActiveAnalysisSceneWord,
   formatAnalysisSceneTime,
   type AnalysisScenePerson,
   type AnalysisSceneTranscriptWord,
   type AnalysisSceneView,
 } from './analysisSceneViewModel';
+import type { AnalysisTranscriptChunk } from './analysisTranscriptChunks';
 
 export interface AnalysisSceneBlobProps {
   scene: AnalysisSceneView;
+  transcriptChunk: AnalysisTranscriptChunk;
   active: boolean;
-  expanded: boolean;
   sourceTime: number;
-  followPlayback?: boolean;
-  selectedPersonId?: string;
-  reviewCandidates?: readonly FaceReviewCandidate[];
   renderPersonThumbnail?: (
     person: AnalysisScenePerson,
     scene: AnalysisSceneView,
     sourceTime?: number,
   ) => ReactNode;
-  renderReviewThumbnail?: (candidate: FaceReviewCandidate, scene: AnalysisSceneView) => ReactNode;
-  onToggle: () => void;
-  onPersonSelect?: (person: AnalysisScenePerson) => void;
-  onPersonAppearanceSelect?: (sourceTime: number) => void;
-  onMergePeople?: (sourcePersonId: string, targetPersonId: string) => void;
-  onMoveAppearance?: (sourcePersonId: string, targetPersonId: string, sourceTime: number) => void;
-  onAssignReviewFaces?: (candidateId: string, faceIds: string[], targetPersonId: string) => void;
-  onReanalyzeDescription?: (scene: AnalysisSceneView) => void;
+  onChunkSelect: () => void;
   onWordClick?: (word: AnalysisSceneTranscriptWord) => void;
 }
 
 function compactTranscript(
-  scene: AnalysisSceneView,
+  transcriptChunk: AnalysisTranscriptChunk,
   sourceTime: number,
   onWordClick?: (word: AnalysisSceneTranscriptWord) => void,
 ): ReactNode {
-  const turns = buildAnalysisSceneTranscriptTurns(
-    scene.range,
-    scene.transcript,
-    scene.speakerTurns,
-  ).slice(0, 2);
-  if (turns.length === 0) {
+  if (transcriptChunk.words.length === 0) {
     return <span className="AnalysisSceneBlob__noSpeech">No speech in this scene</span>;
   }
-  const activeWord = findActiveAnalysisSceneWord(scene.transcript, sourceTime);
-  return turns.map((turn) => (
-    <span className="AnalysisSceneBlob__turn" key={turn.id}>
-      {turn.words.slice(0, 18).map((word) => (
+  const activeWord = findActiveAnalysisSceneWord(transcriptChunk.words, sourceTime);
+  return (
+    <span className="AnalysisSceneBlob__turn">
+      {transcriptChunk.words.map((word, index) => (
         <button
-          aria-current={word.id === activeWord?.id ? 'true' : undefined}
+          aria-current={word === activeWord ? 'true' : undefined}
           aria-label={`Seek word ${word.text}`}
-          className={word.id === activeWord?.id ? 'AnalysisSceneBlob__word AnalysisSceneBlob__word--active' : 'AnalysisSceneBlob__word'}
-          key={`${word.id}:${word.start}`}
+          className={word === activeWord ? 'AnalysisSceneBlob__word AnalysisSceneBlob__word--active' : 'AnalysisSceneBlob__word'}
+          key={`${word.id}:${word.start}:${word.end}:${index}`}
           onClick={() => onWordClick?.(word)}
-          title={`${formatAnalysisSceneTime(word.start)}${word.confidence === undefined ? '' : ` · ${Math.round(word.confidence * 100)}% confidence`}${word.needsReview ? ' · needs review' : ''}`}
+          title={formatAnalysisSceneTime(word.start)}
           type="button"
         >
           {word.text}
         </button>
       ))}
-      {turn.words.length > 18 ? '…' : ''}
     </span>
-  ));
+  );
 }
 
 function initials(label: string): string {
   return label.trim().split(/\s+/).slice(0, 2).map((part) => part[0]).join('').toUpperCase() || '?';
 }
 
-function personAvatars(
+function speakerCode(label: string): string {
+  const normalized = label.trim();
+  const compact = normalized.match(/^s(?:peaker)?\s*(\d+)$/i);
+  return compact ? `S${compact[1]}` : initials(normalized);
+}
+
+function identitySummary(
   scene: AnalysisSceneView,
+  transcriptChunk: AnalysisTranscriptChunk,
   renderPersonThumbnail: AnalysisSceneBlobProps['renderPersonThumbnail'],
 ): ReactNode {
-  const speakers = scene.speakerTurns.reduce<Array<{
-    key: string;
-    label: string;
-    person?: AnalysisScenePerson;
-  }>>((result, turn) => {
-    const person = scene.people.find((candidate) => candidate.id === turn.personId);
-    const key = person ? `person:${person.id}` : `speaker:${turn.speakerId ?? turn.speakerLabel}`;
-    if (!result.some((entry) => entry.key === key)) {
-      result.push({ key, label: person?.label ?? turn.speakerLabel, person });
+  const speaker = transcriptChunk.speakerLabel
+    ? {
+      key: transcriptChunk.speakerId ?? transcriptChunk.speakerLabel,
+      label: transcriptChunk.speakerLabel,
     }
-    return result;
-  }, []);
-  const identities = speakers.length > 0
-    ? speakers
-    : scene.people.map((person) => ({ key: `person:${person.id}`, label: person.label, person }));
-  if (identities.length === 0) {
-    return <span className="AnalysisSceneBlob__avatar AnalysisSceneBlob__avatar--empty"><span>–</span></span>;
-  }
-  return identities.slice(0, 3).map(({ key, label, person }) => (
-    <span
-      className={`AnalysisSceneBlob__avatar${person ? '' : ' AnalysisSceneBlob__avatar--speaker'}`}
-      title={label}
-      key={key}
-    >
-      {person
-        ? renderPersonThumbnail?.(person, scene) ?? <span>{initials(label)}</span>
-        : <span>{initials(label)}</span>}
+    : undefined;
+  return (
+    <span className="AnalysisSceneBlob__identitySummary">
+      <span className="AnalysisSceneBlob__avatars" aria-label="People visible in scene">
+        {scene.people.length > 0
+          ? scene.people.slice(0, 2).map((person) => (
+            <span className="AnalysisSceneBlob__avatar" title={person.label} key={person.id}>
+              {renderPersonThumbnail?.(person, scene) ?? <span>{initials(person.label)}</span>}
+            </span>
+          ))
+          : <span className="AnalysisSceneBlob__avatar AnalysisSceneBlob__avatar--empty"><span>–</span></span>}
+      </span>
+      {speaker && (
+        <span className="AnalysisSceneBlob__speakerCodes" aria-label="Transcript speakers">
+          <span key={speaker.key} title={speaker.label}>{speakerCode(speaker.label)}</span>
+        </span>
+      )}
     </span>
-  ));
-}
-
-function facts(scene: AnalysisSceneView) {
-  return [
-    ['Focus', scene.focus],
-    ['Motion', scene.motion],
-    ['Setup', scene.setup],
-    ['Camera', scene.camera],
-    ['Audio', scene.audio],
-  ].filter((item): item is [string, NonNullable<typeof scene.focus>] => Boolean(item[1]));
-}
-
-function personSpeakerState(scene: AnalysisSceneView, personId: string) {
-  return scene.speakerTurns.find((turn) => turn.personId === personId)?.state;
+  );
 }
 
 export function AnalysisSceneBlob({
   scene,
+  transcriptChunk,
   active,
-  expanded,
   sourceTime,
-  followPlayback = false,
-  selectedPersonId,
-  reviewCandidates = [],
   renderPersonThumbnail,
-  renderReviewThumbnail,
-  onToggle,
-  onPersonSelect,
-  onPersonAppearanceSelect,
-  onMergePeople,
-  onMoveAppearance,
-  onAssignReviewFaces,
-  onReanalyzeDescription,
+  onChunkSelect,
   onWordClick,
 }: AnalysisSceneBlobProps) {
-  const [dropTargetId, setDropTargetId] = useState<string>();
-  const duration = Math.max(0, scene.range.end - scene.range.start);
-  const incompleteCoverage = Object.entries(scene.coverage)
-    .filter(([, item]) => item && item.state !== 'complete');
-
-  const dropOnPerson = (event: DragEvent, targetPersonId: string) => {
-    event.preventDefault();
-    setDropTargetId(undefined);
-    const payload = readFaceDrag(event);
-    if (!payload || ('personId' in payload && payload.personId === targetPersonId)) return;
-    if (payload.kind === 'person') onMergePeople?.(payload.personId, targetPersonId);
-    else if (payload.kind === 'appearance') {
-      onMoveAppearance?.(payload.personId, targetPersonId, payload.timestamp);
-    } else {
-      onAssignReviewFaces?.(payload.candidateId, payload.faceIds, targetPersonId);
-    }
-  };
-
+  const duration = Math.max(0, transcriptChunk.end - transcriptChunk.start);
+  const sceneLabel = scene.index ?? scene.id;
+  const hasMultipleParts = transcriptChunk.partCount > 1;
+  const articleLabel = hasMultipleParts
+    ? `Scene ${sceneLabel}, speech segment ${transcriptChunk.partIndex} of ${transcriptChunk.partCount}`
+    : `Scene ${sceneLabel}`;
+  const seekLabel = transcriptChunk.fallback
+    ? `Seek to scene ${sceneLabel}`
+    : `Seek to speech segment ${transcriptChunk.partIndex} in scene ${sceneLabel}`;
   return (
     <article
-      className={[
-        'AnalysisSceneBlob',
-        active ? 'AnalysisSceneBlob--active' : '',
-        expanded ? 'AnalysisSceneBlob--expanded' : '',
-      ].filter(Boolean).join(' ')}
-      aria-label={`Scene ${scene.index ?? scene.id}`}
+      className={`AnalysisSceneBlob${active ? ' AnalysisSceneBlob--active' : ''}`}
+      aria-label={articleLabel}
     >
       <div className="AnalysisSceneBlob__summary">
-        <span className="AnalysisSceneBlob__avatars" aria-label="People and speakers">
-          {personAvatars(scene, renderPersonThumbnail)}
-        </span>
+        {identitySummary(scene, transcriptChunk, renderPersonThumbnail)}
         <span className="AnalysisSceneBlob__speech">
-          <small>Scene {scene.index ?? '–'} · {scene.boundarySource === 'scene-block' ? 'described scene' : 'shot'}</small>
-          {compactTranscript(scene, sourceTime, onWordClick)}
+          <small>
+            Scene {scene.index ?? '–'} · {scene.boundarySource === 'scene-block' ? 'described scene' : 'shot'}
+            {hasMultipleParts ? ` · speech ${transcriptChunk.partIndex}/${transcriptChunk.partCount}` : ''}
+          </small>
+          {compactTranscript(transcriptChunk, sourceTime, onWordClick)}
         </span>
         <button
           type="button"
-          className="AnalysisSceneBlob__time AnalysisSceneBlob__summaryToggle"
-          aria-expanded={expanded}
-          onClick={onToggle}
+          className="AnalysisSceneBlob__time AnalysisSceneBlob__summarySeek"
+          aria-label={seekLabel}
+          onClick={onChunkSelect}
         >
-          <strong>{formatAnalysisSceneTime(scene.range.start)}–{formatAnalysisSceneTime(scene.range.end)}</strong>
-          <small>{duration.toFixed(1)}s · {expanded ? 'Hide' : 'Details'}</small>
+          <strong>{formatAnalysisSceneTime(transcriptChunk.start)}–{formatAnalysisSceneTime(transcriptChunk.end)}</strong>
+          <small>{duration.toFixed(1)}s</small>
         </button>
       </div>
-
-      {expanded && (
-        <div className="AnalysisSceneBlob__details">
-          {scene.people.length > 0 && (
-            <section className="AnalysisSceneBlob__identity" aria-label="People in this scene">
-              <header>People <small>Click to filter; drag identities or appearances to correct grouping</small></header>
-              <div className="AnalysisSceneBlob__people">
-                {scene.people.map((person) => (
-                  <div
-                    className={`AnalysisSceneBlob__person${dropTargetId === person.id ? ' AnalysisSceneBlob__person--drop' : ''}`}
-                    draggable
-                    key={person.id}
-                    onDragStart={(event) => writeFaceDrag(event, { kind: 'person', personId: person.id })}
-                    onDragOver={(event) => {
-                      event.preventDefault();
-                      setDropTargetId(person.id);
-                    }}
-                    onDragLeave={() => setDropTargetId((current) => current === person.id ? undefined : current)}
-                    onDrop={(event) => dropOnPerson(event, person.id)}
-                  >
-                    <AnalysisPersonChip
-                      person={person}
-                      selected={person.id === selectedPersonId}
-                      speakerState={personSpeakerState(scene, person.id)}
-                      onSelect={onPersonSelect}
-                    />
-                    <div className="AnalysisSceneBlob__appearances" aria-label={`${person.label} appearances`}>
-                      {(person.appearances ?? (person.presence ? [person.presence] : [])).slice(0, 6).map((appearance, index) => (
-                        <button
-                          type="button"
-                          draggable
-                          className="AnalysisSceneBlob__appearance"
-                          key={`${appearance.start}:${appearance.end}:${index}`}
-                          title={`Jump to ${formatAnalysisSceneTime(appearance.start)}. Drag onto another person to move.`}
-                          onClick={() => onPersonAppearanceSelect?.(appearance.start)}
-                          onDragStart={(event) => {
-                            event.stopPropagation();
-                            writeFaceDrag(event, {
-                              kind: 'appearance',
-                              personId: person.id,
-                              timestamp: appearance.start,
-                            });
-                          }}
-                        >
-                          {renderPersonThumbnail?.(person, scene, appearance.start)}
-                          <span>{formatAnalysisSceneTime(appearance.start)}</span>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </section>
-          )}
-
-          {reviewCandidates.length > 0 && (
-            <section className="AnalysisSceneBlob__review" aria-label="Faces needing review">
-              <header>Needs review <small>Drag a detection onto a person</small></header>
-              <div>
-                {reviewCandidates.map((candidate, index) => (
-                  <button
-                    type="button"
-                    draggable
-                    className="AnalysisSceneBlob__reviewFace"
-                    key={candidate.id}
-                    title={`Review detection at ${formatAnalysisSceneTime(candidate.sample.timestamp)}`}
-                    onClick={() => onPersonAppearanceSelect?.(candidate.sample.timestamp)}
-                    onDragStart={(event) => writeFaceDrag(event, {
-                      kind: 'review',
-                      candidateId: candidate.id,
-                      faceIds: candidate.faceIds,
-                      sample: candidate.sample,
-                    })}
-                  >
-                    {renderReviewThumbnail?.(candidate, scene)}
-                    <span>Review {index + 1} · {candidate.observationCount} frame{candidate.observationCount === 1 ? '' : 's'}</span>
-                  </button>
-                ))}
-              </div>
-            </section>
-          )}
-
-          {facts(scene).length > 0 && (
-            <dl className="AnalysisSceneBlob__facts">
-              {facts(scene).map(([label, value]) => (
-                <div key={label}><dt>{label}</dt><dd>{value.label}{value.detail ? ` · ${value.detail}` : ''}</dd></div>
-              ))}
-            </dl>
-          )}
-
-          {scene.description && (
-            <section className="AnalysisSceneBlob__description">
-              <header>
-                <span>Description{scene.description.provenance ? ` · ${scene.description.provenance}` : ''}</span>
-                {onReanalyzeDescription && (
-                  <button type="button" onClick={() => onReanalyzeDescription(scene)}>Reanalyze</button>
-                )}
-              </header>
-              <p>{scene.description.text}</p>
-            </section>
-          )}
-
-          {scene.ocr.length > 0 && (
-            <section className="AnalysisSceneBlob__ocr">
-              <header>On-screen text</header>
-              <p>{scene.ocr.map((item) => item.text).join(' · ')}</p>
-            </section>
-          )}
-
-          {(scene.qualityIssues.length > 0 || incompleteCoverage.length > 0) && (
-            <div className="AnalysisSceneBlob__notices">
-              {scene.qualityIssues.slice(0, 3).map((issue) => (
-                <span key={issue.id}><strong>{issue.label}</strong>{issue.detail ? ` · ${issue.detail}` : ''}</span>
-              ))}
-              {incompleteCoverage.slice(0, 5).map(([channel, item]) => (
-                <span key={channel}><strong>{channel}</strong> · {item!.state}{item!.detail ? ` · ${item!.detail}` : ''}</span>
-              ))}
-            </div>
-          )}
-
-          <AnalysisSceneTranscript
-            sceneRange={scene.range}
-            words={scene.transcript}
-            speakerTurns={scene.speakerTurns}
-            playheadTime={sourceTime}
-            followPlayback={followPlayback}
-            maxTurns={6}
-            maxWordsPerTurn={80}
-            onWordClick={onWordClick}
-          />
-        </div>
-      )}
     </article>
   );
 }

--- a/src/components/panels/properties/analysisWorkspace/AnalysisSceneList.tsx
+++ b/src/components/panels/properties/analysisWorkspace/AnalysisSceneList.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type UIEvent } from 'react';
-import type { FaceReviewCandidate } from '../../../../services/faceAnalysis/faceReviewCandidates';
 import { AnalysisSceneBlob } from './AnalysisSceneBlob';
 import type {
   AnalysisScenePerson,
@@ -7,75 +6,74 @@ import type {
   AnalysisSceneView,
 } from './analysisSceneViewModel';
 import {
+  ANALYSIS_SCENE_LIST_VIEWPORT_HEIGHT,
+  type AnalysisSceneListItem,
   buildAnalysisSceneLayout,
-  filterAnalysisScenes,
+  filterAnalysisSceneListItems,
+  findActiveAnalysisSceneListItem,
   getAnalysisSceneWindow,
 } from './analysisSceneListModel';
 
 export interface AnalysisSceneListProps {
-  scenes: readonly AnalysisSceneView[];
+  items: readonly AnalysisSceneListItem[];
   selectedSceneId?: string;
-  selectedPersonId?: string;
   query?: string;
   sourceTime: number;
   /** Playback follows the active scene only when the host says follow is active. */
   followPlayback?: boolean;
-  reviewCandidates?: readonly FaceReviewCandidate[];
   renderPersonThumbnail?: (
     person: AnalysisScenePerson,
     scene: AnalysisSceneView,
     sourceTime?: number,
   ) => ReactNode;
-  renderReviewThumbnail?: (candidate: FaceReviewCandidate, scene: AnalysisSceneView) => ReactNode;
-  onSceneSelect: (scene: AnalysisSceneView) => void;
-  onPersonSelect?: (person: AnalysisScenePerson) => void;
-  onPersonAppearanceSelect?: (sourceTime: number) => void;
-  onMergePeople?: (sourcePersonId: string, targetPersonId: string) => void;
-  onMoveAppearance?: (sourcePersonId: string, targetPersonId: string, sourceTime: number) => void;
-  onAssignReviewFaces?: (candidateId: string, faceIds: string[], targetPersonId: string) => void;
-  onReanalyzeDescription?: (scene: AnalysisSceneView) => void;
+  onItemSelect: (item: AnalysisSceneListItem) => void;
   onWordClick?: (word: AnalysisSceneTranscriptWord) => void;
 }
 
 export function AnalysisSceneList({
-  scenes,
+  items,
   selectedSceneId,
-  selectedPersonId,
   query = '',
   sourceTime,
   followPlayback = false,
-  reviewCandidates = [],
   renderPersonThumbnail,
-  renderReviewThumbnail,
-  onSceneSelect,
-  onPersonSelect,
-  onPersonAppearanceSelect,
-  onMergePeople,
-  onMoveAppearance,
-  onAssignReviewFaces,
-  onReanalyzeDescription,
+  onItemSelect,
   onWordClick,
 }: AnalysisSceneListProps) {
   const viewportRef = useRef<HTMLDivElement>(null);
   const [scrollTop, setScrollTop] = useState(0);
-  const [expandedSceneId, setExpandedSceneId] = useState<string>();
-  const filteredScenes = useMemo(
-    () => filterAnalysisScenes(scenes, query),
-    [query, scenes],
+  const [viewportHeight, setViewportHeight] = useState(ANALYSIS_SCENE_LIST_VIEWPORT_HEIGHT);
+  const filteredItems = useMemo(
+    () => filterAnalysisSceneListItems(items, query),
+    [items, query],
   );
   const layout = useMemo(
-    () => buildAnalysisSceneLayout(filteredScenes, expandedSceneId),
-    [expandedSceneId, filteredScenes],
+    () => buildAnalysisSceneLayout(filteredItems),
+    [filteredItems],
   );
-  const window = getAnalysisSceneWindow(layout, scrollTop);
+  const window = getAnalysisSceneWindow(layout, scrollTop, viewportHeight);
+  const activeItem = useMemo(
+    () => findActiveAnalysisSceneListItem(items, sourceTime, selectedSceneId),
+    [items, selectedSceneId, sourceTime],
+  );
 
   useEffect(() => {
-    if (followPlayback && selectedSceneId) setExpandedSceneId(selectedSceneId);
-  }, [followPlayback, selectedSceneId]);
+    const viewport = viewportRef.current;
+    if (!viewport) return undefined;
+    const updateHeight = () => {
+      const next = Math.max(1, Math.round(viewport.clientHeight));
+      setViewportHeight((current) => current === next ? current : next);
+    };
+    updateHeight();
+    if (typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, [filteredItems.length]);
 
   useEffect(() => {
     if (!followPlayback) return;
-    const selectedIndex = filteredScenes.findIndex((scene) => scene.id === selectedSceneId);
+    const selectedIndex = filteredItems.findIndex(item => item.id === activeItem?.id);
     const viewport = viewportRef.current;
     const selectedRow = layout.rows[selectedIndex];
     if (!viewport || !selectedRow) return;
@@ -86,10 +84,10 @@ export function AnalysisSceneList({
     } else if (rowBottom > viewport.scrollTop + viewport.clientHeight) {
       viewport.scrollTop = Math.max(0, rowBottom - viewport.clientHeight);
     }
-  }, [filteredScenes, followPlayback, layout.rows, selectedSceneId]);
+  }, [activeItem?.id, filteredItems, followPlayback, layout.rows]);
 
-  if (filteredScenes.length === 0) {
-    return <p className="AnalysisSceneList__empty">No scenes match this search.</p>;
+  if (filteredItems.length === 0) {
+    return <p className="AnalysisSceneList__empty">No segments match this search.</p>;
   }
 
   return (
@@ -97,46 +95,29 @@ export function AnalysisSceneList({
       ref={viewportRef}
       className="AnalysisSceneList"
       role="list"
-      aria-label="Scenes"
+      aria-label="Scene and transcript segments"
       onScroll={(event: UIEvent<HTMLDivElement>) => setScrollTop(event.currentTarget.scrollTop)}
     >
       <div className="AnalysisSceneList__spacer" style={{ height: layout.totalHeight }}>
-        {filteredScenes.slice(window.start, window.end).map((scene, offset) => {
+        {filteredItems.slice(window.start, window.end).map((item, offset) => {
           const index = window.start + offset;
           const row = layout.rows[index];
           if (!row) return null;
           return (
             <div
               role="listitem"
-              aria-current={scene.id === selectedSceneId ? 'true' : undefined}
+              aria-current={item.id === activeItem?.id ? 'true' : undefined}
               className="AnalysisSceneList__row"
-              key={scene.id}
+              key={item.id}
               style={{ height: row.height, transform: `translateY(${row.offset}px)` }}
             >
               <AnalysisSceneBlob
-                scene={scene}
-                active={scene.id === selectedSceneId}
-                expanded={scene.id === expandedSceneId}
+                scene={item.scene}
+                transcriptChunk={item.transcriptChunk}
+                active={item.id === activeItem?.id}
                 sourceTime={sourceTime}
-                followPlayback={followPlayback}
-                selectedPersonId={selectedPersonId}
-                reviewCandidates={reviewCandidates.filter(
-                  (candidate) => candidate.sample.timestamp >= scene.range.start
-                    && candidate.sample.timestamp < scene.range.end,
-                )}
                 renderPersonThumbnail={renderPersonThumbnail}
-                renderReviewThumbnail={renderReviewThumbnail}
-                onToggle={() => {
-                  const opening = expandedSceneId !== scene.id;
-                  setExpandedSceneId(opening ? scene.id : undefined);
-                  if (opening) onSceneSelect(scene);
-                }}
-                onPersonSelect={onPersonSelect}
-                onPersonAppearanceSelect={onPersonAppearanceSelect}
-                onMergePeople={onMergePeople}
-                onMoveAppearance={onMoveAppearance}
-                onAssignReviewFaces={onAssignReviewFaces}
-                onReanalyzeDescription={onReanalyzeDescription}
+                onChunkSelect={() => onItemSelect(item)}
                 onWordClick={onWordClick}
               />
             </div>

--- a/src/components/panels/properties/analysisWorkspace/AnalysisWorkspace.css
+++ b/src/components/panels/properties/analysisWorkspace/AnalysisWorkspace.css
@@ -1,7 +1,11 @@
 .AnalysisWorkspace {
-  display: grid;
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
   gap: var(--sp-2);
+  min-height: 0;
   min-width: 0;
+  overflow: hidden;
   padding: var(--sp-2);
   border-top: 1px solid var(--border-color);
   background: var(--bg-secondary);
@@ -9,69 +13,12 @@
 }
 
 .AnalysisWorkspace__scene {
-  display: grid;
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
   gap: var(--sp-1-5);
+  min-height: 0;
   min-width: 0;
-}
-
-.AnalysisWorkspace__inspector {
-  display: grid;
-  gap: var(--sp-1);
-  border-block: 1px solid var(--border-color);
-  padding-block: var(--sp-1-5);
-}
-
-.AnalysisWorkspace__now {
-  display: flex;
-  align-items: center;
-  gap: var(--sp-2);
-  min-width: 0;
-  color: var(--text-secondary);
-  font-size: var(--font-xs);
-}
-
-.AnalysisWorkspace__now > span {
-  white-space: nowrap;
-}
-
-.AnalysisWorkspace__nowLabel {
-  margin-right: auto;
-  color: var(--text-primary);
-}
-
-.AnalysisWorkspace__now b,
-.AnalysisWorkspace__now strong {
-  color: var(--accent);
-  font-family: var(--font-mono);
-}
-
-.AnalysisWorkspace__summary {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(112px, 1fr));
-  gap: 2px var(--sp-2);
-  margin: 0;
-}
-
-.AnalysisWorkspace__summary div {
-  display: flex;
-  justify-content: space-between;
-  gap: var(--sp-1);
-  min-width: 0;
-  color: var(--text-muted);
-  font-size: var(--font-xs);
-}
-
-.AnalysisWorkspace__summary dt,
-.AnalysisWorkspace__summary dd {
-  overflow: hidden;
-  margin: 0;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.AnalysisWorkspace__summary dd {
-  color: var(--text-primary);
-  font-family: var(--font-mono);
 }
 
 .AnalysisWorkspace__sceneSearch {
@@ -81,35 +28,6 @@
   gap: var(--sp-1-5);
   color: var(--text-muted);
   font-size: var(--font-sm);
-}
-
-.AnalysisWorkspace__personFilter {
-  display: flex;
-  align-items: center;
-  gap: var(--sp-1);
-  color: var(--text-secondary);
-  font-size: var(--font-xs);
-}
-
-.AnalysisWorkspace__personFilter span {
-  margin-right: auto;
-}
-
-.AnalysisWorkspace__personFilter button,
-.AnalysisSceneBlob__description button {
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  background: var(--input-bg);
-  color: var(--text-primary);
-  padding: 2px var(--sp-1-5);
-  font-size: var(--font-xs);
-  cursor: pointer;
-}
-
-.AnalysisWorkspace__personFilter button:hover,
-.AnalysisSceneBlob__description button:hover {
-  border-color: var(--accent);
-  background: var(--bg-hover);
 }
 
 .AnalysisWorkspace__sceneSearch input {
@@ -130,7 +48,9 @@
 }
 
 .AnalysisSceneList {
-  height: min(430px, 52vh);
+  flex: 1 1 0;
+  height: auto;
+  min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-width: thin;
@@ -163,7 +83,7 @@
 
 .AnalysisSceneBlob__summary {
   display: grid;
-  grid-template-columns: 72px minmax(0, 1fr) minmax(72px, auto);
+  grid-template-columns: 112px minmax(0, 1fr) minmax(72px, auto);
   align-items: center;
   gap: var(--sp-2);
   width: 100%;
@@ -173,19 +93,19 @@
   color: inherit;
   padding: var(--sp-1-5) var(--sp-2);
   text-align: left;
-  cursor: pointer;
 }
 
-.AnalysisSceneBlob__summary:hover,
-.AnalysisSceneBlob__summary:focus-visible {
-  outline: none;
-  background: var(--bg-hover);
+.AnalysisSceneBlob__identitySummary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
 }
 
 .AnalysisSceneBlob__avatars {
   display: flex;
   align-items: center;
-  min-width: 46px;
+  min-width: 44px;
   padding-left: 2px;
 }
 
@@ -215,8 +135,24 @@
   border-radius: calc(var(--radius-sm) - 1px) !important;
 }
 
-.AnalysisSceneBlob__avatar--speaker {
-  background: var(--bg-primary);
+.AnalysisSceneBlob__speakerCodes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  min-width: 0;
+}
+
+.AnalysisSceneBlob__speakerCodes > span {
+  display: inline-grid;
+  min-width: 24px;
+  height: 20px;
+  place-items: center;
+  padding-inline: 4px;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font: var(--font-semibold) var(--font-2xs)/1 var(--font-family);
 }
 
 .AnalysisSceneBlob__avatar--empty {
@@ -286,14 +222,19 @@
   white-space: nowrap;
 }
 
-.AnalysisSceneBlob__summaryToggle {
+.AnalysisSceneBlob__summarySeek {
   border: 0;
   background: transparent;
+  border-radius: var(--radius-sm);
   font: inherit;
   cursor: pointer;
 }
 
-.AnalysisSceneBlob__summaryToggle:focus-visible,
+.AnalysisSceneBlob__summarySeek:hover {
+  background: var(--bg-hover);
+}
+
+.AnalysisSceneBlob__summarySeek:focus-visible,
 .AnalysisSceneBlob__word:focus-visible {
   outline: 1px solid var(--accent);
   outline-offset: 1px;
@@ -306,182 +247,6 @@
 .AnalysisSceneBlob__time small {
   color: var(--accent);
   font-size: var(--font-xs);
-}
-
-.AnalysisSceneBlob__details {
-  display: grid;
-  gap: var(--sp-2);
-  height: 278px;
-  align-content: start;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  border-top: 1px solid var(--border-color);
-  padding: var(--sp-2);
-  scrollbar-width: thin;
-}
-
-.AnalysisSceneBlob__identity,
-.AnalysisSceneBlob__review,
-.AnalysisSceneBlob__description,
-.AnalysisSceneBlob__ocr {
-  min-width: 0;
-}
-
-.AnalysisSceneBlob__identity > header,
-.AnalysisSceneBlob__review > header,
-.AnalysisSceneBlob__description > header,
-.AnalysisSceneBlob__ocr > header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--sp-2);
-  margin-bottom: var(--sp-1);
-  color: var(--text-primary);
-  font-size: var(--font-xs);
-  font-weight: var(--font-semibold);
-}
-
-.AnalysisSceneBlob__identity header small,
-.AnalysisSceneBlob__review header small {
-  overflow: hidden;
-  color: var(--text-muted);
-  font-size: var(--font-2xs);
-  font-weight: var(--font-normal);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.AnalysisSceneBlob__people {
-  display: flex;
-  gap: var(--sp-1);
-  overflow-x: auto;
-  padding-bottom: 2px;
-  scrollbar-width: thin;
-}
-
-.AnalysisSceneBlob__person {
-  display: grid;
-  flex: 0 0 auto;
-  gap: 3px;
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  padding: 2px;
-}
-
-.AnalysisSceneBlob__person--drop {
-  border-color: var(--accent);
-  background: var(--accent-dim);
-}
-
-.AnalysisSceneBlob__appearances {
-  display: flex;
-  gap: 3px;
-}
-
-.AnalysisSceneBlob__appearance,
-.AnalysisSceneBlob__reviewFace {
-  display: grid;
-  grid-template-columns: 28px auto;
-  align-items: center;
-  gap: var(--sp-1);
-  overflow: hidden;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
-  padding: 2px;
-  font-size: var(--font-2xs);
-  cursor: grab;
-}
-
-.AnalysisSceneBlob__appearance > img,
-.AnalysisSceneBlob__appearance > .FaceCropThumbnail,
-.AnalysisSceneBlob__appearance > span[aria-hidden='true'],
-.AnalysisSceneBlob__reviewFace > img,
-.AnalysisSceneBlob__reviewFace > .FaceCropThumbnail,
-.AnalysisSceneBlob__reviewFace > span[aria-hidden='true'] {
-  width: 28px !important;
-  height: 28px !important;
-}
-
-.AnalysisSceneBlob__appearance:hover,
-.AnalysisSceneBlob__reviewFace:hover {
-  border-color: var(--accent);
-  background: var(--bg-hover);
-}
-
-.AnalysisSceneBlob__review > div {
-  display: flex;
-  gap: var(--sp-1);
-  overflow-x: auto;
-  scrollbar-width: thin;
-}
-
-.AnalysisSceneBlob__reviewFace {
-  grid-template-columns: 36px minmax(90px, auto);
-  flex: 0 0 auto;
-}
-
-.AnalysisSceneBlob__reviewFace > img,
-.AnalysisSceneBlob__reviewFace > .FaceCropThumbnail,
-.AnalysisSceneBlob__reviewFace > span[aria-hidden='true'] {
-  width: 36px !important;
-  height: 36px !important;
-}
-
-.AnalysisSceneBlob__facts {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(88px, 1fr));
-  gap: var(--sp-1);
-  margin: 0;
-}
-
-.AnalysisSceneBlob__facts div {
-  min-width: 0;
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  padding: var(--sp-1) var(--sp-1-5);
-}
-
-.AnalysisSceneBlob__facts dt {
-  color: var(--accent);
-  font-size: var(--font-2xs);
-  text-transform: uppercase;
-}
-
-.AnalysisSceneBlob__facts dd {
-  overflow: hidden;
-  margin: 1px 0 0;
-  color: var(--text-secondary);
-  font-size: var(--font-xs);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.AnalysisSceneBlob__description p,
-.AnalysisSceneBlob__ocr p {
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: var(--font-xs);
-  line-height: 1.4;
-}
-
-.AnalysisSceneBlob__notices {
-  display: grid;
-  gap: var(--sp-1);
-}
-
-.AnalysisSceneBlob__notices span {
-  border-left: 2px solid var(--warning-light);
-  background: color-mix(in srgb, var(--warning) 10%, var(--bg-secondary));
-  color: var(--text-secondary);
-  padding: var(--sp-1);
-  font-size: var(--font-2xs);
-}
-
-.AnalysisSceneBlob__notices strong {
-  color: var(--warning-light);
-  text-transform: capitalize;
 }
 
 .AnalysisSceneList__empty {
@@ -505,17 +270,8 @@
 }
 
 @media (max-width: 360px) {
-  .AnalysisWorkspace__now {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-  }
-
-  .AnalysisWorkspace__nowLabel {
-    grid-column: 1 / -1;
-  }
-
   .AnalysisSceneBlob__summary {
-    grid-template-columns: 56px minmax(0, 1fr) 62px;
+    grid-template-columns: 76px minmax(0, 1fr) 62px;
     gap: 6px;
     padding-inline: 7px;
   }
@@ -523,5 +279,10 @@
   .AnalysisSceneBlob__avatar {
     width: 36px;
     height: 36px;
+  }
+
+  .AnalysisSceneBlob__speakerCodes > span {
+    min-width: 20px;
+    height: 18px;
   }
 }

--- a/src/components/panels/properties/analysisWorkspace/AnalysisWorkspace.tsx
+++ b/src/components/panels/properties/analysisWorkspace/AnalysisWorkspace.tsx
@@ -1,68 +1,28 @@
 import { useCallback, useMemo, useState, type ReactNode } from 'react';
-import type { FaceReviewCandidate } from '../../../../services/faceAnalysis/faceReviewCandidates';
-import type { FacePersonSummary, FrameAnalysisData } from '../../../../types/clipMetadata';
-import { FacePeopleSummary } from '../FacePeopleSummary';
-import { FaceReviewSummary } from '../FaceReviewSummary';
 import { AnalysisOverviewTimeline } from './AnalysisOverviewTimeline';
 import { AnalysisSceneList } from './AnalysisSceneList';
-import { filterAnalysisScenes } from './analysisSceneListModel';
 import {
-  formatAnalysisSceneTime,
+  buildAnalysisSceneListItems,
+  filterAnalysisSceneListItems,
+} from './analysisSceneListModel';
+import {
   type AnalysisScenePerson,
   type AnalysisSceneView,
 } from './analysisSceneViewModel';
 import type { AnalysisWorkspaceViewModel } from './analysisWorkspaceAdapter';
 import './AnalysisWorkspace.css';
 
-export interface AnalysisWorkspaceCurrentFrame {
-  sourceTime: number;
-  focus: number;
-  motion: number;
-  faceCount: number;
-}
-
-export interface AnalysisWorkspaceSummary {
-  frameCount?: number;
-  averageFocus?: number;
-  peakFocus?: number;
-  averageMotion?: number;
-  peakMotion?: number;
-  totalFaces?: number;
-  groupedPeople: number;
-  cutCount?: number;
-  totalSourceCuts?: number;
-  cutStatusText?: string;
-  transcriptWords: number;
-  describedScenes: number;
-}
-
 export interface AnalysisWorkspaceProps {
   model: AnalysisWorkspaceViewModel;
   sourceTime: number;
-  currentFrame?: AnalysisWorkspaceCurrentFrame;
-  summary?: AnalysisWorkspaceSummary;
-  reviewCandidates?: readonly FaceReviewCandidate[];
-  facePeople?: readonly FacePersonSummary[];
-  faceFrames?: readonly FrameAnalysisData[];
-  faceSourceFile?: File;
   transcriptSearchQuery?: string;
-  transcriptControls?: ReactNode;
   onTranscriptSearchChange?: (query: string) => void;
   isFollowingPlayback?: boolean;
   onSeekSourceTime: (sourceTime: number) => void;
-  onPersonSelect?: (person: AnalysisScenePerson) => void;
-  onMergePeople?: (sourcePersonId: string, targetPersonId: string) => void;
-  onMoveAppearance?: (sourcePersonId: string, targetPersonId: string, sourceTime: number) => void;
-  onAssignReviewFaces?: (candidateId: string, faceIds: string[], targetPersonId: string) => void;
-  onReanalyzeDescription?: (scene: AnalysisSceneView) => void;
   renderPersonThumbnail?: (
     person: AnalysisScenePerson,
     scene: AnalysisSceneView,
     sourceTime?: number,
-  ) => ReactNode;
-  renderReviewThumbnail?: (
-    candidate: FaceReviewCandidate,
-    scene: AnalysisSceneView,
   ) => ReactNode;
 }
 
@@ -72,45 +32,14 @@ function findSceneIndex(model: AnalysisWorkspaceViewModel, sourceTime: number): 
   );
 }
 
-function percent(value: number): string {
-  return `${Math.round(Math.min(1, Math.max(0, value)) * 100)}%`;
-}
-
-function nextPersonAppearance(
-  scenes: readonly AnalysisSceneView[],
-  personId: string,
-  sourceTime: number,
-): number | undefined {
-  const starts = scenes.flatMap((scene) => scene.people
-    .filter((person) => person.id === personId)
-    .flatMap((person) => (person.appearances ?? (person.presence ? [person.presence] : []))
-      .map((appearance) => appearance.start)))
-    .filter(Number.isFinite)
-    .toSorted((left, right) => left - right);
-  return starts.find((start) => start > sourceTime + 0.001) ?? starts[0];
-}
-
 export function AnalysisWorkspace({
   model,
   sourceTime,
-  currentFrame,
-  summary,
-  reviewCandidates = [],
-  facePeople = [],
-  faceFrames = [],
-  faceSourceFile,
   transcriptSearchQuery,
-  transcriptControls,
   onTranscriptSearchChange,
   isFollowingPlayback = false,
   onSeekSourceTime,
-  onPersonSelect,
-  onMergePeople,
-  onMoveAppearance,
-  onAssignReviewFaces,
-  onReanalyzeDescription,
   renderPersonThumbnail,
-  renderReviewThumbnail,
 }: AnalysisWorkspaceProps) {
   const activeSceneIndex = useMemo(
     () => findSceneIndex(model, sourceTime),
@@ -119,16 +48,13 @@ export function AnalysisWorkspace({
   const [localSceneQuery, setLocalSceneQuery] = useState('');
   const sceneQuery = transcriptSearchQuery ?? localSceneQuery;
   const setSceneQuery = onTranscriptSearchChange ?? setLocalSceneQuery;
-  const [selectedPersonId, setSelectedPersonId] = useState<string>();
-  const personScenes = useMemo(
-    () => selectedPersonId
-      ? model.scenes.filter((scene) => scene.people.some((person) => person.id === selectedPersonId))
-      : model.scenes,
-    [model.scenes, selectedPersonId],
+  const sceneListItems = useMemo(
+    () => buildAnalysisSceneListItems(model.scenes),
+    [model.scenes],
   );
-  const matchingSceneCount = useMemo(
-    () => filterAnalysisScenes(personScenes, sceneQuery).length,
-    [personScenes, sceneQuery],
+  const matchingSegmentCount = useMemo(
+    () => filterAnalysisSceneListItems(sceneListItems, sceneQuery).length,
+    [sceneListItems, sceneQuery],
   );
   const selectedScene = activeSceneIndex >= 0
     ? model.scenes[activeSceneIndex]
@@ -139,24 +65,8 @@ export function AnalysisWorkspace({
     if (scene) onSeekSourceTime(scene.range.start);
   }, [model.scenes, onSeekSourceTime]);
 
-  const selectPerson = useCallback((person: AnalysisScenePerson) => {
-    setSelectedPersonId((current) => current === person.id ? undefined : person.id);
-    if (selectedPersonId !== person.id) {
-      const next = nextPersonAppearance(model.scenes, person.id, sourceTime - 0.002);
-      if (next !== undefined) onSeekSourceTime(next);
-    }
-    onPersonSelect?.(person);
-  }, [model.scenes, onPersonSelect, onSeekSourceTime, selectedPersonId, sourceTime]);
-
-  const seekNextAppearance = useCallback(() => {
-    if (!selectedPersonId) return;
-    const next = nextPersonAppearance(model.scenes, selectedPersonId, sourceTime);
-    if (next !== undefined) onSeekSourceTime(next);
-  }, [model.scenes, onSeekSourceTime, selectedPersonId, sourceTime]);
-
   return (
     <section className="AnalysisWorkspace" aria-label="Clip analysis workspace">
-      {transcriptControls}
       <AnalysisOverviewTimeline
         analysis={model.overview}
         playheadTime={sourceTime}
@@ -165,48 +75,10 @@ export function AnalysisWorkspace({
         onSceneClick={(event) => selectScene(event.id)}
       />
 
-      {(currentFrame || summary) && (
-        <section className="AnalysisWorkspace__inspector" aria-label="Analysis at playhead and clip summary">
-          {currentFrame && (
-            <div className="AnalysisWorkspace__now">
-              <span className="AnalysisWorkspace__nowLabel">
-                Now <strong>{formatAnalysisSceneTime(currentFrame.sourceTime)}</strong>
-              </span>
-              <span>Focus <b>{percent(currentFrame.focus)}</b></span>
-              <span>Motion <b>{percent(currentFrame.motion)}</b></span>
-              <span>Faces <b>{currentFrame.faceCount}</b></span>
-            </div>
-          )}
-          {summary && (
-            <dl className="AnalysisWorkspace__summary">
-              {summary.frameCount !== undefined && <div><dt>Frames:</dt><dd>{summary.frameCount}</dd></div>}
-              {summary.cutStatusText !== undefined && (
-                <div>
-                  <dt>Cuts:</dt>
-                  <dd title={summary.totalSourceCuts === undefined ? undefined : `${summary.totalSourceCuts} in source`}>
-                    {summary.cutStatusText}
-                  </dd>
-                </div>
-              )}
-              <div><dt>People:</dt><dd>{summary.groupedPeople}</dd></div>
-              <div><dt>Words:</dt><dd>{summary.transcriptWords}</dd></div>
-              <div><dt>Descriptions:</dt><dd>{summary.describedScenes}</dd></div>
-              {summary.averageFocus !== undefined && (
-                <div><dt>Focus avg/peak:</dt><dd>{summary.averageFocus}% / {summary.peakFocus}%</dd></div>
-              )}
-              {summary.averageMotion !== undefined && (
-                <div><dt>Motion avg/peak:</dt><dd>{summary.averageMotion}% / {summary.peakMotion}%</dd></div>
-              )}
-              {summary.totalFaces !== undefined && <div><dt>Face sightings:</dt><dd>{summary.totalFaces}</dd></div>}
-            </dl>
-          )}
-        </section>
-      )}
-
       {selectedScene ? (
         <div className="AnalysisWorkspace__scene">
           <div className="AnalysisWorkspace__sceneSearch">
-            <label htmlFor="analysis-scene-search">Scenes</label>
+            <label htmlFor="analysis-scene-search">Segments</label>
             <input
               id="analysis-scene-search"
               type="search"
@@ -214,53 +86,22 @@ export function AnalysisWorkspace({
               placeholder="Search text, speaker, person…"
               onChange={(event) => setSceneQuery(event.target.value)}
             />
-            <span>{matchingSceneCount}/{model.scenes.length}</span>
+            <span>{matchingSegmentCount}/{sceneListItems.length}</span>
           </div>
-          {selectedPersonId && (
-            <div className="AnalysisWorkspace__personFilter" role="status">
-              <span>Person filter active</span>
-              <button type="button" onClick={seekNextAppearance}>Next appearance</button>
-              <button type="button" onClick={() => setSelectedPersonId(undefined)}>Clear</button>
-            </div>
-          )}
           <AnalysisSceneList
-            scenes={personScenes}
+            items={sceneListItems}
             selectedSceneId={selectedScene.id}
-            selectedPersonId={selectedPersonId}
             query={sceneQuery}
             sourceTime={sourceTime}
             followPlayback={isFollowingPlayback}
-            reviewCandidates={reviewCandidates}
             renderPersonThumbnail={renderPersonThumbnail}
-            renderReviewThumbnail={renderReviewThumbnail}
-            onSceneSelect={(scene) => selectScene(scene.id)}
-            onPersonSelect={selectPerson}
-            onPersonAppearanceSelect={onSeekSourceTime}
-            onMergePeople={onMergePeople}
-            onMoveAppearance={onMoveAppearance}
-            onAssignReviewFaces={onAssignReviewFaces}
-            onReanalyzeDescription={onReanalyzeDescription}
+            onItemSelect={(item) => onSeekSourceTime(
+              item.transcriptChunk.fallback
+                ? item.scene.range.start
+                : item.transcriptChunk.start,
+            )}
             onWordClick={(word) => onSeekSourceTime(word.start)}
           />
-          {facePeople.length > 0 && onMergePeople && onMoveAppearance && onAssignReviewFaces && (
-            <FacePeopleSummary
-              people={facePeople}
-              frames={faceFrames}
-              sourceFile={faceSourceFile}
-              onSelectSourceTime={onSeekSourceTime}
-              onMergePeople={onMergePeople}
-              onMoveAppearance={onMoveAppearance}
-              onAssignReviewFaces={onAssignReviewFaces}
-            />
-          )}
-          {reviewCandidates.length > 0 && (
-            <FaceReviewSummary
-              candidates={reviewCandidates}
-              frames={faceFrames}
-              sourceFile={faceSourceFile}
-              onSelectSourceTime={onSeekSourceTime}
-            />
-          )}
         </div>
       ) : (
         <p className="AnalysisWorkspace__empty">

--- a/src/components/panels/properties/analysisWorkspace/analysisSceneListModel.ts
+++ b/src/components/panels/properties/analysisWorkspace/analysisSceneListModel.ts
@@ -1,7 +1,10 @@
 import type { AnalysisSceneView } from './analysisSceneViewModel';
+import {
+  buildAnalysisTranscriptChunks,
+  type AnalysisTranscriptChunk,
+} from './analysisTranscriptChunks';
 
 export const ANALYSIS_SCENE_COLLAPSED_HEIGHT = 78;
-export const ANALYSIS_SCENE_EXPANDED_HEIGHT = 350;
 export const ANALYSIS_SCENE_ROW_GAP = 6;
 export const ANALYSIS_SCENE_LIST_VIEWPORT_HEIGHT = 430;
 const OVERSCAN_PIXELS = 180;
@@ -14,6 +17,12 @@ export interface AnalysisSceneLayoutRow {
 export interface AnalysisSceneLayout {
   rows: readonly AnalysisSceneLayoutRow[];
   totalHeight: number;
+}
+
+export interface AnalysisSceneListItem {
+  id: string;
+  scene: AnalysisSceneView;
+  transcriptChunk: AnalysisTranscriptChunk;
 }
 
 function searchableSceneText(scene: AnalysisSceneView): string {
@@ -34,6 +43,58 @@ export function filterAnalysisScenes(
   return scenes.filter((scene) => searchableSceneText(scene).includes(normalizedQuery));
 }
 
+export function buildAnalysisSceneListItems(
+  scenes: readonly AnalysisSceneView[],
+): readonly AnalysisSceneListItem[] {
+  return scenes.flatMap(scene => buildAnalysisTranscriptChunks(scene).map(transcriptChunk => ({
+    id: transcriptChunk.id,
+    scene,
+    transcriptChunk,
+  })));
+}
+
+function searchableListItemText(item: AnalysisSceneListItem): string {
+  return [
+    item.scene.description?.text,
+    ...item.scene.people.map(person => person.label),
+    item.transcriptChunk.speakerLabel,
+    ...item.transcriptChunk.words.map(word => word.text),
+  ].filter(Boolean).join(' ').toLocaleLowerCase();
+}
+
+export function filterAnalysisSceneListItems(
+  items: readonly AnalysisSceneListItem[],
+  query: string,
+): readonly AnalysisSceneListItem[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (!normalizedQuery) return items;
+  return items.filter(item => searchableListItemText(item).includes(normalizedQuery));
+}
+
+export function findActiveAnalysisSceneListItem(
+  items: readonly AnalysisSceneListItem[],
+  sourceTime: number,
+  selectedSceneId?: string,
+): AnalysisSceneListItem | undefined {
+  const sourceScene = Number.isFinite(sourceTime)
+    ? items.find(item => sourceTime >= item.scene.range.start && sourceTime < item.scene.range.end)?.scene
+    : undefined;
+  const sceneId = sourceScene?.id ?? selectedSceneId;
+  const sceneItems = items
+    .filter(item => item.scene.id === sceneId)
+    .toSorted((left, right) => (
+      left.transcriptChunk.start - right.transcriptChunk.start
+      || left.transcriptChunk.end - right.transcriptChunk.end
+      || left.id.localeCompare(right.id)
+    ));
+  if (sceneItems.length === 0) return undefined;
+  const containing = sceneItems.find(item => (
+    sourceTime >= item.transcriptChunk.start && sourceTime < item.transcriptChunk.end
+  ));
+  if (containing) return containing;
+  return sceneItems.findLast(item => item.transcriptChunk.start <= sourceTime) ?? sceneItems[0];
+}
+
 export function getAnalysisSceneWindow(
   layout: AnalysisSceneLayout,
   scrollTop: number,
@@ -50,14 +111,11 @@ export function getAnalysisSceneWindow(
 }
 
 export function buildAnalysisSceneLayout(
-  scenes: readonly AnalysisSceneView[],
-  expandedSceneId?: string,
+  items: readonly unknown[],
 ): AnalysisSceneLayout {
   let offset = 0;
-  const rows = scenes.map((scene) => {
-    const height = scene.id === expandedSceneId
-      ? ANALYSIS_SCENE_EXPANDED_HEIGHT
-      : ANALYSIS_SCENE_COLLAPSED_HEIGHT;
+  const rows = items.map(() => {
+    const height = ANALYSIS_SCENE_COLLAPSED_HEIGHT;
     const row = { offset, height };
     offset += height + ANALYSIS_SCENE_ROW_GAP;
     return row;

--- a/src/components/panels/properties/analysisWorkspace/analysisTranscriptChunks.ts
+++ b/src/components/panels/properties/analysisWorkspace/analysisTranscriptChunks.ts
@@ -1,0 +1,219 @@
+import {
+  rangesOverlap,
+  type AnalysisSceneRange,
+  type AnalysisSceneSpeakerTurn,
+  type AnalysisSceneTranscriptWord,
+  type AnalysisSceneView,
+} from './analysisSceneViewModel';
+
+export const ANALYSIS_TRANSCRIPT_CHUNK_TARGET_SECONDS = 10;
+export const ANALYSIS_TRANSCRIPT_CHUNK_MIN_SECONDS = 3;
+export const ANALYSIS_TRANSCRIPT_CHUNK_MAX_SECONDS = 15;
+export const ANALYSIS_TRANSCRIPT_CHUNK_SILENCE_SECONDS = 1.5;
+const ANALYSIS_TRANSCRIPT_CHUNK_MAX_WORDS = 28;
+const SENTENCE_END = /[.!?…](?:["'’”»)\]}]+)?$/u;
+
+interface ResolvedTranscriptWord {
+  word: AnalysisSceneTranscriptWord;
+  speakerKey: string;
+  speakerId?: string;
+  speakerLabel: string;
+  personId?: string;
+  state: AnalysisSceneSpeakerTurn['state'];
+}
+
+export interface AnalysisTranscriptChunk extends AnalysisSceneRange {
+  id: string;
+  sceneId: string;
+  words: readonly AnalysisSceneTranscriptWord[];
+  speakerId?: string;
+  speakerLabel?: string;
+  personId?: string;
+  speakerState?: AnalysisSceneSpeakerTurn['state'];
+  partIndex: number;
+  partCount: number;
+  fallback: boolean;
+}
+
+function validWord(word: AnalysisSceneTranscriptWord): boolean {
+  return Number.isFinite(word.start) && Number.isFinite(word.end) && word.end > word.start;
+}
+
+function sentenceEndsAt(word: AnalysisSceneTranscriptWord): boolean {
+  return SENTENCE_END.test(word.text.trim());
+}
+
+function resolveWords(scene: AnalysisSceneView): readonly ResolvedTranscriptWord[] {
+  const turns = scene.speakerTurns
+    .filter(turn => Number.isFinite(turn.start) && Number.isFinite(turn.end) && turn.end > turn.start)
+    .toSorted((left, right) => left.start - right.start || left.end - right.end || left.id.localeCompare(right.id));
+  return scene.transcript
+    .filter(word => validWord(word) && rangesOverlap(scene.range, word))
+    .toSorted((left, right) => left.start - right.start || left.end - right.end || left.id.localeCompare(right.id))
+    .map((word): ResolvedTranscriptWord => {
+      const turn = turns.find(candidate => rangesOverlap(candidate, word));
+      const speakerId = turn?.speakerId ?? word.speakerId;
+      const speakerLabel = turn?.speakerLabel ?? (word.speakerLabel?.trim() || 'Unknown speaker');
+      return {
+        word,
+        speakerKey: speakerId ? `id:${speakerId}` : `label:${speakerLabel}`,
+        speakerId,
+        speakerLabel,
+        personId: turn?.personId,
+        state: turn?.state ?? (speakerId || word.speakerLabel ? 'offscreen' : 'unknown'),
+      };
+    });
+}
+
+function splitIntoSpeechRuns(words: readonly ResolvedTranscriptWord[]): readonly ResolvedTranscriptWord[][] {
+  const runs: ResolvedTranscriptWord[][] = [];
+  for (const resolved of words) {
+    const run = runs.at(-1);
+    const previous = run?.at(-1);
+    const speakerChanged = previous && previous.speakerKey !== resolved.speakerKey;
+    const longSilence = previous
+      && resolved.word.start - previous.word.end >= ANALYSIS_TRANSCRIPT_CHUNK_SILENCE_SECONDS;
+    if (!run || speakerChanged || longSilence) {
+      runs.push([resolved]);
+    } else {
+      run.push(resolved);
+    }
+  }
+  return runs;
+}
+
+function rangeDuration(words: readonly ResolvedTranscriptWord[], startIndex: number, endIndex: number): number {
+  return Math.max(0, words[endIndex].word.end - words[startIndex].word.start);
+}
+
+function remainingDuration(words: readonly ResolvedTranscriptWord[], afterIndex: number): number {
+  const next = words[afterIndex + 1];
+  return next ? Math.max(0, words.at(-1)!.word.end - next.word.start) : 0;
+}
+
+function closestToTarget(
+  words: readonly ResolvedTranscriptWord[],
+  startIndex: number,
+  candidates: readonly number[],
+): number | undefined {
+  return candidates.reduce<number | undefined>((best, candidate) => {
+    if (best === undefined) return candidate;
+    const candidateDistance = Math.abs(
+      rangeDuration(words, startIndex, candidate) - ANALYSIS_TRANSCRIPT_CHUNK_TARGET_SECONDS,
+    );
+    const bestDistance = Math.abs(
+      rangeDuration(words, startIndex, best) - ANALYSIS_TRANSCRIPT_CHUNK_TARGET_SECONDS,
+    );
+    return candidateDistance < bestDistance ? candidate : best;
+  }, undefined);
+}
+
+function chooseChunkEnd(words: readonly ResolvedTranscriptWord[], startIndex: number): number {
+  const finalIndex = words.length - 1;
+  let limitIndex = startIndex;
+  while (limitIndex < finalIndex) {
+    const nextIndex = limitIndex + 1;
+    const nextDuration = rangeDuration(words, startIndex, nextIndex);
+    const nextWordCount = nextIndex - startIndex + 1;
+    if (
+      nextDuration > ANALYSIS_TRANSCRIPT_CHUNK_MAX_SECONDS
+      || nextWordCount > ANALYSIS_TRANSCRIPT_CHUNK_MAX_WORDS
+    ) break;
+    limitIndex = nextIndex;
+  }
+
+  // A single unusually long token stays atomic even when its timestamp exceeds
+  // the normal maximum; splitting a transcript word would invent timing data.
+  if (limitIndex === startIndex && startIndex === finalIndex) return finalIndex;
+
+  const forcedSplit = limitIndex < finalIndex;
+  const preferredCandidates: number[] = [];
+  for (let index = startIndex; index <= limitIndex; index += 1) {
+    const duration = rangeDuration(words, startIndex, index);
+    if (duration < ANALYSIS_TRANSCRIPT_CHUNK_MIN_SECONDS) continue;
+    const leavesUsableTail = index === finalIndex
+      || remainingDuration(words, index) >= ANALYSIS_TRANSCRIPT_CHUNK_MIN_SECONDS;
+    if (leavesUsableTail && sentenceEndsAt(words[index].word)) preferredCandidates.push(index);
+  }
+
+  const preferred = closestToTarget(words, startIndex, preferredCandidates);
+  if (preferred !== undefined) return preferred;
+  if (!forcedSplit) return finalIndex;
+
+  const wordBoundaryCandidates: number[] = [];
+  for (let index = startIndex; index <= limitIndex; index += 1) {
+    const duration = rangeDuration(words, startIndex, index);
+    if (duration < ANALYSIS_TRANSCRIPT_CHUNK_MIN_SECONDS) continue;
+    if (remainingDuration(words, index) >= ANALYSIS_TRANSCRIPT_CHUNK_MIN_SECONDS) {
+      wordBoundaryCandidates.push(index);
+    }
+  }
+  return closestToTarget(words, startIndex, wordBoundaryCandidates) ?? limitIndex;
+}
+
+function chunkSpeechRun(words: readonly ResolvedTranscriptWord[]): readonly ResolvedTranscriptWord[][] {
+  const chunks: ResolvedTranscriptWord[][] = [];
+  let startIndex = 0;
+  while (startIndex < words.length) {
+    const endIndex = chooseChunkEnd(words, startIndex);
+    chunks.push(words.slice(startIndex, endIndex + 1));
+    startIndex = endIndex + 1;
+  }
+  return chunks;
+}
+
+function chunkId(
+  sceneId: string,
+  words: readonly ResolvedTranscriptWord[],
+  partIndex: number,
+): string {
+  const first = words[0].word;
+  const last = words.at(-1)!.word;
+  return [
+    sceneId,
+    'speech',
+    partIndex,
+    first.id,
+    first.start.toFixed(3),
+    last.id,
+    last.end.toFixed(3),
+  ].join(':');
+}
+
+/**
+ * Builds presentation-only transcript chunks without changing the semantic
+ * scene boundaries used by the overview, coverage, and analysis data.
+ */
+export function buildAnalysisTranscriptChunks(
+  scene: AnalysisSceneView,
+): readonly AnalysisTranscriptChunk[] {
+  const resolvedWords = resolveWords(scene);
+  if (resolvedWords.length === 0) {
+    return [{
+      id: `${scene.id}:speech:fallback`,
+      sceneId: scene.id,
+      ...scene.range,
+      words: [],
+      partIndex: 1,
+      partCount: 1,
+      fallback: true,
+    }];
+  }
+
+  const wordChunks = splitIntoSpeechRuns(resolvedWords).flatMap(chunkSpeechRun);
+  const partCount = wordChunks.length;
+  return wordChunks.map((words, index) => ({
+    id: chunkId(scene.id, words, index + 1),
+    sceneId: scene.id,
+    start: Math.max(scene.range.start, words[0].word.start),
+    end: Math.min(scene.range.end, words.at(-1)!.word.end),
+    words: words.map(item => item.word),
+    speakerId: words[0].speakerId,
+    speakerLabel: words[0].speakerLabel,
+    personId: words[0].personId,
+    speakerState: words[0].state,
+    partIndex: index + 1,
+    partCount,
+    fallback: false,
+  }));
+}

--- a/src/components/panels/properties/index.tsx
+++ b/src/components/panels/properties/index.tsx
@@ -216,13 +216,7 @@ export function PropertiesPanel() {
       }
 
       if (selectedPropertiesTrack) {
-        // A MIDI track opens on its instrument — that is what you actually reach
-        // for when you select one; volume/pan already live in the mixer.
-        if (selectedPropertiesTrack.type === 'midi') {
-          setActiveTab('track-instrument');
-        } else {
-          setActiveTab(selectedPropertiesTrack.type === 'audio' ? 'track-effects' : 'track-controls');
-        }
+        setActiveTab(selectedPropertiesTrack.type === 'audio' ? 'track-effects' : 'track-controls');
         return;
       }
 
@@ -646,7 +640,7 @@ export function PropertiesPanel() {
         )}
       </PropertiesTabStrip>
 
-      <div className={`properties-content ${activeTab === 'transcript' ? 'properties-content--transcript' : ''}`}>
+      <div className={`properties-content ${activeTab === 'transcript' ? 'properties-content--transcript' : activeTab === 'analysis' ? 'properties-content--analysis' : ''}`}>
         <Suspense fallback={<TabLoading />}>
           {activeTab === 'live' && isLiveInputClip && <LiveInputTab clipId={selectedClip.id} />}
           {activeTab === 'text' && isTextClip && selectedClip.textProperties && (

--- a/src/services/kernelClient/index.ts
+++ b/src/services/kernelClient/index.ts
@@ -110,7 +110,7 @@ export class KernelServiceClient {
   }
 
   health(options?: KernelRequestOptions): Promise<KernelServiceResult<KernelHealthResponse>> {
-    return this.request('/health', false, { method: 'GET' }, options);
+    return this.request('/kernel/health', false, { method: 'GET' }, options);
   }
 
   run(

--- a/src/services/kernelClient/kernelChatGateway.ts
+++ b/src/services/kernelClient/kernelChatGateway.ts
@@ -91,11 +91,18 @@ function readConfig(storage: Storage): KernelConfig | undefined {
 
     const token = storage.getItem(KERNEL_TOKEN_KEY)?.trim();
     const baseUrl = storage.getItem(KERNEL_URL_KEY)?.trim();
-    if (!token || !baseUrl) {
-      return undefined;
+    if (token && baseUrl) {
+      return { baseUrl, token };
     }
 
-    return { baseUrl, token };
+    // Production default: route through the same-origin Pages proxy, which
+    // injects the kernel bearer token server-side. localStorage keys remain
+    // the explicit override; 'ms.kernel.enabled' = 'false' still disables.
+    if (import.meta.env.PROD) {
+      return { baseUrl: '/api', token: '' };
+    }
+
+    return undefined;
   } catch {
     return undefined;
   }

--- a/tests/unit/AnalysisActionCenter.test.tsx
+++ b/tests/unit/AnalysisActionCenter.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { AnalysisActionCenter } from '../../src/components/panels/properties/AnalysisActionCenter';
 
 describe('AnalysisActionCenter', () => {
-  it('keeps global actions compact and channel actions inside three-column cards', () => {
+  it('keeps global actions compact and channel actions as pills', () => {
     render(
       <AnalysisActionCenter
         actions={[
@@ -16,10 +16,13 @@ describe('AnalysisActionCenter', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: 'Analyze All' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Clear Analysis' })).toBeInTheDocument();
-    const cards = document.querySelectorAll('.analysis-action-row');
-    expect(cards).toHaveLength(3);
-    expect(cards[0]?.querySelector('.analysis-action-buttons .btn')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Analyze all' })).toBeInTheDocument();
+    const pills = document.querySelectorAll('.analysis-action-pill');
+    expect(pills).toHaveLength(3);
+
+    // Clear analysis lives behind the settings toggle, not in the main bar.
+    expect(screen.queryByRole('button', { name: 'Clear analysis' })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Analysis settings' }));
+    expect(screen.getByRole('button', { name: 'Clear analysis' })).toBeInTheDocument();
   });
 });

--- a/tests/unit/AnalysisSceneList.test.tsx
+++ b/tests/unit/AnalysisSceneList.test.tsx
@@ -4,8 +4,11 @@ import {
   AnalysisSceneList,
 } from '../../src/components/panels/properties/analysisWorkspace/AnalysisSceneList';
 import {
+  buildAnalysisSceneListItems,
   buildAnalysisSceneLayout,
+  filterAnalysisSceneListItems,
   filterAnalysisScenes,
+  findActiveAnalysisSceneListItem,
   getAnalysisSceneWindow,
 } from '../../src/components/panels/properties/analysisWorkspace/analysisSceneListModel';
 import type { AnalysisSceneView } from '../../src/components/panels/properties/analysisWorkspace/analysisSceneViewModel';
@@ -29,6 +32,7 @@ function scene(index: number): AnalysisSceneView {
 
 describe('AnalysisSceneList', () => {
   const scenes = Array.from({ length: 100 }, (_, index) => scene(index));
+  const items = buildAnalysisSceneListItems(scenes);
 
   it('filters scene facts without mutating the complete scene list', () => {
     expect(filterAnalysisScenes(scenes, 'needle').map((item) => item.id)).toEqual(['scene-8']);
@@ -36,8 +40,26 @@ describe('AnalysisSceneList', () => {
     expect(scenes).toHaveLength(100);
   });
 
+  it('filters individual transcript segments without changing semantic scenes', () => {
+    const longScene: AnalysisSceneView = {
+      ...scene(0),
+      range: { start: 0, end: 24 },
+      transcript: Array.from({ length: 24 }, (_, index) => ({
+        id: `long-${index}`,
+        text: index === 9 ? 'Needle.' : index === 19 ? 'Second.' : `word${index}`,
+        start: index,
+        end: index + 0.4,
+      })),
+    };
+    const longItems = buildAnalysisSceneListItems([longScene]);
+
+    expect(longItems.length).toBeGreaterThan(1);
+    expect(filterAnalysisSceneListItems(longItems, 'needle')).toHaveLength(1);
+    expect(longScene.range).toEqual({ start: 0, end: 24 });
+  });
+
   it('keeps the rendered window bounded for long sources', () => {
-    const layout = buildAnalysisSceneLayout(scenes);
+    const layout = buildAnalysisSceneLayout(items);
     const firstWindow = getAnalysisSceneWindow(layout, 0);
     const laterWindow = getAnalysisSceneWindow(layout, 460);
 
@@ -48,19 +70,37 @@ describe('AnalysisSceneList', () => {
   });
 
   it('renders only the visible scene rows and selects by source scene', () => {
-    const onSceneSelect = vi.fn();
+    const onItemSelect = vi.fn();
     render(
       <AnalysisSceneList
-        scenes={scenes}
+        items={items}
         selectedSceneId="scene-0"
         sourceTime={0}
-        onSceneSelect={onSceneSelect}
+        onItemSelect={onItemSelect}
       />,
     );
 
-    const items = screen.getAllByRole('listitem');
-    expect(items.length).toBeLessThan(10);
-    fireEvent.click(screen.getAllByRole('button', { expanded: false })[1]);
-    expect(onSceneSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'scene-1' }));
+    const rows = screen.getAllByRole('listitem');
+    expect(rows.length).toBeLessThan(10);
+    fireEvent.click(screen.getByRole('button', { name: 'Seek to scene 2' }));
+    expect(onItemSelect).toHaveBeenCalledWith(expect.objectContaining({
+      scene: expect.objectContaining({ id: 'scene-1' }),
+    }));
+  });
+
+  it('selects exactly one transcript row through speech gaps', () => {
+    const longScene: AnalysisSceneView = {
+      ...scene(0),
+      range: { start: 0, end: 20 },
+      transcript: [
+        { id: 'first', text: 'First.', start: 1, end: 2 },
+        { id: 'second', text: 'Second.', start: 10, end: 11 },
+      ],
+    };
+    const longItems = buildAnalysisSceneListItems([longScene]);
+
+    expect(findActiveAnalysisSceneListItem(longItems, 1.5)?.transcriptChunk.words[0].id).toBe('first');
+    expect(findActiveAnalysisSceneListItem(longItems, 6)?.transcriptChunk.words[0].id).toBe('first');
+    expect(findActiveAnalysisSceneListItem(longItems, 10.5)?.transcriptChunk.words[0].id).toBe('second');
   });
 });

--- a/tests/unit/AnalysisTabSceneCuts.test.tsx
+++ b/tests/unit/AnalysisTabSceneCuts.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AnalysisTab } from '../../src/components/panels/properties/AnalysisTab';
 import type { MediaFile } from '../../src/stores/mediaStore';
@@ -30,7 +30,10 @@ const sceneDescriberMock = vi.hoisted(() => ({
 
 const clipTranscriberMock = vi.hoisted(() => ({
   transcribeClip: vi.fn().mockResolvedValue(undefined),
+  clearClipTranscript: vi.fn(),
 }));
+
+const runCurrentClipAnalysisMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
 vi.mock('../../src/stores/mediaStore', () => {
   const useMediaStore = Object.assign(
@@ -51,6 +54,10 @@ vi.mock('../../src/services/sceneDescriber', () => sceneDescriberMock);
 vi.mock('../../src/services/clipTranscriber', () => clipTranscriberMock);
 vi.mock('../../src/services/agentTimeline/runtime/persistence/agentTimelineRuntimePersistence', () => ({
   startAgentTimelineRuntimePersistence: vi.fn(),
+}));
+vi.mock('../../src/services/agentTimeline/jobs/currentClipAnalysisExecution', async (importOriginal) => ({
+  ...await importOriginal<Record<string, unknown>>(),
+  runCurrentClipAnalysis: runCurrentClipAnalysisMock,
 }));
 
 function createSceneCut(timestamp: number, frameNumber: number): SceneCutPoint {
@@ -93,6 +100,21 @@ const clipAnalysis: ClipAnalysis = {
     brightness: 0.5,
     faceCount: 0,
   }],
+};
+
+// Frames covering the whole 2s-8s range at the balanced cadence, so the
+// metrics channel reads as fully analyzed (pill intent = Reanalyze).
+const fullCoverageAnalysis: ClipAnalysis = {
+  sampleInterval: 500,
+  frames: Array.from({ length: 13 }, (_, index) => ({
+    timestamp: 2 + index * 0.5,
+    motion: 0.2,
+    globalMotion: 0.2,
+    localMotion: 0.1,
+    focus: 0.9,
+    brightness: 0.5,
+    faceCount: 0,
+  })),
 };
 
 function prepareStores(
@@ -152,17 +174,40 @@ function prepareStores(
   } as MediaFile);
 }
 
+function cutsPill(): HTMLButtonElement {
+  const pill = document.querySelector<HTMLButtonElement>('.analysis-action-pill--cuts');
+  expect(pill).toBeTruthy();
+  return pill as HTMLButtonElement;
+}
+
+function metricsPill(): HTMLButtonElement {
+  const pill = document.querySelector<HTMLButtonElement>('.analysis-action-pill--metrics');
+  expect(pill).toBeTruthy();
+  return pill as HTMLButtonElement;
+}
+
+function facesPill(): HTMLButtonElement {
+  const pill = document.querySelector<HTMLButtonElement>('.analysis-action-pill--faces');
+  expect(pill).toBeTruthy();
+  return pill as HTMLButtonElement;
+}
+
+function openSettings() {
+  fireEvent.click(screen.getByRole('button', { name: 'Analysis settings' }));
+}
+
 afterEach(() => {
   cleanup();
   useTimelineStore.setState({ clips: [] });
   mediaStoreMock.files.splice(0, mediaStoreMock.files.length);
   mediaStoreMock.analyzeSceneCuts.mockReset();
   mediaStoreMock.cancelProxyGeneration.mockReset();
+  runCurrentClipAnalysisMock.mockClear();
   vi.clearAllMocks();
 });
 
 describe('AnalysisTab scene-cut counter', () => {
-  it('shows the number of source cuts inside the selected clip range', () => {
+  it('shows the source cut count on the cuts pill', () => {
     prepareStores('ready');
     expect(useTimelineStore.getState().clips[0]?.source?.mediaFileId).toBe('media-1');
     expect(mediaStoreMock.files[0]?.sceneCutAnalysis?.cuts).toHaveLength(4);
@@ -179,9 +224,9 @@ describe('AnalysisTab scene-cut counter', () => {
       />,
     );
 
-    const cutsRow = screen.getByText('Cuts:').parentElement;
-    expect(cutsRow?.textContent).toBe('Cuts:2');
-    expect(cutsRow?.querySelector('[title="4 in source"]')).toBeTruthy();
+    const pill = cutsPill();
+    expect(pill.title).toContain('4 cuts');
+    expect(pill.querySelector('strong')?.textContent).toBe('4');
   });
 
   it('shows scene-cut scan progress while analysis is running', () => {
@@ -199,9 +244,10 @@ describe('AnalysisTab scene-cut counter', () => {
       />,
     );
 
-    expect(screen.getByText('Analyzing 37%')).toBeTruthy();
+    expect(cutsPill().title).toContain('37%');
+    openSettings();
     expect(
-      (screen.getByRole('button', { name: 'Clear Analysis' }) as HTMLButtonElement).disabled,
+      (screen.getByRole('button', { name: 'Clear analysis' }) as HTMLButtonElement).disabled,
     ).toBe(true);
   });
 
@@ -220,9 +266,7 @@ describe('AnalysisTab scene-cut counter', () => {
       />,
     );
 
-    const cutsAction = screen.getByText('Scene Cuts').closest('.analysis-action-row');
-    expect(cutsAction).toBeTruthy();
-    fireEvent.click(within(cutsAction as HTMLElement).getByRole('button', { name: 'Analyze' }));
+    fireEvent.click(cutsPill());
     expect(mediaStoreMock.analyzeSceneCuts).toHaveBeenCalledWith('media-1', {
       force: false,
     });
@@ -243,9 +287,7 @@ describe('AnalysisTab scene-cut counter', () => {
       />,
     );
 
-    const cutsAction = screen.getByText('Scene Cuts').closest('.analysis-action-row');
-    expect(cutsAction).toBeTruthy();
-    fireEvent.click(within(cutsAction as HTMLElement).getByRole('button', { name: 'Retry' }));
+    fireEvent.click(cutsPill());
     expect(mediaStoreMock.analyzeSceneCuts).toHaveBeenCalledWith('media-1', {
       force: true,
     });
@@ -257,7 +299,7 @@ describe('AnalysisTab scene-cut counter', () => {
     render(
       <AnalysisTab
         clipId="clip-1"
-        analysis={clipAnalysis}
+        analysis={fullCoverageAnalysis}
         analysisStatus="ready"
         analysisProgress={100}
         clipStartTime={0}
@@ -266,13 +308,7 @@ describe('AnalysisTab scene-cut counter', () => {
       />,
     );
 
-    const metricsAction = screen.getByText('Focus & Motion').closest('.analysis-action-row');
-    const facesAction = screen.getByText('Faces', { selector: '.analysis-action-title' })
-      .closest('.analysis-action-row');
-    expect(metricsAction).toBeTruthy();
-    expect(facesAction).toBeTruthy();
-
-    fireEvent.click(within(metricsAction as HTMLElement).getByRole('button', { name: 'Reanalyze' }));
+    fireEvent.click(metricsPill());
     await vi.waitFor(() => {
       expect(clipAnalyzerMock.analyzeClip).toHaveBeenCalledWith('clip-1', expect.objectContaining({
         target: 'metrics',
@@ -282,7 +318,7 @@ describe('AnalysisTab scene-cut counter', () => {
       }));
     });
 
-    fireEvent.click(within(facesAction as HTMLElement).getByRole('button', { name: 'Analyze' }));
+    fireEvent.click(facesPill());
     await vi.waitFor(() => {
       expect(clipAnalyzerMock.analyzeClip).toHaveBeenCalledWith('clip-1', expect.objectContaining({
         target: 'faces',
@@ -293,7 +329,7 @@ describe('AnalysisTab scene-cut counter', () => {
     });
   });
 
-  it('runs the default channels without starting optional scene descriptions', async () => {
+  it('starts the analyze-all orchestrator with the resolved local visual scope', async () => {
     prepareStores('none', 0, false);
 
     render(
@@ -309,25 +345,19 @@ describe('AnalysisTab scene-cut counter', () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Analyze All' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Analyze all' }));
     });
 
     await vi.waitFor(() => {
-      expect(clipAnalyzerMock.analyzeClip).toHaveBeenCalledWith('clip-1', expect.objectContaining({
-        target: 'all',
-        force: false,
-        sourceRange: { start: 2, end: 8 },
-        sampleIntervalMs: 500,
-        faceSampleIntervalMs: 500,
+      expect(runCurrentClipAnalysisMock).toHaveBeenCalledWith(expect.objectContaining({
+        clipId: 'clip-1',
+        localVisual: expect.objectContaining({
+          profile: 'balanced',
+          sourceRange: { start: 2, end: 8 },
+          includeFaces: true,
+        }),
       }));
-      expect(mediaStoreMock.analyzeSceneCuts).toHaveBeenCalledWith('media-1', {
-        force: false,
-      });
-      expect(sceneDescriberMock.describeClip).not.toHaveBeenCalled();
-      expect(clipTranscriberMock.transcribeClip).toHaveBeenCalledWith('clip-1', 'auto');
     });
-    expect(clipAnalyzerMock.analyzeClip.mock.invocationCallOrder[0])
-      .toBeLessThan(mediaStoreMock.analyzeSceneCuts.mock.invocationCallOrder[0]);
   });
 
   it('forwards supported scope and Quick cadence to the local visual runner', async () => {
@@ -345,20 +375,16 @@ describe('AnalysisTab scene-cut counter', () => {
       />,
     );
 
-    expect(screen.getByRole('region', { name: 'Analysis scope and profile' }))
-      .toHaveTextContent('Scope');
+    openSettings();
+    expect(screen.getByRole('group', { name: 'Analysis scope' })).toHaveTextContent('Scope');
     expect(screen.getByRole('button', { name: 'Used Ranges' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByRole('button', { name: 'Selection' })).toBeDisabled();
-    expect(screen.getByText(/receive this exact source range and selected cadence/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Quick' }));
     expect(screen.getByRole('button', { name: 'Quick' })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByText('low cost')).toBeInTheDocument();
 
-    const metricsAction = screen.getByText('Focus & Motion').closest('.analysis-action-row');
-    expect(metricsAction).toBeTruthy();
     await act(async () => {
-      fireEvent.click(within(metricsAction as HTMLElement).getByRole('button', { name: 'Analyze' }));
+      fireEvent.click(metricsPill());
     });
     await vi.waitFor(() => {
       expect(clipAnalyzerMock.analyzeClip).toHaveBeenCalledWith('clip-1', expect.objectContaining({
@@ -385,15 +411,19 @@ describe('AnalysisTab scene-cut counter', () => {
       />,
     );
 
+    openSettings();
     fireEvent.click(screen.getByRole('button', { name: 'Deep' }));
-    expect(screen.getByText(/Blocked: Deep is blocked until matching real-media benchmark evidence/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Analyze All' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Analyze all|Analyzing…/ })).toBeDisabled();
+    expect(metricsPill().disabled).toBe(true);
+    fireEvent.click(metricsPill());
+    expect(clipAnalyzerMock.analyzeClip).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Balanced' }));
     fireEvent.click(screen.getByRole('button', { name: 'Source' }));
-    const facesAction = screen.getByText('Faces', { selector: '.analysis-action-title' })
-      .closest('.analysis-action-row');
-    expect(within(facesAction as HTMLElement).getByRole('button', { name: 'Analyze' })).toBeDisabled();
-    expect(screen.getByText('Unavailable for source scope')).toBeInTheDocument();
+    const faces = facesPill();
+    expect(faces.disabled).toBe(true);
+    expect(faces.title).toContain('Unavailable for source scope');
+    fireEvent.click(faces);
+    expect(clipAnalyzerMock.analyzeClip).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/AnalysisWorkspace.test.tsx
+++ b/tests/unit/AnalysisWorkspace.test.tsx
@@ -4,7 +4,7 @@ import { AnalysisWorkspace } from '../../src/components/panels/properties/analys
 import { buildAnalysisWorkspaceViewModel } from '../../src/components/panels/properties/analysisWorkspace/analysisWorkspaceAdapter';
 
 describe('AnalysisWorkspace', () => {
-  it('keeps scene, person, and transcript navigation on one source-time model', () => {
+  it('keeps scene and transcript navigation on one source-time model', () => {
     const model = buildAnalysisWorkspaceViewModel({
       range: { inPoint: 0, outPoint: 4 },
       sceneSegments: [
@@ -42,14 +42,12 @@ describe('AnalysisWorkspace', () => {
       }],
     });
     const onSeekSourceTime = vi.fn();
-    const onPersonSelect = vi.fn();
 
     render(
       <AnalysisWorkspace
         model={model}
         sourceTime={0.6}
         onSeekSourceTime={onSeekSourceTime}
-        onPersonSelect={onPersonSelect}
       />,
     );
 
@@ -57,23 +55,44 @@ describe('AnalysisWorkspace', () => {
     expect(screen.queryByText('Ava')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Seek word Hello' }));
     expect(onSeekSourceTime).toHaveBeenCalledWith(0.5);
-    const sceneButtons = screen.getAllByRole('button', { expanded: false });
-    fireEvent.click(sceneButtons[0]);
+    fireEvent.click(screen.getByRole('button', { name: /^Scene 1\b/ }));
     expect(onSeekSourceTime).toHaveBeenCalledWith(0);
-
-    fireEvent.click(screen.getByRole('button', { name: /Ava.*90% confidence/i }));
-    expect(onPersonSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'ava' }));
-    expect(screen.getByText('Person filter active')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Hello' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Seek to speech segment 1 in scene 1' }));
     expect(onSeekSourceTime).toHaveBeenCalledWith(0.5);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
-    fireEvent.click(screen.getAllByRole('button', { expanded: false })[0]);
-    expect(onSeekSourceTime).toHaveBeenCalledWith(2);
+    // The overview map's "People" lane label is legitimate; only a People
+    // statistics section (heading) would be redundant in the workspace.
+    expect(screen.queryByRole('heading', { name: 'People' })).not.toBeInTheDocument();
   });
 
-  it('replaces legacy frame and summary boxes with one workspace inspector', () => {
+  it('shows several speech segments without inventing visual scene cuts', () => {
+    const model = buildAnalysisWorkspaceViewModel({
+      range: { inPoint: 0, outPoint: 24 },
+      cuts: [],
+      transcript: Array.from({ length: 24 }, (_, index) => ({
+        id: `word-${index}`,
+        text: index === 9 || index === 19 ? `word${index}.` : `word${index}`,
+        start: index,
+        end: index + 0.4,
+        speaker: 'Ava',
+      })),
+    });
+
+    render(
+      <AnalysisWorkspace
+        model={model}
+        sourceTime={0}
+        onSeekSourceTime={vi.fn()}
+      />,
+    );
+
+    expect(model.scenes).toHaveLength(1);
+    expect(model.overview.lanes.scenes).toHaveLength(1);
+    expect(screen.getByText('3/3')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+    expect(screen.getByRole('article', { name: 'Scene 1, speech segment 2 of 3' })).toBeInTheDocument();
+  });
+
+  it('keeps redundant playhead and summary statistics out of the scene workspace', () => {
     const model = buildAnalysisWorkspaceViewModel({
       range: { inPoint: 10, outPoint: 14 },
       transcript: [{ id: 'word', text: 'Audio only', start: 11, end: 12 }],
@@ -83,166 +102,12 @@ describe('AnalysisWorkspace', () => {
       <AnalysisWorkspace
         model={model}
         sourceTime={11}
-        currentFrame={{ sourceTime: 11, focus: 0.82, motion: 0.21, faceCount: 2 }}
-        summary={{
-          frameCount: 8,
-          averageFocus: 75,
-          peakFocus: 94,
-          averageMotion: 22,
-          peakMotion: 61,
-          totalFaces: 5,
-          groupedPeople: 2,
-          cutStatusText: '3',
-          totalSourceCuts: 7,
-          transcriptWords: 1,
-          describedScenes: 0,
-        }}
         onSeekSourceTime={vi.fn()}
       />,
     );
 
-    expect(screen.getByRole('region', { name: 'Analysis at playhead and clip summary' }))
-      .toHaveTextContent('Now 00:11.0');
-    expect(screen.getByText('Focus avg/peak:').parentElement).toHaveTextContent('75% / 94%');
-    expect(screen.getByText('Cuts:').parentElement).toHaveTextContent('Cuts:3');
-    expect(screen.getByText('Cuts:').nextElementSibling).toHaveAttribute('title', '7 in source');
+    expect(screen.queryByRole('region', { name: 'Analysis at playhead and clip summary' }))
+      .not.toBeInTheDocument();
     expect(screen.getByText('Audio only')).toBeInTheDocument();
-  });
-
-  it('keeps review assignment inside the expanded scene', () => {
-    const model = buildAnalysisWorkspaceViewModel({
-      range: { inPoint: 0, outPoint: 2 },
-      analysis: {
-        sampleInterval: 500,
-        frames: [],
-        faceAnalysis: {
-          schemaVersion: 1,
-          modelVersion: 'test',
-          detector: 'YuNet',
-          recognizer: 'SFace',
-          backend: 'wasm',
-          observationCount: 1,
-          people: [{
-            id: 'ava',
-            label: 'Ava',
-            firstSeen: 0,
-            lastSeen: 2,
-            sampleCount: 1,
-            averageConfidence: 0.9,
-            maxConfidence: 0.9,
-            appearances: [{ start: 0, end: 2 }],
-          }],
-        },
-      },
-    });
-    const onSeekSourceTime = vi.fn();
-    const onAssignReviewFaces = vi.fn();
-    const reviewCandidate = {
-      id: 'review-1',
-      faceIds: ['face-1'],
-      firstSeen: 0.8,
-      lastSeen: 0.8,
-      observationCount: 1,
-      sample: {
-        timestamp: 0.8,
-        confidence: 0.75,
-        box: { x: 0.1, y: 0.1, width: 0.2, height: 0.2 },
-      },
-    };
-
-    render(
-      <AnalysisWorkspace
-        model={model}
-        sourceTime={0.5}
-        reviewCandidates={[reviewCandidate]}
-        onSeekSourceTime={onSeekSourceTime}
-        onAssignReviewFaces={onAssignReviewFaces}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole('button', { expanded: false }));
-    const reviewButton = screen.getByRole('button', { name: /Review 1 · 1 frame/ });
-    fireEvent.click(reviewButton);
-    expect(onSeekSourceTime).toHaveBeenCalledWith(0.8);
-
-    const values = new Map<string, string>();
-    const dataTransfer = {
-      effectAllowed: 'uninitialized',
-      setData: (type: string, value: string) => values.set(type, value),
-      getData: (type: string) => values.get(type) ?? '',
-    } as unknown as DataTransfer;
-    fireEvent.dragStart(reviewButton, { dataTransfer });
-    const personTarget = screen.getByRole('button', { name: /Ava.*90% confidence/i })
-      .closest('.AnalysisSceneBlob__person');
-    expect(personTarget).not.toBeNull();
-    fireEvent.drop(personTarget as Element, { dataTransfer });
-    expect(onAssignReviewFaces).toHaveBeenCalledWith('review-1', ['face-1'], 'ava');
-  });
-
-  it('keeps complete people and review correction controls below virtualized scenes', () => {
-    const person = {
-      id: 'ava',
-      label: 'Ava',
-      firstSeen: 0,
-      lastSeen: 2,
-      sampleCount: 1,
-      averageConfidence: 0.9,
-      maxConfidence: 0.9,
-      appearances: [{ start: 0, end: 2 }],
-    };
-    const model = buildAnalysisWorkspaceViewModel({
-      range: { inPoint: 0, outPoint: 2 },
-      analysis: {
-        sampleInterval: 500,
-        frames: [{
-          timestamp: 0.5,
-          motion: 0,
-          globalMotion: 0,
-          localMotion: 0,
-          focus: 1,
-          brightness: 0.5,
-          faceCount: 1,
-          faces: [{
-            id: 'face-1', personId: 'ava', label: 'Ava', confidence: 0.9,
-            box: { x: 0.1, y: 0.1, width: 0.2, height: 0.2 }, landmarks: [],
-          }],
-        }],
-        faceAnalysis: {
-          schemaVersion: 1, modelVersion: 'test', detector: 'YuNet', recognizer: 'SFace',
-          backend: 'wasm', observationCount: 1, people: [person],
-        },
-      },
-    });
-    const onSeekSourceTime = vi.fn();
-    const reviewCandidate = {
-      id: 'review-1', faceIds: ['face-review'], firstSeen: 1.1, lastSeen: 1.1,
-      observationCount: 1,
-      sample: { timestamp: 1.1, confidence: 0.7, box: { x: 0.2, y: 0.2, width: 0.2, height: 0.2 } },
-    };
-
-    render(
-      <AnalysisWorkspace
-        model={model}
-        sourceTime={0.5}
-        facePeople={[person]}
-        faceFrames={model.scenes.length ? [{
-          timestamp: 0.5, motion: 0, globalMotion: 0, localMotion: 0, focus: 1,
-          brightness: 0.5, faceCount: 1, faces: [{
-            id: 'face-1', personId: 'ava', label: 'Ava', confidence: 0.9,
-            box: { x: 0.1, y: 0.1, width: 0.2, height: 0.2 }, landmarks: [],
-          }],
-        }] : []}
-        reviewCandidates={[reviewCandidate]}
-        onSeekSourceTime={onSeekSourceTime}
-        onMergePeople={vi.fn()}
-        onMoveAppearance={vi.fn()}
-        onAssignReviewFaces={vi.fn()}
-      />,
-    );
-
-    expect(screen.getByRole('region', { name: 'Detected people and face corrections' })).toBeInTheDocument();
-    expect(screen.getByRole('region', { name: 'Faces needing review' })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'View Ava appearances' }));
-    expect(screen.getByText('Ava appearances')).toBeInTheDocument();
   });
 });

--- a/tests/unit/analysisTranscriptChunks.test.ts
+++ b/tests/unit/analysisTranscriptChunks.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ANALYSIS_TRANSCRIPT_CHUNK_MAX_SECONDS,
+  buildAnalysisTranscriptChunks,
+} from '../../src/components/panels/properties/analysisWorkspace/analysisTranscriptChunks';
+import type {
+  AnalysisSceneTranscriptWord,
+  AnalysisSceneView,
+} from '../../src/components/panels/properties/analysisWorkspace/analysisSceneViewModel';
+
+function word(
+  index: number,
+  speaker = 'Ava',
+  text = `word${index}`,
+  start = index,
+): AnalysisSceneTranscriptWord {
+  return {
+    id: `word-${index}`,
+    text,
+    start,
+    end: start + 0.4,
+    speakerId: speaker,
+    speakerLabel: speaker,
+  };
+}
+
+function scene(
+  transcript: readonly AnalysisSceneTranscriptWord[],
+  end = 82,
+): AnalysisSceneView {
+  return {
+    id: 'scene',
+    index: 1,
+    boundarySource: 'shot-fallback',
+    range: { start: 0, end },
+    people: [],
+    speakerTurns: [],
+    transcript,
+    ocr: [],
+    qualityIssues: [],
+    coverage: {},
+  };
+}
+
+describe('analysis transcript chunks', () => {
+  it('turns one long visual scene into sentence-sized presentation chunks', () => {
+    const words = Array.from({ length: 82 }, (_, index) => (
+      word(index, 'Ava', (index + 1) % 10 === 0 ? `word${index}.` : `word${index}`)
+    ));
+    const chunks = buildAnalysisTranscriptChunks(scene(words));
+
+    expect(chunks).toHaveLength(8);
+    expect(chunks.every(chunk => chunk.end - chunk.start <= ANALYSIS_TRANSCRIPT_CHUNK_MAX_SECONDS)).toBe(true);
+    expect(chunks.flatMap(chunk => chunk.words.map(item => item.id))).toEqual(words.map(item => item.id));
+    expect(chunks.map(chunk => chunk.partIndex)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it('prefers a sentence end near ten seconds', () => {
+    const words = Array.from({ length: 18 }, (_, index) => (
+      word(index, 'Ava', index === 9 || index === 17 ? `word${index}.` : `word${index}`)
+    ));
+    const chunks = buildAnalysisTranscriptChunks(scene(words, 18));
+
+    expect(chunks[0]).toMatchObject({ start: 0, end: 9.4 });
+    expect(chunks[0].words.at(-1)?.text).toBe('word9.');
+  });
+
+  it('forces unpunctuated speech to word boundaries before fifteen seconds', () => {
+    const words = Array.from({ length: 31 }, (_, index) => word(index));
+    const chunks = buildAnalysisTranscriptChunks(scene(words, 31));
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every(chunk => chunk.end - chunk.start <= ANALYSIS_TRANSCRIPT_CHUNK_MAX_SECONDS)).toBe(true);
+    expect(chunks.flatMap(chunk => chunk.words)).toHaveLength(words.length);
+  });
+
+  it('uses the word-cap boundary instead of emitting single words for dense speech', () => {
+    const words = Array.from({ length: 100 }, (_, index) => (
+      word(index, 'Ava', `word${index}`, index * 0.05)
+    )).map(item => ({ ...item, end: item.start + 0.02 }));
+    const chunks = buildAnalysisTranscriptChunks(scene(words, 5));
+
+    expect(chunks.length).toBeLessThan(10);
+    expect(chunks.every(chunk => chunk.words.length > 1)).toBe(true);
+    expect(chunks.flatMap(chunk => chunk.words)).toHaveLength(words.length);
+  });
+
+  it('hard-splits a speaker change even before the target duration', () => {
+    const words = [
+      ...Array.from({ length: 4 }, (_, index) => word(index, 'Ava')),
+      ...Array.from({ length: 8 }, (_, index) => word(index + 4, 'Ben')),
+    ];
+    const chunks = buildAnalysisTranscriptChunks(scene(words, 12));
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks.map(chunk => chunk.speakerLabel)).toEqual(['Ava', 'Ben']);
+    expect(chunks[0].end - chunks[0].start).toBeLessThan(4);
+  });
+
+  it('uses a long silence as a natural boundary and keeps words immutable', () => {
+    const words = [
+      word(0, 'Ava', 'One', 0),
+      word(1, 'Ava', 'thought.', 1),
+      word(2, 'Ava', 'Next', 5),
+      word(3, 'Ava', 'thought.', 6),
+    ].toReversed();
+    const originalOrder = words.map(item => item.id);
+    const chunks = buildAnalysisTranscriptChunks(scene(words, 7));
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks.map(chunk => chunk.start)).toEqual([0, 5]);
+    expect(words.map(item => item.id)).toEqual(originalOrder);
+  });
+
+  it('keeps a no-speech scene as one fallback row', () => {
+    expect(buildAnalysisTranscriptChunks(scene([], 20))).toEqual([
+      expect.objectContaining({
+        sceneId: 'scene',
+        start: 0,
+        end: 20,
+        words: [],
+        fallback: true,
+        partIndex: 1,
+        partCount: 1,
+      }),
+    ]);
+  });
+
+  it('makes duplicate word ids at different times produce unique chunk ids', () => {
+    const words = [
+      { ...word(0, 'Ava', 'First.', 0), id: 'duplicate' },
+      { ...word(1, 'Ava', 'Second.', 10), id: 'duplicate' },
+      { ...word(2, 'Ava', 'Third.', 20), id: 'duplicate' },
+    ];
+    const chunks = buildAnalysisTranscriptChunks(scene(words, 21));
+
+    expect(new Set(chunks.map(chunk => chunk.id)).size).toBe(chunks.length);
+  });
+});

--- a/tests/unit/kernelClient.test.ts
+++ b/tests/unit/kernelClient.test.ts
@@ -24,7 +24,7 @@ describe('KernelServiceClient', () => {
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
-    expect(url).toBe('http://127.0.0.1:8787/health');
+    expect(url).toBe('http://127.0.0.1:8787/kernel/health');
     expect(init.method).toBe('GET');
     expect(init.headers).toEqual({ Accept: 'application/json' });
     expect(result).toEqual({
@@ -152,6 +152,6 @@ describe('KernelServiceClient', () => {
 
     await expect(isKernelServiceAvailable(client)).resolves.toBe(true);
     expect(fetchImpl).toHaveBeenCalledTimes(1);
-    expect(fetchImpl.mock.calls[0]?.[0]).toBe('http://127.0.0.1:8787/health');
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe('http://127.0.0.1:8787/kernel/health');
   });
 });


### PR DESCRIPTION
- Analysis tab redesign: channel pills with inline status, scope/profile + people/transcript settings behind the settings toggle, analysis-map overview lanes, scene-list transcript chunking; tests reconciled with the new UI.
- Kernel default-on in production: /api/kernel/* Pages proxy injects the bearer token server-side (signed-in users only); localStorage keys remain override + kill switch; health probe unified on /kernel/health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)