### PR TITLE
Kernel: silent fallback on pre-execution compile failures

### DIFF
--- a/src/services/kernelClient/kernelChatGateway.ts
+++ b/src/services/kernelClient/kernelChatGateway.ts
@@ -522,15 +522,14 @@ export async function tryKernelFirst(
       });
       return { handled: false };
     }
-    log.warn('kernel compile failed', {
+    // Compile failures happen before any local mutation, so the legacy
+    // loop can still serve the request. Honest failures are reserved for
+    // post-execution states (deferred rollback, fingerprint mismatch).
+    log.warn('kernel compile failed; falling back', {
       runId: compiled.runId,
       failures: compiled.failures,
     });
-    return {
-      handled: true,
-      message: failedMessage(compiled.failures),
-      runId: compiled.runId,
-    };
+    return { handled: false };
   }
 
   const compiledPlan: KernelCompileCompiledResponse = compiled;


### PR DESCRIPTION
Compile-stage kernel failures (before any timeline mutation) now fall back to the legacy chat loop instead of surfacing an opaque error; details stay in the KernelGateway log.

Pairs with kernel-side fixes already deployed: cut-count requests ("mache N schnitte" / "make N cuts") compile mechanically as N+1 even clips with zero provider cost, and story runs whose assembly beats all collide fail honestly with a recovery hint instead of succeeding without a winner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
